### PR TITLE
feat: Apple Music 风格逐字歌词 / 播放页 / Lyricon 词幕推送 / OLED 纯黑模式

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,6 +81,15 @@ jobs:
           echo "full_version=$FULL_VERSION" >> "$GITHUB_OUTPUT"
           echo "Building tag=$TAG version=$VERSION versionCode=$VERSION_CODE (full=$FULL_VERSION)"
 
+          # 检查 tag 是否真实存在（用于决定是否创建 release）
+          if git rev-parse --verify "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "tag_exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag ${TAG} exists in repo (will create release)"
+          else
+            echo "tag_exists=false" >> "$GITHUB_OUTPUT"
+            echo "WARN: Tag ${TAG} does NOT exist in repo (will skip release creation)"
+          fi
+
       # ============================================================
       # 2.5 自动更新 pubspec.yaml 的 version 字段
       # ============================================================
@@ -308,10 +317,11 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       # ============================================================
-      # 9. 创建/更新 GitHub Release
+      # 9. 创建/更新 GitHub Release（仅在 tag 真实存在时执行）
       #    append=true 保留历史资产，不会删除旧版本
       # ============================================================
       - name: Upload APKs to Release
+        if: steps.version.outputs.tag_exists == 'true'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.tag }}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![Flutter](https://img.shields.io/badge/Flutter-3.12+-02569B?logo=flutter)](https://flutter.dev)
 [![Platform](https://img.shields.io/badge/Platform-Android-green)]()
-[![Version](https://img.shields.io/badge/Version-3.2.0-blue)]()
+[![Version](https://img.shields.io/badge/Version-2.5.0-blue)]()
 [![License](https://img.shields.io/badge/License-MIT-yellow)](LICENSE)
 
 </div>
@@ -119,9 +119,6 @@ rm native-libs.zip
 - `android/app/src/main/jniLibs/` — 3个架构的 `libnode.so`
 - `android/app/src/main/cpp/include/` — Node.js v18 头文件
 
-> **CI 用户**：项目已配置 [GitHub Actions 自动构建](#-github-actions-自动构建)。
-> 首次启用前需要手动上传一次 `native-libs.zip` 到 `native-libs` release，详见下方 CI 文档。
-
 ### 3. 安装 Flutter 依赖
 
 ```bash
@@ -172,71 +169,6 @@ flutter build apk --release --split-per-abi
 - **arm64-v8a**：大多数现代 Android 设备（推荐）
 - **armeabi-v7a**：较旧的 32 位设备
 - **x86_64**：Android 模拟器
-
----
-
-## 🤖 GitHub Actions 自动构建
-
-项目已配置 GitHub Actions，推送 `v*` 标签即可自动编译并发布 Android APK。
-
-### 工作流
-
-[`.github/workflows/main.yml`](.github/workflows/main.yml) 定义了一个 Ubuntu 任务，主要步骤：
-
-1. 解析 tag → 提取版本号
-2. 安装 Java 17、Android SDK（含 NDK 28.2.13676358）、Flutter stable、Node 18
-3. 下载 `native-libs.zip`（`libnode.so` + Node headers）
-4. 重新构建 `kugou_api_server/server_bundle.js` 并拷贝到 `assets/`
-5. `flutter build apk --release --split-per-abi` → 产出 3 个 APK
-6. 自动从 `git log` 生成 changelog
-7. 把 3 个 APK 上传到 GitHub Release（追加模式，不覆盖历史版本）
-
-### 首次启用（一次性）
-
-CI 运行环境无法编译 `nodejs-mobile` 的 native libs，所以需要你**先手动准备一次** `native-libs.zip`：
-
-```bash
-# 1. 在 Windows 本地已成功构建的环境下打包
-cd android/app/src/main
-powershell -Command "Compress-Archive -Path 'jniLibs','cpp' -DestinationPath 'native-libs.zip' -Force"
-
-# 2. 创建一个名为 'native-libs' 的 release
-#    https://github.com/zzyoxml/md3Music/releases/new?tag=native-libs
-#    把 native-libs.zip 拖进去上传
-
-# 3. 后续 workflow 会自动从这里下载
-```
-
-> 也可以直接复用你已有的 [setup_native.bat](setup_native.bat) 下载好的文件来打包。
-
-### 触发构建
-
-**方式一：推送 tag（推荐）**
-
-```bash
-git tag v3.3.0
-git push origin v3.3.0
-# → Actions 自动开始构建，约 3-5 分钟后 APK 出现在 release 页
-```
-
-**方式二：手动触发**
-
-1. 进入仓库 → Actions → "Build & Release Android APK" → Run workflow
-2. 填入要构建的 tag（如 `v3.3.0`）
-3. 点击运行
-
-### Release 产物
-
-每次发布都会自动生成 3 个 APK：
-- `app-arm64-v8a-release.apk` — 推荐：大多数现代 Android 设备
-- `app-armeabi-v7a-release.apk` — 较旧的 32 位设备
-- `app-x86_64-release.apk` — Android 模拟器
-
-历史版本**不会**被删除，新 APK 是**追加**到对应 release 的。
-
-### 签名
-
-当前 `android/app/build.gradle.kts` 使用 debug keys 签名（见 [build.gradle.kts:43](android/app/build.gradle.kts#L43)），所以 CI 也不需要额外配置签名密钥。**生产环境请改为正式签名。**
 
 ---
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -60,6 +60,8 @@ kotlin {
 dependencies {
     implementation("androidx.media:media:1.6.0")
     implementation("androidx.core:core-ktx:1.12.0")
+    implementation("io.github.proify.lyricon:provider:0.1.70")
+    implementation("io.github.proify.lyricon.lyric:model:0.1.70")
 }
 
 flutter {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:usesCleartextTraffic="true"
+        android:enableOnBackInvokedCallback="true"
         android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name=".MainActivity"
@@ -66,6 +67,10 @@
             android:name=".FloatingLyricService"
             android:foregroundServiceType="specialUse"
             android:exported="false" />
+        <meta-data android:name="lyricon_module" android:value="true" />
+        <meta-data android:name="lyricon_module_author" android:value="md3music" />
+        <meta-data android:name="lyricon_module_description" android:value="MD3Music Lyricon Provider" />
+        <meta-data android:name="lyricon_module_tags" android:resource="@array/lyricon_module_tags" />
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/android/app/src/main/kotlin/com/md3music/md3music/AudioPlaybackService.kt
+++ b/android/app/src/main/kotlin/com/md3music/md3music/AudioPlaybackService.kt
@@ -23,6 +23,12 @@ import android.support.v4.media.session.PlaybackStateCompat
 import androidx.core.app.NotificationCompat
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
+import io.github.proify.lyricon.provider.ConnectionListener
+import io.github.proify.lyricon.provider.LyriconFactory
+import io.github.proify.lyricon.provider.LyriconProvider
+import io.github.proify.lyricon.lyric.model.LyricWord
+import io.github.proify.lyricon.lyric.model.RichLyricLine
+import io.github.proify.lyricon.lyric.model.Song
 
 class AudioPlaybackService : Service() {
     companion object {
@@ -43,7 +49,6 @@ class AudioPlaybackService : Service() {
         const val EXTRA_DESKTOP_LYRIC_ENABLED = "desktopLyricEnabled"
         const val EXTRA_IS_FAVORITED = "isFavorited"
 
-        // 静态变量用于跨组件传递 FlutterEngine
         private var staticFlutterEngine: FlutterEngine? = null
         private var wakeLock: PowerManager.WakeLock? = null
 
@@ -68,6 +73,52 @@ class AudioPlaybackService : Service() {
             }
             wakeLock = null
         }
+
+        @Volatile
+        private var lyriconProvider: LyriconProvider? = null
+        private var lyriconChannel: MethodChannel? = null
+
+        fun setLyriconChannel(channel: MethodChannel?) {
+            lyriconChannel = channel
+        }
+
+        fun getLyriconProvider(): LyriconProvider? = lyriconProvider
+
+        fun buildLyriconSong(arg: Map<String, Any?>): Song {
+            @Suppress("UNCHECKED_CAST")
+            val lyricsRaw = arg["lyrics"] as? List<Map<String, Any?>> ?: emptyList()
+            val lyrics = lyricsRaw.map { line ->
+                @Suppress("UNCHECKED_CAST")
+                val wordsRaw = line["words"] as? List<Map<String, Any?>> ?: emptyList()
+                RichLyricLine(
+                    begin = (line["begin"] as? Number)?.toLong() ?: 0L,
+                    end = (line["end"] as? Number)?.toLong() ?: 0L,
+                    text = line["text"] as? String ?: "",
+                    translation = line["translation"] as? String,
+                    words = wordsRaw.map { w ->
+                        LyricWord(
+                            text = w["text"] as? String ?: "",
+                            begin = (w["begin"] as? Number)?.toLong() ?: 0L,
+                            end = (w["end"] as? Number)?.toLong() ?: 0L
+                        )
+                    }
+                )
+            }
+            val song = Song(
+                id = arg["id"] as? String ?: "",
+                name = arg["name"] as? String ?: "",
+                artist = arg["artist"] as? String ?: "",
+                duration = (arg["duration"] as? Number)?.toLong() ?: 0L,
+                lyrics = lyrics
+            )
+            val first = lyrics.firstOrNull()
+            android.util.Log.d("LyriconDebug",
+                "buildLyriconSong: name='${song.name}', artist='${song.artist}', " +
+                "duration=${song.duration}, lyrics.size=${lyrics.size}, " +
+                "first=${first?.let { "begin=${it.begin}, end=${it.end}, text='${it.text}', words=${it.words?.size ?: 0}" }}"
+            )
+            return song
+        }
     }
 
     private var mediaSession: MediaSessionCompat? = null
@@ -84,6 +135,30 @@ class AudioPlaybackService : Service() {
         initMediaSession()
         registerReceiver()
         acquireWakeLock(this)
+
+        lyriconProvider = try {
+            LyriconFactory.createProvider(this).apply {
+                autoSync = true
+                try {
+                    service.addConnectionListener(object : ConnectionListener {
+                        override fun onConnected(provider: LyriconProvider) {
+                            lyriconChannel?.invokeMethod("onConnectionStateChanged", "connected")
+                        }
+                        override fun onReconnected(provider: LyriconProvider) {
+                            lyriconChannel?.invokeMethod("onConnectionStateChanged", "reconnected")
+                        }
+                        override fun onDisconnected(provider: LyriconProvider) {
+                            lyriconChannel?.invokeMethod("onConnectionStateChanged", "disconnected")
+                        }
+                        override fun onConnectTimeout(provider: LyriconProvider) {
+                            lyriconChannel?.invokeMethod("onConnectionStateChanged", "timeout")
+                        }
+                    })
+                } catch (_: Exception) {}
+            }
+        } catch (_: Exception) {
+            null
+        }
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -215,33 +290,25 @@ class AudioPlaybackService : Service() {
     private fun createNotificationChannel() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val manager = getSystemService(NotificationManager::class.java)
-            
-            // 删除旧渠道（如果存在且配置不正确）- Android 8+ 渠道一旦创建无法修改，必须删除重建
             try {
                 val existingChannel = manager.getNotificationChannel(CHANNEL_ID)
                 if (existingChannel != null) {
-                    // 检查是否需要重建（重要度不是 LOW，或者声音未禁用）
                     if (existingChannel.importance != NotificationManager.IMPORTANCE_LOW ||
                         existingChannel.sound != null) {
                         manager.deleteNotificationChannel(CHANNEL_ID)
                     }
                 }
             } catch (_: Exception) {}
-            
-            // 创建静音通知渠道 - 修复荣耀/vivo 手机通知提示音问题
             val channel = NotificationChannel(
                 CHANNEL_ID,
                 "音乐播放",
-                NotificationManager.IMPORTANCE_LOW  // 使用 LOW 而不是 DEFAULT，减少通知干扰
+                NotificationManager.IMPORTANCE_LOW
             ).apply {
                 description = "音乐播放控制"
                 setShowBadge(false)
                 lockscreenVisibility = NotificationCompat.VISIBILITY_PUBLIC
-                // 关键修复：禁用声音和震动
                 setSound(null, null)
                 enableVibration(false)
-                // 不在锁屏上显示（可选，根据需求调整）
-                // setLockscreenVisibility(Notification.VISIBILITY_PUBLIC)
             }
             manager.createNotificationChannel(channel)
         }
@@ -262,20 +329,18 @@ class AudioPlaybackService : Service() {
             this, 0, launchIntent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
-
         val prevIntent = PendingIntent.getService(
             this, 1, Intent(this, AudioPlaybackService::class.java).apply { action = ACTION_PREV },
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
         val playPauseIntent = PendingIntent.getService(
             this, 2, Intent(this, AudioPlaybackService::class.java).apply { action = ACTION_PLAY_PAUSE },
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            PendingIntent.FLAG_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
         val nextIntent = PendingIntent.getService(
             this, 3, Intent(this, AudioPlaybackService::class.java).apply { action = ACTION_NEXT },
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
-        // 桌面歌词开关：通知栏按钮 → 调 dart 端 toggleDesktopLyric
         val toggleLyricIntent = PendingIntent.getService(
             this, 4, Intent(this, AudioPlaybackService::class.java).apply { action = ACTION_TOGGLE_DESKTOP_LYRIC },
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
@@ -284,11 +349,9 @@ class AudioPlaybackService : Service() {
             this, 5, Intent(this, AudioPlaybackService::class.java).apply { action = ACTION_TOGGLE_FAVORITE },
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
-
         val playPauseIcon = if (isPlaying) android.R.drawable.ic_media_pause else android.R.drawable.ic_media_play
         val lyricIconRes = if (desktopLyricEnabled) R.drawable.ic_lyric_on else R.drawable.ic_lyric_off
         val favoriteIconRes = if (isFavorited) R.drawable.ic_favorite_on else R.drawable.ic_favorite_off
-
         val builder = NotificationCompat.Builder(this, CHANNEL_ID)
             .setSmallIcon(android.R.drawable.ic_media_play)
             .setContentTitle(title)
@@ -296,8 +359,8 @@ class AudioPlaybackService : Service() {
             .setContentIntent(pendingIntent)
             .setOngoing(true)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
-            .setPriority(NotificationCompat.PRIORITY_LOW)  // 降低优先级，配合渠道的 LOW 设置
-            .setOnlyAlertOnce(true)  // 关键：确保通知更新时不会触发声音/震动
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setOnlyAlertOnce(true)
             .setShowWhen(false)
             .addAction(android.R.drawable.ic_media_previous, "上一首", prevIntent)
             .addAction(playPauseIcon, if (isPlaying) "暂停" else "播放", playPauseIntent)
@@ -310,7 +373,6 @@ class AudioPlaybackService : Service() {
                     .setMediaSession(mediaSession?.sessionToken)
                     .setShowActionsInCompactView(0, 1, 3)
             )
-
         if (!artUrl.isNullOrEmpty()) {
             Thread {
                 try {
@@ -322,7 +384,6 @@ class AudioPlaybackService : Service() {
         } else {
             startForeground(NOTIFICATION_ID, builder.build())
         }
-
         mediaSession?.setPlaybackState(
             PlaybackStateCompat.Builder()
                 .setState(
@@ -354,7 +415,9 @@ class AudioPlaybackService : Service() {
                 )
                 .build()
         )
-
+        try {
+            lyriconProvider?.player?.setPlaybackState(isPlaying)
+        } catch (_: Exception) {}
         mediaSession?.setMetadata(
             MediaMetadataCompat.Builder()
                 .putString(MediaMetadataCompat.METADATA_KEY_TITLE, title)
@@ -382,6 +445,13 @@ class AudioPlaybackService : Service() {
             } catch (_: Exception) {}
         }
         mediaSession?.release()
+        try {
+            lyriconProvider?.unregister()
+        } catch (_: Exception) {}
+        try {
+            lyriconProvider?.destroy()
+        } catch (_: Exception) {}
+        lyriconProvider = null
         releaseWakeLock()
         super.onDestroy()
     }

--- a/android/app/src/main/kotlin/com/md3music/md3music/FloatingLyricService.kt
+++ b/android/app/src/main/kotlin/com/md3music/md3music/FloatingLyricService.kt
@@ -76,6 +76,8 @@ class FloatingLyricService : Service() {
         const val ACTION_TOGGLE_LOCK = "com.md3music.md3music.TOGGLE_LOCK"
         const val EXTRA_LYRIC = "lyric"
         const val EXTRA_NEXT_LYRIC = "nextLyric"
+        // 当前行已唱字数（KRC 逐字）。-1 表示无逐字（LRC/纯文本），原生侧整行渐变色
+        const val EXTRA_SUNG_CHAR_COUNT = "sungCharCount"
         const val EXTRA_TITLE = "title"
         const val EXTRA_POSITION = "position"
         const val EXTRA_DURATION = "duration"
@@ -110,7 +112,8 @@ class FloatingLyricService : Service() {
             ACTION_UPDATE_LYRIC -> {
                 val lyric = intent.getStringExtra(EXTRA_LYRIC) ?: ""
                 val next = intent.getStringExtra(EXTRA_NEXT_LYRIC)
-                updateLyric(lyric, next)
+                val sungCount = intent.getIntExtra(EXTRA_SUNG_CHAR_COUNT, -1)
+                updateLyric(lyric, next, sungCount)
             }
             ACTION_UPDATE_TITLE -> {}
             ACTION_UPDATE_PROGRESS -> {
@@ -195,6 +198,9 @@ class FloatingLyricService : Service() {
 
         lyricText1?.setGradient(gradientStart, gradientEnd)
         lyricText2?.setGradient(gradientStart, gradientEnd)
+        // 同步未唱色给文本视图（KRC 逐字二分色模式下未唱部分用此色）
+        lyricText1?.setUnplayedColor(unplayedColor)
+        lyricText2?.setUnplayedColor(unplayedColor)
 
         // Background opacity
         val bgAlpha = (opacity * 255 / 100).coerceIn(0, 255)
@@ -208,12 +214,19 @@ class FloatingLyricService : Service() {
         lyricText2?.setOpacityForContrast(opacity)
 
         progressBar?.setGradient(gradientStart, gradientEnd, unplayedColor)
-        updateLyric(lyricText1?.text?.toString() ?: "", lyricText2?.text?.toString())
+        updateLyric(lyricText1?.text?.toString() ?: "", lyricText2?.text?.toString(), -1)
     }
 
-    private fun updateLyric(lyric: String, nextLyric: String?) {
+    /// 更新悬浮窗歌词文本 + 逐字进度。
+    ///
+    /// - [sungCharCount] >= 0：KRC 逐字模式，[lyricText1] 用 clipRect 二分色
+    ///   （已唱部分渐变色 + 未唱部分灰色）
+    /// - [sungCharCount] == -1：LRC/纯文本，[lyricText1] 整行渐变色（保持原行为）
+    /// - [lyricText2]（下一行预览）始终整行渐变色，不参与逐字
+    private fun updateLyric(lyric: String, nextLyric: String?, sungCharCount: Int = -1) {
         val safeLyric = lyric.ifEmpty { "歌词加载中..." }
         lyricText1?.text = safeLyric
+        lyricText1?.setSungCharCount(sungCharCount)
         if (doubleLine) {
             lyricText2?.text = nextLyric ?: ""
             lyricText2?.visibility = if (nextLyric.isNullOrEmpty()) View.INVISIBLE else View.VISIBLE
@@ -680,10 +693,19 @@ class FloatingLyricService : Service() {
 }
 
 /// Gradient text view with contrast optimization for low opacity
+///
+/// 逐字二分色支持（KRC）：
+/// - [sungCharCount] >= 0：当前行有 KRC 字级时间戳，onDraw 中先画整行灰色（未唱色），
+///   再 clipRect 已唱宽度画渐变色，实现"已唱渐变 / 未唱灰"的二分色效果
+/// - [sungCharCount] == -1：LRC/纯文本，整行渐变色（保持原行为）
 class GradientTextView(context: Context) : TextView(context) {
     private var startColor = 0xFF00E5FF.toInt()
     private var endColor = 0xFFFF00FF.toInt()
     private var bgOpacity = 80
+    // 未唱色（灰色），用于逐字二分色模式下绘制未唱部分
+    private var unplayedColor = 0xFF666666.toInt()
+    // 当前行已唱字数；-1 表示无逐字（整行渐变色）
+    private var sungCharCount = -1
 
     init {
         setTextColor(Color.WHITE)
@@ -695,9 +717,24 @@ class GradientTextView(context: Context) : TextView(context) {
         invalidate()
     }
 
+    fun setUnplayedColor(color: Int) {
+        unplayedColor = color
+        invalidate()
+    }
+
     fun setOpacityForContrast(opacity: Int) {
         bgOpacity = opacity
         invalidate()
+    }
+
+    /// 设置已唱字数（KRC 逐字模式）。
+    /// - count >= 0：启用逐字二分色
+    /// - count == -1：禁用逐字，整行渐变色
+    fun setSungCharCount(count: Int) {
+        if (sungCharCount != count) {
+            sungCharCount = count
+            invalidate()
+        }
     }
 
     override fun onDraw(canvas: Canvas) {
@@ -732,13 +769,52 @@ class GradientTextView(context: Context) : TextView(context) {
             paint.clearShadowLayer()
         }
 
-        if (width > 0) {
-            paint.shader = LinearGradient(
-                0f, 0f, width, 0f,
-                startColor, endColor, Shader.TileMode.CLAMP
-            )
+        val text = text?.toString() ?: ""
+        val enableKrcMode = sungCharCount >= 0 && text.isNotEmpty()
+
+        if (enableKrcMode) {
+            // KRC 逐字二分色：先画整行灰色（未唱色），再 clipRect 已唱宽度画渐变色
+            // 1. 计算已唱像素宽度（用 paint 测量前 sungCharCount 个字符）
+            val safeCount = sungCharCount.coerceIn(0, text.length)
+            val sungWidth = if (safeCount > 0) {
+                paint.measureText(text, 0, safeCount)
+            } else 0f
+
+            // 2. 先画整行灰色（未唱色）
+            //    注意：TextView.onDraw 会用 currentTextColor 覆盖 paint.color，
+            //    所以必须用 setTextColor 切换，不能直接设 paint.color
+            val savedTextColor = currentTextColor
+            setTextColor(unplayedColor)
+            paint.shader = null
+            super.onDraw(canvas)
+
+            // 3. clipRect 已唱宽度，画渐变色覆盖已唱部分
+            //    shader 优先于 color，渐变色会盖住灰色
+            if (sungWidth > 0 && width > 0) {
+                canvas.save()
+                canvas.clipRect(0f, 0f, sungWidth, height.toFloat())
+                paint.shader = LinearGradient(
+                    0f, 0f, width, 0f,
+                    startColor, endColor, Shader.TileMode.CLAMP
+                )
+                // 已唱部分不要 shadow（避免双重 shadow），清掉再画
+                paint.clearShadowLayer()
+                super.onDraw(canvas)
+                canvas.restore()
+            }
+
+            // 恢复 textColor（下次 onDraw 用）
+            setTextColor(savedTextColor)
+        } else {
+            // LRC/纯文本：整行渐变色（原行为）
+            if (width > 0) {
+                paint.shader = LinearGradient(
+                    0f, 0f, width, 0f,
+                    startColor, endColor, Shader.TileMode.CLAMP
+                )
+            }
+            super.onDraw(canvas)
         }
-        super.onDraw(canvas)
 
         // Reset shadow after draw to avoid affecting other draws
         paint.clearShadowLayer()

--- a/android/app/src/main/kotlin/com/md3music/md3music/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/md3music/md3music/MainActivity.kt
@@ -8,12 +8,14 @@ import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
 import android.support.v4.media.session.MediaSessionCompat
+import android.support.v4.media.session.PlaybackStateCompat
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.embedding.engine.FlutterEngineCache
 import io.flutter.plugin.common.MethodChannel
 import com.md3music.md3music.AudioPlaybackService
 import com.md3music.md3music.FloatingLyricService
+import io.github.proify.lyricon.lyric.model.Song
 
 class MainActivity : FlutterActivity() {
     private val FLOATING_CHANNEL = "com.md3music.md3music/floating_lyric"
@@ -88,6 +90,7 @@ class MainActivity : FlutterActivity() {
                         action = FloatingLyricService.ACTION_UPDATE_LYRIC
                         putExtra(FloatingLyricService.EXTRA_LYRIC, call.argument<String>("lyric") ?: "")
                         putExtra(FloatingLyricService.EXTRA_NEXT_LYRIC, call.argument<String>("nextLyric") ?: "")
+                        putExtra(FloatingLyricService.EXTRA_SUNG_CHAR_COUNT, call.argument<Int>("sungCharCount") ?: -1)
                     }
                     startService(intent)
                     result.success(true)
@@ -190,6 +193,108 @@ class MainActivity : FlutterActivity() {
                     }
                     startService(intent)
                     result.success(true)
+                }
+                else -> result.notImplemented()
+            }
+        }
+
+        // 注册 Lyricon Provider MethodChannel，让 Dart 端能控制 Lyricon 播放器
+        val lyriconChannel = MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "com.md3music.md3music/lyricon"
+        )
+        AudioPlaybackService.setLyriconChannel(lyriconChannel)
+        lyriconChannel.setMethodCallHandler { call, result ->
+            val provider = AudioPlaybackService.getLyriconProvider()
+            when (call.method) {
+                "setEnabled" -> {
+                    val enabled = call.argument<Boolean>("enabled") ?: false
+                    try {
+                        if (enabled) provider?.register() else provider?.unregister()
+                        result.success(true)
+                    } catch (_: Exception) {
+                        result.success(false)
+                    }
+                }
+                "setSong" -> {
+                    val arg = call.argument<Map<String, Any?>>("song")
+                    if (arg == null) {
+                        try {
+                            // SDK 的 setSong 不接受 null，传一个空 Song 表示清空
+                            provider?.player?.setSong(Song())
+                            result.success(true)
+                        } catch (_: Exception) {
+                            result.success(false)
+                        }
+                    } else {
+                        try {
+                            val song = AudioPlaybackService.buildLyriconSong(arg)
+                            provider?.player?.setSong(song)
+                            result.success(true)
+                        } catch (e: Exception) {
+                            result.error("BUILD_SONG_FAILED", e.message, null)
+                        }
+                    }
+                }
+                "sendText" -> {
+                    val text = call.argument<String>("text")
+                    try {
+                        provider?.player?.sendText(text)
+                        result.success(true)
+                    } catch (_: Exception) {
+                        result.success(false)
+                    }
+                }
+                "setPosition" -> {
+                    val pos = call.argument<Number>("positionMs")?.toLong() ?: 0L
+                    try {
+                        provider?.player?.setPosition(pos)
+                        result.success(true)
+                    } catch (_: Exception) {
+                        result.success(false)
+                    }
+                }
+                "setPlaybackState" -> {
+                    val state = call.argument<Number>("state")?.toInt()
+                        ?: PlaybackStateCompat.STATE_NONE
+                    val pos = call.argument<Number>("position")?.toLong() ?: 0L
+                    // SDK 的 setPlaybackState 接受 Boolean，从 PlaybackStateCompat 状态码推导 isPlaying
+                    val isPlaying = state == PlaybackStateCompat.STATE_PLAYING
+                    try {
+                        // 位置通过 setPosition 同步（原本打包在 PlaybackStateCompat 中）
+                        provider?.player?.setPosition(pos)
+                        provider?.player?.setPlaybackState(isPlaying)
+                        result.success(true)
+                    } catch (_: Exception) {
+                        result.success(false)
+                    }
+                }
+                "seekTo" -> {
+                    val pos = call.argument<Number>("positionMs")?.toLong() ?: 0L
+                    try {
+                        provider?.player?.seekTo(pos)
+                        result.success(true)
+                    } catch (_: Exception) {
+                        result.success(false)
+                    }
+                }
+                "setDisplayTranslation" -> {
+                    val enabled = call.argument<Boolean>("enabled") ?: false
+                    try {
+                        provider?.player?.setDisplayTranslation(enabled)
+                        result.success(true)
+                    } catch (_: Exception) {
+                        result.success(false)
+                    }
+                }
+                "setDisplayRoma" -> {
+                    val enabled = call.argument<Boolean>("enabled") ?: false
+                    try {
+                        provider?.player?.setDisplayRoma(enabled)
+                        result.success(true)
+                    } catch (_: Exception) {
+                        result.success(false)
+                    }
                 }
                 else -> result.notImplemented()
             }

--- a/android/app/src/main/res/values/arrays.xml
+++ b/android/app/src/main/res/values/arrays.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="lyricon_module_tags">
+        <item>$syllable</item>
+        <item>$translation</item>
+    </string-array>
+</resources>

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,8 +1,4 @@
-import 'dart:io' show exit;
-
-import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart' show SystemNavigator;
 import 'package:provider/provider.dart';
 
 import 'core/layout/responsive_layout.dart';
@@ -15,6 +11,7 @@ import 'modules/user/user_center_page.dart';
 import 'modules/user/favorites_page.dart';
 
 import 'modules/player/full_player.dart';
+import 'modules/player/full_player_route.dart';
 import 'modules/player/mini_player.dart';
 import 'modules/playlist/playlist_page.dart';
 import 'modules/search/search_page.dart';
@@ -30,6 +27,65 @@ import 'providers/player_provider.dart';
 import 'providers/playlist_collection_notifier.dart';
 import 'providers/theme_provider.dart';
 import 'services/nodejs_server.dart';
+
+/// 主页（`/`）专用的 [MaterialPageRoute] 子类。
+///
+/// 重写 [buildTransitions]：当 FullPlayer 在栈顶（[isFullPlayerOnTop] == true）
+/// 且 [secondaryAnimation] 驱动时，让 _MainLayout 向上偏移 15% + 淡出
+/// （Apple Music 经典效果）；其他路由 push 时走默认 transitions。
+///
+/// 通过 [isFullPlayerOnTop] 全局 ValueNotifier 限制只对 FullPlayer 生效，
+/// 避免 /search /settings /playlist 等也触发 up-fade。
+class _UpFadeMainRoute<T> extends MaterialPageRoute<T> {
+  _UpFadeMainRoute({required super.builder});
+
+  @override
+  Widget buildTransitions(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    // 入场动画走默认（_MainLayout 是 initialRoute，入场无动画）
+    // 离场动画（被覆盖）：监听 isFullPlayerOnTop，true 时 up-fade，false 时默认
+    return AnimatedBuilder(
+      animation: Listenable.merge([secondaryAnimation, isFullPlayerOnTop]),
+      builder: (context, _) {
+        if (!isFullPlayerOnTop.value) {
+          return super.buildTransitions(
+            context,
+            animation,
+            secondaryAnimation,
+            child,
+          );
+        }
+        // FullPlayer 在栈顶：_MainLayout 向上偏移 15% + 淡出
+        final offset = Tween<Offset>(
+          begin: Offset.zero,
+          end: const Offset(0, -0.15),
+        ).animate(
+          CurvedAnimation(
+            parent: secondaryAnimation,
+            curve: Curves.easeOutCubic,
+          ),
+        );
+        final fade = Tween<double>(
+          begin: 1.0,
+          end: 0.0,
+        ).animate(
+          CurvedAnimation(
+            parent: secondaryAnimation,
+            curve: Curves.easeOutCubic,
+          ),
+        );
+        return FadeTransition(
+          opacity: fade,
+          child: SlideTransition(position: offset, child: child),
+        );
+      },
+    );
+  }
+}
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
@@ -62,19 +118,34 @@ class _AppView extends StatelessWidget {
     return MaterialApp(
       title: 'MD3Music',
       debugShowCheckedModeBanner: false,
-      darkTheme: AppTheme.darkTheme,
+      // 同时传 theme 和 darkTheme，并根据 ThemeProvider.effectiveSeedColor
+      // 动态生成（支持「莫奈色」开关切换系统主色）。
+      // darkTheme 额外接收 useOledBlack 开关，开启时 surface 系列覆盖为纯黑。
+      theme: AppTheme.lightThemeFromSeed(themeProvider.effectiveSeedColor),
+      darkTheme: AppTheme.darkThemeFromSeed(
+        themeProvider.effectiveSeedColor,
+        useOledBlack: themeProvider.useOledBlack,
+      ),
       themeMode: themeProvider.themeMode,
       navigatorKey: appNavigatorKey,
       initialRoute: '/',
       routes: {
-        '/': (_) => const _MainLayout(),
+        // '/' 不在 routes 注册，改在 onGenerateRoute 用 _UpFadeMainRoute 创建，
+        // 以便 push FullPlayer 时主页面向上淡出（仅 FullPlayer 生效）
         '/search': (_) => const SearchPage(),
         '/library': (_) => const LibraryPage(),
         '/settings': (_) => const SettingsPage(),
+        // 发现页右上角头像点击跳转入口（push 独立路由，与底部 tab 中的实例并存无冲突）
+        '/user': (_) => const UserCenterPage(),
         '/player': (_) => const FullPlayer(),
         '/personal_fm': (_) => const PersonalFmPage(),
       },
       onGenerateRoute: (settings) {
+        if (settings.name == '/') {
+          return _UpFadeMainRoute<void>(
+            builder: (_) => const _MainLayout(),
+          );
+        }
         if (settings.name == '/playlist') {
           final playlist = settings.arguments as Playlist;
           return PageRouteBuilder(
@@ -247,84 +318,42 @@ class _MainLayoutState extends State<_MainLayout> with WidgetsBindingObserver {
 
   @override
   Widget build(BuildContext context) {
-    // 让系统返回键先走 Navigator 栈（关掉 sub-page / pop dialog），
-    // 栈空了再弹"退出应用"确认对话框，避免在子页面按返回就直接弹退出。
-    return PopScope(
-      canPop: false,
-      onPopInvokedWithResult: (didPop, result) {
-        if (didPop) return;
-        final nav = appNavigatorKey.currentState;
-        if (nav != null && nav.canPop()) {
-          nav.pop();
-          return;
-        }
-        _showExitDialog();
+    // 预测返回手势由 AndroidManifest 的 enableOnBackInvokedCallback 控制（编译时静态），
+    // 应用无法运行时关闭系统预测动画。栈空时直接退出 App（系统默认行为）。
+    return ResponsiveScaffold(
+      destinations: _destinations,
+      railDestinations: _railDestinations,
+      drawerDestinations: _drawerDestinations,
+      selectedIndex: _selectedIndex,
+      onDestinationSelected: (index) {
+        setState(() {
+          _selectedIndex = index;
+        });
       },
-      child: ResponsiveScaffold(
-        destinations: _destinations,
-        railDestinations: _railDestinations,
-        drawerDestinations: _drawerDestinations,
-        selectedIndex: _selectedIndex,
-        onDestinationSelected: (index) {
-          setState(() {
-            _selectedIndex = index;
-          });
-        },
-        body: Column(
-          children: [
-            Expanded(child: _pages[_selectedIndex]),
-            const MiniPlayer(),
-          ],
-        ),
-        compactBody: Column(
-          children: [
-            Expanded(child: _pages[_selectedIndex]),
-            const MiniPlayer(),
-          ],
-        ),
-        mediumBody: Column(
-          children: [
-            Expanded(child: _pages[_selectedIndex]),
-            const MiniPlayer(),
-          ],
-        ),
-        expandedBody: Column(
-          children: [
-            Expanded(child: _pages[_selectedIndex]),
-            const MiniPlayer(),
-          ],
-        ),
+      body: Column(
+        children: [
+          Expanded(child: _pages[_selectedIndex]),
+          const MiniPlayer(),
+        ],
       ),
-    );
-  }
-
-  Future<void> _showExitDialog() async {
-    final ok = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('退出应用'),
-        content: const Text('确定要退出 MD3Music 吗？'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('取消'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            child: const Text('确定'),
-          ),
+      compactBody: Column(
+        children: [
+          Expanded(child: _pages[_selectedIndex]),
+          const MiniPlayer(),
+        ],
+      ),
+      mediumBody: Column(
+        children: [
+          Expanded(child: _pages[_selectedIndex]),
+          const MiniPlayer(),
+        ],
+      ),
+      expandedBody: Column(
+        children: [
+          Expanded(child: _pages[_selectedIndex]),
+          const MiniPlayer(),
         ],
       ),
     );
-    if (ok != true) return;
-    if (kIsWeb) {
-      SystemNavigator.pop();
-    } else {
-      // 先让本地 Node.js 服务器停止监听（释放 8080 端口），再杀进程
-      // ignore: discarded_futures
-      NodeJsServer.stop();
-      // 立即杀进程，关闭所有后台服务（如 audio_service）
-      exit(0);
-    }
   }
 }

--- a/lib/core/services/audio_service_io.dart
+++ b/lib/core/services/audio_service_io.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:audio_session/audio_session.dart';
 

--- a/lib/core/services/audio_service_web.dart
+++ b/lib/core/services/audio_service_web.dart
@@ -1,6 +1,5 @@
 import 'dart:html' as html;
 
-import 'package:flutter/foundation.dart';
 import 'package:just_audio/just_audio.dart';
 
 class AudioService {

--- a/lib/core/services/desktop_lyric_service.dart
+++ b/lib/core/services/desktop_lyric_service.dart
@@ -8,10 +8,20 @@ import '../../main.dart';
 import '../../providers/favorites_provider.dart';
 import '../../providers/kugou_provider.dart';
 import '../../providers/player_provider.dart';
+import '../../widgets/apple_lyrics/models/lyric_line.dart';
+import '../../widgets/apple_lyrics/parsers/lyric_parser_chain.dart';
 import 'media_notification_service.dart';
 
-/// 桌面歌词服务：管理开关、解析 LRC、按播放位置同步到原生悬浮窗。
-/// 设置面板已内嵌到原生悬浮窗，Dart 端不再弹 dialog。
+/// 桌面歌词服务：管理开关、解析歌词（KRC/LRC/纯文本）、按播放位置同步到原生悬浮窗。
+///
+/// **关键修复**：之前用 `displayLyric`（KRC 优先）+ LRC 正则解析，导致 KRC 文本
+/// 解析全部失败、悬浮窗永远显示「暂无歌词」。现改用 [LyricParserChain.parse]
+/// 自动识别 KRC/LRC/纯文本，输出统一 [LyricLine] 列表。
+///
+/// **逐字支持**：KRC 解析后每行携带 [LyricWord] 字级时间戳，本服务按当前播放
+/// 位置计算已唱字数 `sungCharCount`，通过 `updateLyric` 通道传给原生悬浮窗，
+/// 原生侧用 clipRect 实现已唱/未唱二分色。LRC/纯文本无字时间戳时传 -1，
+/// 原生侧走整行渐变色（保持原行为）。
 class DesktopLyricService {
   static final DesktopLyricService instance = DesktopLyricService._();
   DesktopLyricService._();
@@ -25,7 +35,8 @@ class DesktopLyricService {
 
   String? _currentSongId;
   String? _currentLrcText;
-  List<_LyricLine> _lines = const [];
+  // 解析后的歌词行列表（统一模型，KRC 含 words，LRC/纯文本 words 为空）
+  List<LyricLine> _lines = const [];
   int _currentLineIndex = -1;
   Timer? _ticker;
   bool _awaitingLyric = false;
@@ -48,8 +59,6 @@ class DesktopLyricService {
       cb();
     }
   }
-
-  static final RegExp _lrcLine = RegExp(r'\[(\d{2}):(\d{2})\.(\d{2,3})\](.*)');
 
   /// 在 app 启动时（main 中）调用：注册原生回调
   void registerNativeCallbacks() {
@@ -195,6 +204,8 @@ class DesktopLyricService {
     await _pushConfig();
     _syncCurrentFromPlayer();
     _ticker?.cancel();
+    // 250ms tick：逐行歌词不需要高频刷新，250ms 足够检测切行
+    // （曾用 100ms 支持逐字二分色但卡顿严重，已恢复逐行）
     _ticker = Timer.periodic(
       const Duration(milliseconds: 250),
       (_) => _onTick(),
@@ -293,21 +304,25 @@ class DesktopLyricService {
       _awaitingLyric = false;
       _lastPushedPosMs = null;
       _pushPlaying(_player!.isPlaying);
-      _pushLyric('歌词加载中...', '');
+      _pushLyric('歌词加载中...', '', -1);
       _fetchLyricFor(song);
       return;
     }
 
-    // 拉取/解析歌词
+    // 拉取/解析歌词（修复：用 LyricParserChain 自动识别 KRC/LRC/纯文本）
     if (!_awaitingLyric && _lines.isEmpty) {
       final lyric = _kugou!.lyric;
       if (lyric != null && lyric.displayLyric.isNotEmpty) {
         final lrc = lyric.displayLyric;
         if (lrc != _currentLrcText) {
           _currentLrcText = lrc;
-          _lines = _parseLrc(lrc);
+          // LyricParserChain.parse 自动检测格式：
+          // - KRC：返回 LyricLine 列表，每行含 LyricWord 字级时间戳
+          // - LRC：返回 LyricLine 列表，words 为空
+          // - 纯文本：返回 LyricLine 列表，words 为空，startTime 全部为 0
+          _lines = LyricParserChain.parse(lrc);
           if (_lines.isEmpty) {
-            _pushLyric('暂无歌词', '');
+            _pushLyric('暂无歌词', '', -1);
           }
         }
       } else if (song.id.isNotEmpty) {
@@ -327,14 +342,17 @@ class DesktopLyricService {
 
     // Find current line
     if (_lines.isEmpty) return;
-    final newIndex = _findLineIndex(pos);
+    final newIndex = _findLineIndex(posMs);
+
+    // 行变化时推送（逐行模式：每行只在进入时推一次，不高频刷字色）
     if (newIndex != _currentLineIndex) {
       _currentLineIndex = newIndex;
       final current = newIndex >= 0 ? _lines[newIndex].text : '';
       final next = (_doubleLine && newIndex + 1 < _lines.length)
           ? _lines[newIndex + 1].text
           : '';
-      _pushLyric(current, next);
+      // sungCharCount 固定 -1：不启用逐字二分色，原生侧走整行渐变色（避免 100ms invalidate 卡顿）
+      _pushLyric(current, next, -1);
     }
   }
 
@@ -344,7 +362,7 @@ class DesktopLyricService {
     try {
       await _kugou!.getLyric(song.id, songName: song.title, fmt: 'lrc');
     } catch (_) {
-      _pushLyric('歌词加载失败', '');
+      _pushLyric('歌词加载失败', '', -1);
     } finally {
       _awaitingLyric = false;
     }
@@ -352,39 +370,29 @@ class DesktopLyricService {
 
   int? _lastPushedPosMs;
 
-  Future<void> _pushLyric(String current, String next) async {
+  /// 推送当前行文本到原生悬浮窗。
+  ///
+  /// - [sungCharCount] 始终传 -1（逐行模式，不启用逐字二分色）
+  ///   原生侧 GradientTextView.onDraw 走 LRC/纯文本分支，整行渐变色
+  ///   历史参数保留是为了不破坏 MethodChannel 协议，原生侧会忽略 -1
+  Future<void> _pushLyric(String current, String next, int sungCharCount) async {
     try {
       await _channel.invokeMethod('updateLyric', {
         'lyric': current,
         'nextLyric': next,
+        'sungCharCount': sungCharCount,
       });
     } catch (_) {}
   }
 
-  List<_LyricLine> _parseLrc(String lrc) {
-    final result = <_LyricLine>[];
-    for (final raw in lrc.split('\n')) {
-      final line = raw.trim();
-      if (line.isEmpty) continue;
-      final m = _lrcLine.firstMatch(line);
-      if (m == null) continue;
-      final mm = int.parse(m.group(1)!);
-      final ss = int.parse(m.group(2)!);
-      final ff = int.parse(m.group(3)!);
-      final ms = m.group(3)!.length == 2 ? ff * 10 : ff;
-      final text = m.group(4)!.trim();
-      if (text.isEmpty) continue;
-      final ts = Duration(minutes: mm, seconds: ss, milliseconds: ms);
-      result.add(_LyricLine(ts, text));
-    }
-    result.sort((a, b) => a.timestamp.compareTo(b.timestamp));
-    return result;
-  }
-
-  int _findLineIndex(Duration position) {
+  /// 二分查找当前播放位置对应的歌词行 index。
+  ///
+  /// _lines 已按 startTime 升序排列（LyricParserChain 保证），
+  /// 找到最后一个 startTime <= posMs 的行。
+  int _findLineIndex(int posMs) {
     int idx = -1;
     for (int i = 0; i < _lines.length; i++) {
-      if (position >= _lines[i].timestamp) {
+      if (posMs >= _lines[i].startTime) {
         idx = i;
       } else {
         break;
@@ -392,10 +400,4 @@ class DesktopLyricService {
     }
     return idx;
   }
-}
-
-class _LyricLine {
-  final Duration timestamp;
-  final String text;
-  _LyricLine(this.timestamp, this.text);
 }

--- a/lib/core/services/lyricon_provider_service.dart
+++ b/lib/core/services/lyricon_provider_service.dart
@@ -1,0 +1,245 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+import '../../data/models/song.dart';
+import '../../widgets/apple_lyrics/models/lyric_line.dart';
+
+/// Lyricon 设备桥接服务：作为 Dart 与 Kotlin（MainActivity MethodChannel
+/// `com.md3music.md3music/lyricon`）之间的中间层，负责向 Lyricon 实时歌词
+/// 提供方推送歌曲信息、播放进度、播放状态以及用户偏好（翻译 / 罗马音），
+/// 并接收 Kotlin 侧反向回调的连接状态变更，通知 UI 刷新。
+///
+/// 设计参考 [DesktopLyricService]：单例 + `addListener` 通知模式，
+/// 所有 MethodChannel 调用均 try-catch 静默吞异常，避免桥接失败影响主播放流程。
+enum LyriconConnectionState {
+  /// 未启用
+  disabled,
+
+  /// 连接中
+  connecting,
+
+  /// 已连接
+  connected,
+
+  /// 已断开
+  disconnected,
+
+  /// 连接超时
+  timeout,
+}
+
+class LyriconProviderService {
+  static final LyriconProviderService instance =
+      LyriconProviderService._();
+  LyriconProviderService._();
+
+  static const _channel = MethodChannel('com.md3music.md3music/lyricon');
+
+  LyriconConnectionState _state = LyriconConnectionState.disabled;
+  LyriconConnectionState get state => _state;
+
+  bool get enabled => _state != LyriconConnectionState.disabled;
+
+  // 通知外部状态变化（让 UI 可以监听刷新连接状态指示）
+  final List<VoidCallback> _listeners = [];
+  void addListener(VoidCallback cb) => _listeners.add(cb);
+  void removeListener(VoidCallback cb) => _listeners.remove(cb);
+  void _notify() {
+    for (final cb in List.of(_listeners)) {
+      cb();
+    }
+  }
+
+  /// 在 main.dart 启动时调用一次：注册 Kotlin 反向回调 handler。
+  Future<void> initialize() async {
+    _channel.setMethodCallHandler((call) async {
+      switch (call.method) {
+        case 'onConnectionStateChanged':
+          _onConnectionStateChanged(call.arguments as String?);
+          break;
+      }
+    });
+  }
+
+  void _onConnectionStateChanged(String? state) {
+    switch (state) {
+      case 'connected':
+      case 'reconnected':
+        _state = LyriconConnectionState.connected;
+        break;
+      case 'disconnected':
+        _state = LyriconConnectionState.disconnected;
+        break;
+      case 'timeout':
+        _state = LyriconConnectionState.timeout;
+        break;
+      default:
+        return;
+    }
+    _notify();
+  }
+
+  /// 启用 / 禁用 Lyricon 提供方。
+  ///
+  /// 启用前先本地切到 connecting 态，禁用立刻切到 disabled 态，
+  /// 让 UI 无需等待原生回调即可反馈。
+  Future<void> setEnabled(bool enabled) async {
+    if (enabled) {
+      _state = LyriconConnectionState.connecting;
+    } else {
+      _state = LyriconConnectionState.disabled;
+    }
+    _notify();
+    try {
+      await _channel.invokeMethod('setEnabled', {'enabled': enabled});
+    } catch (_) {}
+  }
+
+  /// 推送当前歌曲 + 完整歌词列表给 Kotlin。
+  ///
+  /// 字段映射（已与模型源码核对）：
+  /// - Song.title → songMap['name']（Kotlin 侧期望 name）
+  /// - Song.artist → songMap['artist']
+  /// - Song.duration 是 Duration，需 .inMilliseconds 转 int
+  /// - LyricLine.startTime / endTime 均为 int（毫秒），endTime 是 getter
+  /// - LyricWord.startTime 是 int（毫秒），无 endTime getter，用 startTime + duration
+  /// - LyricLine.translation 是 String?，原样透传
+  Future<void> setSong(Song? song, List<LyricLine> lines) async {
+    if (song == null) {
+      try {
+        await _channel.invokeMethod('setSong', {'song': null});
+      } catch (_) {}
+      return;
+    }
+    // 预处理：为每行计算一个合法的 end。
+    // LRC 解析器输出的 duration=0，导致 endTime==startTime，会被 SDK 的
+    // Song.normalize() 过滤（条件 begin < end 失败）。兜底策略：
+    // - LRC 行（duration==0）：end = 下一行 startTime；末行 end = begin + 5000
+    // - KRC 行（duration>0）：原样使用 endTime
+    // 同时过滤 text 为空白的行（normalize 也会过滤，提前过滤避免无意义传输）。
+    final List<Map<String, dynamic>> lyricMaps = [];
+    for (int i = 0; i < lines.length; i++) {
+      final line = lines[i];
+      if (line.text.trim().isEmpty) continue;
+      final int begin = line.startTime;
+      final int end;
+      if (line.endTime > begin) {
+        end = line.endTime;
+      } else if (i + 1 < lines.length && lines[i + 1].startTime > begin) {
+        end = lines[i + 1].startTime;
+      } else {
+        end = begin + 5000; // 末行兜底 5 秒
+      }
+      lyricMaps.add(<String, dynamic>{
+        'begin': begin,
+        'end': end,
+        'text': line.text,
+        if (line.translation != null) 'translation': line.translation,
+        'words': line.words
+            .map((w) => <String, dynamic>{
+                  'text': w.text,
+                  'begin': w.startTime,
+                  'end': w.startTime + w.duration,
+                })
+            .toList(),
+      });
+    }
+
+    final songMap = <String, dynamic>{
+      'id': song.id,
+      // 用 displayName 剥离 .mp3/.flac 等后缀，避免 Lyricon 标题显示带后缀
+      'name': song.displayName,
+      'artist': song.artist,
+      'duration': song.duration.inMilliseconds,
+      'lyrics': lyricMaps,
+    };
+    try {
+      await _channel.invokeMethod('setSong', {'song': songMap});
+    } catch (_) {}
+  }
+
+  /// 由 PlayerProvider 在切歌时调用。
+  ///
+  /// Lyricon 推荐调用顺序（文档 6.8）：setSong → setPosition → setPlaybackState。
+  /// 只调 setSong 不调后两个，Lyricon 中心服务无法确定当前播放进度和状态，
+  /// 会导致歌词不渲染、回退显示"作者-歌名"。
+  Future<void> onSongChanged(
+    Song? song,
+    List<LyricLine> lines, {
+    int positionMs = 0,
+    bool isPlaying = false,
+  }) async {
+    if (!enabled) return;
+    await setSong(song, lines);
+    try {
+      await _channel.invokeMethod('setPosition', {'positionMs': positionMs});
+      await _channel.invokeMethod(
+        'setPlaybackState',
+        {
+          // 必须用 PlaybackStateCompat 常量：STATE_PLAYING=3, STATE_PAUSED=2
+          // Kotlin 端判断 state==3 推导 isPlaying，传 1 会被当成 STATE_STOPPED→isPlaying=false
+          'state': isPlaying ? 3 : 2,
+          'position': positionMs,
+          'speed': 1.0,
+        },
+      );
+    } catch (_) {}
+  }
+
+  /// 推送一段纯文本（如临时提示）。
+  Future<void> sendText(String text) async {
+    try {
+      await _channel.invokeMethod('sendText', {'text': text});
+    } catch (_) {}
+  }
+
+  /// 推送当前播放位置（毫秒）。
+  Future<void> setPosition(int positionMs) async {
+    try {
+      // key 必须与 Kotlin 端 MainActivity.kt 的 "setPosition" handler 对齐（期望 "positionMs"）
+      await _channel.invokeMethod('setPosition', {'positionMs': positionMs});
+    } catch (_) {}
+  }
+
+  /// 推送播放状态。
+  ///
+  /// state 必须用 PlaybackStateCompat 常量：STATE_PLAYING=3, STATE_PAUSED=2。
+  /// Kotlin 端判断 state==3 推导 isPlaying，传其他值会被当成 paused。
+  Future<void> setPlaybackState({
+    required int state,
+    required int position,
+    required double speed,
+  }) async {
+    try {
+      await _channel.invokeMethod('setPlaybackState', {
+        'state': state,
+        'position': position,
+        'speed': speed,
+      });
+    } catch (_) {}
+  }
+
+  /// 用户拖动进度条时通知 Lyricon 跳转。
+  Future<void> seekTo(int positionMs) async {
+    try {
+      // key 必须与 Kotlin 端 MainActivity.kt 的 "seekTo" handler 对齐（期望 "positionMs"）
+      await _channel.invokeMethod('seekTo', {'positionMs': positionMs});
+    } catch (_) {}
+  }
+
+  /// 切换翻译显示。
+  Future<void> setDisplayTranslation(bool enabled) async {
+    try {
+      await _channel.invokeMethod('setDisplayTranslation', {'enabled': enabled});
+    } catch (_) {}
+  }
+
+  /// 切换罗马音显示。
+  Future<void> setDisplayRoma(bool enabled) async {
+    try {
+      await _channel.invokeMethod('setDisplayRoma', {'enabled': enabled});
+    } catch (_) {}
+  }
+}

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -3,7 +3,23 @@ import 'package:flutter/material.dart';
 class AppTheme {
   AppTheme._();
 
-  static const Color _seedColor = Color(0xFF6750A4);
+  /// 8 个预设种子色，取自 Material 3 官方 Theme Builder 的 key tone 40。
+  /// 顺序：色环顺序（紫→蓝→青→绿→黄→橙→红→粉）。
+  /// 索引 0 是默认色，与 [defaultSeedColor] 保持一致。
+  static const List<Color> presetSeedColors = [
+    Color(0xFF6750A4), // 紫（M3 默认）
+    Color(0xFF0061A4), // 蓝
+    Color(0xFF006A6A), // 青绿
+    Color(0xFF386A20), // 绿
+    Color(0xFF7E5700), // 黄
+    Color(0xFF8C4A00), // 橙
+    Color(0xFFB3261E), // 红
+    Color(0xFF984061), // 粉
+  ];
+
+  /// 默认种子色（紫色），用于未启用系统主题色且未手动选择时的兜底。
+  /// 必须独立定义为 const，不能引用 [presetSeedColors] 的索引（非常量表达式）。
+  static const Color defaultSeedColor = Color(0xFF6750A4);
 
   // CJK 字体回退链 - 按平台优先级排序:
   // 1) Web 浏览器(Windows + Edge) 优先用系统自带的 "Microsoft YaHei" (无需下载)
@@ -29,7 +45,7 @@ class AppTheme {
 
   static ThemeData get lightTheme {
     final colorScheme = ColorScheme.fromSeed(
-      seedColor: _seedColor,
+      seedColor: defaultSeedColor,
       brightness: Brightness.light,
     );
     return _buildTheme(colorScheme, Brightness.light);
@@ -37,9 +53,47 @@ class AppTheme {
 
   static ThemeData get darkTheme {
     final colorScheme = ColorScheme.fromSeed(
-      seedColor: _seedColor,
+      seedColor: defaultSeedColor,
       brightness: Brightness.dark,
     );
+    return _buildTheme(colorScheme, Brightness.dark);
+  }
+
+  /// 根据传入的种子色构建浅色主题。
+  ///
+  /// 用于「莫奈色」开关启用时，由 ThemeProvider 传入系统提取的主色。
+  static ThemeData lightThemeFromSeed(Color seedColor) {
+    final colorScheme = ColorScheme.fromSeed(
+      seedColor: seedColor,
+      brightness: Brightness.light,
+    );
+    return _buildTheme(colorScheme, Brightness.light);
+  }
+
+  /// 根据传入的种子色构建深色主题。
+  ///
+  /// [useOledBlack] 为 true 时启用 OLED 纯黑变体：
+  /// 将 [ColorScheme] 的 surface 系列覆盖为 [Colors.black] / 极深灰，
+  /// 保留 onSurface 等前景色不变（保证对比度），
+  /// surfaceContainerHigh/Highest 用极深灰保留卡片层级感。
+  static ThemeData darkThemeFromSeed(Color seedColor, {bool useOledBlack = false}) {
+    var colorScheme = ColorScheme.fromSeed(
+      seedColor: seedColor,
+      brightness: Brightness.dark,
+    );
+    if (useOledBlack) {
+      colorScheme = colorScheme.copyWith(
+        surface: Colors.black,
+        surfaceContainerLowest: Colors.black,
+        surfaceContainerLow: Colors.black,
+        surfaceContainer: Colors.black,
+        // High/Highest 保留极深灰，让卡片/底栏仍有微妙层级感
+        surfaceContainerHigh: const Color(0xFF111111),
+        surfaceContainerHighest: const Color(0xFF1A1A1A),
+        // onSurface 等前景色保持不变，确保文字对比度
+        // inverseSurface 保持不变，确保 Snackbar 反色正常
+      );
+    }
     return _buildTheme(colorScheme, Brightness.dark);
   }
 

--- a/lib/data/models/song.dart
+++ b/lib/data/models/song.dart
@@ -37,6 +37,17 @@ class Song {
     return '$minutes:$seconds';
   }
 
+  /// 用于 UI 显示的标题——剥离常见音频文件扩展名后缀。
+  ///
+  /// 酷狗 API 返回的 `songname`/`FileName` 字段有时带 `.mp3`/`.flac` 等后缀，
+  /// 在 UI 显示时应当剥离。原始 [title] 字段保持不变用于搜索/收藏 key 等场景。
+  /// 支持的扩展名：mp3, flac, wav, ape, m4a, ogg, aac, wma, opus（大小写不敏感）。
+  String get displayName {
+    final pattern = RegExp(r'\.(mp3|flac|wav|ape|m4a|ogg|aac|wma|opus)$',
+        caseSensitive: false);
+    return title.replaceFirst(pattern, '');
+  }
+
   factory Song.fromJson(Map<String, dynamic> json) {
     return Song(
       id: json['id'] as String,

--- a/lib/data/repositories/settings_repository.dart
+++ b/lib/data/repositories/settings_repository.dart
@@ -169,4 +169,36 @@ class SettingsRepository {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool('settings_dl_locked', v);
   }
+
+  // ===== Lyricon 配置 =====
+
+  Future<bool> getLyriconEnabled() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool('lyricon_enabled') ?? false;
+  }
+
+  Future<void> setLyriconEnabled(bool v) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('lyricon_enabled', v);
+  }
+
+  Future<bool> getLyriconDisplayTranslation() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool('lyricon_display_translation') ?? true;
+  }
+
+  Future<void> setLyriconDisplayTranslation(bool v) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('lyricon_display_translation', v);
+  }
+
+  Future<bool> getLyriconDisplayRoma() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool('lyricon_display_roma') ?? false;
+  }
+
+  Future<void> setLyriconDisplayRoma(bool v) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('lyricon_display_roma', v);
+  }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,8 +7,10 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'app.dart';
 import 'core/services/desktop_lyric_service.dart';
+import 'core/services/lyricon_provider_service.dart';
 import 'core/services/media_notification_service.dart';
 import 'services/nodejs_server.dart';
+import 'widgets/apple_lyrics/layout/lyric_preferences.dart';
 
 const String _kBatteryPromptShownKey = 'battery_prompt_shown';
 
@@ -18,9 +20,14 @@ final GlobalKey<NavigatorState> appNavigatorKey = GlobalKey<NavigatorState>();
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await initializeDateFormatting('zh_CN');
+  // 加载歌词字号/行间距偏好（从 SharedPreferences）
+  await LyricPreferences.instance.load();
   // 注册通知栏/悬浮窗回调（悬浮窗内按钮 → DesktopLyricService；通知栏桌面歌词按钮 → toggle）
   MediaNotificationService.initCallbacks();
   DesktopLyricService.instance.registerNativeCallbacks();
+  // 注册 Lyricon 反向回调（连接状态变更 → UI 刷新）
+  // initialize 内部仅 setMethodCallHandler，同步完成，无需 await
+  LyriconProviderService.instance.initialize();
   // 权限请求包裹 try/catch：在部分设备/早期阶段 permission_handler 可能抛
   // "Unable to detect current Android Activity"，不能让它中断启动流程。
   try {

--- a/lib/modules/album/album_detail_page.dart
+++ b/lib/modules/album/album_detail_page.dart
@@ -25,10 +25,31 @@ class _AlbumDetailPageState extends State<AlbumDetailPage> {
   String? _error;
   KugouAlbumDetail? _albumDetail;
 
+  // 顶栏 fade-in 用的滚动监听：与 playlist_page.dart 保持一致的实现风格
+  final ScrollController _scrollController = ScrollController();
+  double _scrollOffset = 0;
+
   @override
   void initState() {
     super.initState();
+    _scrollController.addListener(_onScroll);
     WidgetsBinding.instance.addPostFrameCallback((_) => _fetchAlbum());
+  }
+
+  @override
+  void dispose() {
+    _scrollController.removeListener(_onScroll);
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  /// 滚动监听：阈值 0.5px 防抖，避免过度 setState。
+  void _onScroll() {
+    if (!mounted) return;
+    final offset = _scrollController.offset;
+    if ((offset - _scrollOffset).abs() > 0.5) {
+      setState(() => _scrollOffset = offset);
+    }
   }
 
   Future<void> _fetchAlbum() async {
@@ -75,10 +96,34 @@ class _AlbumDetailPageState extends State<AlbumDetailPage> {
                   children: [
                     Expanded(
                       child: CustomScrollView(
+                        controller: _scrollController,
                         slivers: [
                           SliverAppBar(
                             expandedHeight: 280,
                             pinned: true,
+                            // pinned 后顶栏背景色：滚动到 expandedHeight - kToolbarHeight
+                            // 之后从透明渐变到 surface（与 playlist_page 一致）
+                            backgroundColor: Color.lerp(
+                              Colors.transparent,
+                              colorScheme.surface,
+                              (_scrollOffset - (280 - kToolbarHeight))
+                                  .clamp(0.0, 60.0) / 60,
+                            )!,
+                            surfaceTintColor: Colors.transparent,
+                            scrolledUnderElevation: 0,
+                            // pinned 后顶栏标题：滚动超过阈值后 fade-in 显示专辑名称
+                            title: Opacity(
+                              opacity: ((_scrollOffset - (280 - kToolbarHeight)) /
+                                      60.0)
+                                  .clamp(0.0, 1.0),
+                              child: Text(
+                                displayAlbum.name,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: textTheme.titleLarge
+                                    ?.copyWith(fontWeight: FontWeight.w600),
+                              ),
+                            ),
                             flexibleSpace: FlexibleSpaceBar(
                               background: Container(
                                 decoration: BoxDecoration(

--- a/lib/modules/charts/charts_page.dart
+++ b/lib/modules/charts/charts_page.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import '../../providers/kugou_provider.dart';
 import '../../providers/player_provider.dart';
 import '../../widgets/app_animation.dart';
+import '../../widgets/scroll_aware_app_bar.dart';
 import '../../widgets/song_list_item.dart';
 
 class ChartsPage extends StatefulWidget {
@@ -15,6 +16,15 @@ class ChartsPage extends StatefulWidget {
 }
 
 class _ChartsPageState extends State<ChartsPage> {
+  /// 顶栏渐变 ScrollController：与 ScrollAwareAppBar 共享
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
   @override
   void initState() {
     super.initState();
@@ -26,13 +36,10 @@ class _ChartsPageState extends State<ChartsPage> {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final textTheme = Theme.of(context).textTheme;
     return Scaffold(
-      appBar: AppBar(
-        title: Text(
-          '排行榜',
-          style: textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w600),
-        ),
+      appBar: ScrollAwareAppBar(
+        title: '排行榜',
+        scrollController: _scrollController,
       ),
       body: _buildRankList(context, cs),
     );
@@ -69,6 +76,7 @@ class _ChartsPageState extends State<ChartsPage> {
         return RefreshIndicator(
           onRefresh: () => kugou.getRankList(forceRefresh: true),
           child: ListView.builder(
+            controller: _scrollController,
             padding: const EdgeInsets.all(16),
             itemCount: ranks.ranks.length,
             itemBuilder: (context, i) {

--- a/lib/modules/discover/discover_page.dart
+++ b/lib/modules/discover/discover_page.dart
@@ -8,6 +8,7 @@ import '../../providers/kugou_provider.dart';
 import '../../providers/player_provider.dart';
 import '../../widgets/album_card.dart';
 import '../../widgets/app_animation.dart';
+import '../../widgets/scroll_aware_app_bar.dart';
 import '../../widgets/song_list_item.dart';
 import '../charts/charts_page.dart';
 import '../playlist/playlist_page.dart';
@@ -25,6 +26,15 @@ class _DiscoverPageState extends State<DiscoverPage> {
 
   bool _isLoading = true;
   String? _error;
+
+  /// 顶栏渐变 ScrollController：与 ScrollAwareAppBar 共享，监听滚动 offset
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
 
   @override
   void initState() {
@@ -127,14 +137,11 @@ class _DiscoverPageState extends State<DiscoverPage> {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    final textTheme = Theme.of(context).textTheme;
 
     return Scaffold(
-      appBar: AppBar(
-        title: Text(
-          'MD3Music',
-          style: textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w600),
-        ),
+      appBar: ScrollAwareAppBar(
+        title: 'MD3Music',
+        scrollController: _scrollController,
         actions: [
           IconButton(
             icon: const Icon(Icons.search),
@@ -145,7 +152,11 @@ class _DiscoverPageState extends State<DiscoverPage> {
           Consumer<KugouProvider>(
             builder: (context, kugou, _) => Padding(
               padding: const EdgeInsets.only(right: 8),
-              child: _buildAvatar(kugou, colorScheme),
+              // 头像可点击：跳转到「我的」页面（push 独立路由）
+              child: GestureDetector(
+                onTap: () => Navigator.of(context).pushNamed('/user'),
+                child: _buildAvatar(kugou, colorScheme),
+              ),
             ),
           ),
         ],
@@ -157,6 +168,7 @@ class _DiscoverPageState extends State<DiscoverPage> {
             : _error != null
             ? _buildError(colorScheme)
             : CustomScrollView(
+                controller: _scrollController,
                 slivers: [
                   _buildBannerSection(colorScheme),
                   _buildDailySection(colorScheme),

--- a/lib/modules/login/login_page.dart
+++ b/lib/modules/login/login_page.dart
@@ -396,6 +396,7 @@ class _LoginPageState extends State<LoginPage> {
     );
   }
 
+  // ignore: unused_element
   Widget _buildWxTab(ColorScheme colorScheme, TextTheme textTheme) {
     final base64 = _wxQrData?['qrcode']?['qrcodebase64']?.toString();
     final bytes = _decodeBase64Image(base64);

--- a/lib/modules/personal_fm/personal_fm_page.dart
+++ b/lib/modules/personal_fm/personal_fm_page.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../../providers/kugou_provider.dart';
 import '../../providers/player_provider.dart';
 import '../../services/kugou_api/kugou_models.dart';
+import '../../widgets/scroll_aware_app_bar.dart';
 
 class PersonalFmPage extends StatefulWidget {
   const PersonalFmPage({super.key});
@@ -21,6 +22,9 @@ class _PersonalFmPageState extends State<PersonalFmPage>
   final int _visibleSideCount = 3;
   late AnimationController _vinylRotationController;
   late AnimationController _slideController;
+
+  /// 顶栏渐变 ScrollController：与 ScrollAwareAppBar 共享
+  final ScrollController _scrollController = ScrollController();
 
   final List<Map<String, dynamic>> _modeOptions = [
     {'value': 'normal', 'label': '红心'},
@@ -79,6 +83,7 @@ class _PersonalFmPageState extends State<PersonalFmPage>
     } catch (_) {}
     _vinylRotationController.dispose();
     _slideController.dispose();
+    _scrollController.dispose();
     super.dispose();
   }
 
@@ -285,13 +290,12 @@ class _PersonalFmPageState extends State<PersonalFmPage>
     }
 
     return Scaffold(
-      appBar: AppBar(
-        title: Text(
-          '私人 FM',
-          style: textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w600),
-        ),
+      appBar: ScrollAwareAppBar(
+        title: '私人 FM',
+        scrollController: _scrollController,
       ),
       body: SingleChildScrollView(
+        controller: _scrollController,
         padding: const EdgeInsets.only(
           left: 16,
           right: 16,

--- a/lib/modules/player/comments_view.dart
+++ b/lib/modules/player/comments_view.dart
@@ -1,14 +1,39 @@
 import 'package:flutter/material.dart';
+import 'package:palette_generator/palette_generator.dart';
 import 'package:provider/provider.dart';
 
 import '../../providers/kugou_provider.dart';
 import '../../services/kugou_api/kugou_models.dart';
 
+/// 评论列表视图。
+///
+/// 在 FullPlayer 中作为 TabBarView 第三个 Tab 展示，背景为模糊封面 + 黑蒙版。
+/// 由于背景永远是深色封面图，原 MD3 主题的黑色文字几乎不可见。
+///
+/// **智能反色**：通过 [PaletteGenerator] 从当前封面提取主色（dominantColor），
+/// 根据主色亮度（[Color.computeLuminance]）决定文字颜色：
+/// - 主色亮度 < 0.5（暗色封面）→ 文字反色为白色
+/// - 主色亮度 >= 0.5（亮色封面）→ 文字反色为黑色
+/// - 无封面或提取失败 → 默认白色（FullPlayer 背景为黑+黑蒙版）
+///
+/// 辅助文字（用户名、时间）在反色基础上加 70% 透明度。
+///
+/// **mask alpha 渐变**：列表顶部/底部各 24px 范围用 ShaderMask + BlendMode.dstIn
+/// 实现 alpha 渐变（比歌词页更窄），让滚动内容从背景柔和淡入、淡出到背景，
+/// 避免列表硬切边。
 class CommentsView extends StatefulWidget {
   final String songHash;
   final String? albumAudioId;
 
-  const CommentsView({super.key, required this.songHash, this.albumAudioId});
+  /// 封面 URL，用于提取主色驱动智能反色。
+  final String? artworkUri;
+
+  const CommentsView({
+    super.key,
+    required this.songHash,
+    this.albumAudioId,
+    this.artworkUri,
+  });
 
   @override
   State<CommentsView> createState() => _CommentsViewState();
@@ -19,9 +44,17 @@ class _CommentsViewState extends State<CommentsView> {
   bool _isLoading = false;
   String? _error;
 
+  /// 智能反色后的主文字颜色（评论正文）。
+  /// null 表示尚未确定（首帧先用白色兜底，避免黑底黑字）。
+  Color _primaryTextColor = Colors.white;
+
+  /// 智能反色后的辅助文字颜色（用户名、时间戳）。
+  Color _secondaryTextColor = const Color(0xB3FFFFFF); // 70% 透明白
+
   @override
   void initState() {
     super.initState();
+    _updatePalette();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _fetchComments();
     });
@@ -35,6 +68,63 @@ class _CommentsViewState extends State<CommentsView> {
         _fetchComments();
       });
     }
+    // 封面切换时重新提取主色
+    if (oldWidget.artworkUri != widget.artworkUri) {
+      _updatePalette();
+    }
+  }
+
+  /// 从封面提取主色并设置反色后的文字颜色。
+  ///
+  /// 使用 [PaletteGenerator.fromImageProvider] 异步提取 dominantColor，
+  /// 根据亮度选择黑/白反色。失败时降级为白色（适配 FullPlayer 深色背景）。
+  Future<void> _updatePalette() async {
+    final uri = widget.artworkUri;
+    if (uri == null || uri.isEmpty) {
+      _applyPalette(null);
+      return;
+    }
+
+    try {
+      final palette = await PaletteGenerator.fromImageProvider(
+        NetworkImage(uri),
+        maximumColorCount: 16,
+      );
+      if (!mounted) return;
+      _applyPalette(palette.dominantColor?.color);
+    } catch (_) {
+      if (!mounted) return;
+      _applyPalette(null);
+    }
+  }
+
+  /// 根据主色亮度应用反色文字。
+  ///
+  /// - `artworkUri == null`（原版 MD3 FullPlayer 调用，未传封面 URL）：
+  ///   背景是 colorScheme.surface，跟随主题色，主文字用 onSurface、辅助文字用 onSurfaceVariant。
+  /// - `artworkUri != null`（AM 风格 FullPlayer 调用，传入封面 URL）：启用智能反色
+  ///   - 主色为 null：默认白色（适配 AM 黑色模糊封面背景）
+  ///   - 主色亮度 < 0.5：暗背景 → 文字反色为白色
+  ///   - 主色亮度 >= 0.5：亮背景 → 文字反色为黑色
+  /// 辅助文字 = 主文字颜色 × 70% 透明度（仅 AM 风格分支，用户原话："黑色加上70%灰色"）。
+  void _applyPalette(Color? dominant) {
+    // 原版 MD3 风格：未传 artworkUri，背景是 surface，跟随主题色
+    if (widget.artworkUri == null) {
+      final colorScheme = Theme.of(context).colorScheme;
+      setState(() {
+        _primaryTextColor = colorScheme.onSurface;
+        _secondaryTextColor = colorScheme.onSurfaceVariant;
+      });
+      return;
+    }
+    // AM 风格：智能反色，根据封面主色亮度决定黑/白
+    final bool isDarkBg =
+        dominant == null ? true : dominant.computeLuminance() < 0.5;
+    final Color base = isDarkBg ? Colors.white : Colors.black;
+    setState(() {
+      _primaryTextColor = base;
+      _secondaryTextColor = base.withValues(alpha: 0.7);
+    });
   }
 
   Future<void> _fetchComments() async {
@@ -46,7 +136,8 @@ class _CommentsViewState extends State<CommentsView> {
     });
 
     final kugouProvider = context.read<KugouProvider>();
-    await kugouProvider.getComments(widget.songHash, albumAudioId: widget.albumAudioId);
+    await kugouProvider.getComments(widget.songHash,
+        albumAudioId: widget.albumAudioId);
 
     if (mounted) {
       setState(() {
@@ -64,10 +155,10 @@ class _CommentsViewState extends State<CommentsView> {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-
     if (_isLoading) {
-      return const Center(child: CircularProgressIndicator());
+      return Center(
+        child: CircularProgressIndicator(color: _primaryTextColor),
+      );
     }
 
     if (_error != null) {
@@ -80,18 +171,20 @@ class _CommentsViewState extends State<CommentsView> {
               Icon(
                 Icons.error_outline,
                 size: 48,
-                color: colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
+                color: _secondaryTextColor,
               ),
               const SizedBox(height: 12),
               Text(
                 '加载评论失败',
-                style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                      color: colorScheme.onSurfaceVariant,
-                    ),
+                style: TextStyle(
+                  color: _secondaryTextColor,
+                  fontSize: 16,
+                ),
               ),
               const SizedBox(height: 16),
-              FilledButton.tonal(
+              TextButton(
                 onPressed: _fetchComments,
+                style: TextButton.styleFrom(foregroundColor: _primaryTextColor),
                 child: const Text('重试'),
               ),
             ],
@@ -108,78 +201,111 @@ class _CommentsViewState extends State<CommentsView> {
             Icon(
               Icons.comment_outlined,
               size: 48,
-              color: colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
+              color: _secondaryTextColor,
             ),
             const SizedBox(height: 12),
             Text(
               '暂无评论',
-              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                    color: colorScheme.onSurfaceVariant,
-                  ),
+              style: TextStyle(color: _secondaryTextColor, fontSize: 16),
             ),
           ],
         ),
       );
     }
 
-    return ListView.separated(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      itemCount: _comments.length,
-      separatorBuilder: (_, _) => const Divider(height: 1),
-      itemBuilder: (context, index) {
-        final comment = _comments[index];
-        return Padding(
-          padding: const EdgeInsets.symmetric(vertical: 12),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              CircleAvatar(
-                radius: 18,
-                backgroundColor: colorScheme.surfaceContainerHighest,
-                child: Text(
-                  comment.username.isNotEmpty ? comment.username[0] : '?',
-                  style: TextStyle(
-                    color: colorScheme.onSurfaceVariant,
-                    fontSize: 14,
+    // 用 ShaderMask + BlendMode.dstIn 实现上下 alpha 渐变：
+    // 顶部 24px alpha 0→1，底部 24px alpha 1→0，
+    // 比 lyrics 视图更窄，让评论从背景柔和淡入、淡出到背景。
+    return ShaderMask(
+      shaderCallback: (Rect bounds) {
+        const double fadeHeight = 24.0;
+        final double fadeRatio = (fadeHeight / bounds.height).clamp(0.0, 0.5);
+        return LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: const [
+            Colors.transparent,
+            Colors.black,
+            Colors.black,
+            Colors.transparent,
+          ],
+          stops: [
+            0.0,
+            fadeRatio,
+            1.0 - fadeRatio,
+            1.0,
+          ],
+        ).createShader(bounds);
+      },
+      blendMode: BlendMode.dstIn,
+      child: ListView.separated(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        itemCount: _comments.length,
+        separatorBuilder: (_, _) => Divider(
+          height: 1,
+          color: _secondaryTextColor.withValues(alpha: 0.2),
+        ),
+        itemBuilder: (context, index) {
+          final comment = _comments[index];
+          return Padding(
+            padding: const EdgeInsets.symmetric(vertical: 12),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                CircleAvatar(
+                  radius: 18,
+                  backgroundColor: _secondaryTextColor.withValues(alpha: 0.2),
+                  child: Text(
+                    comment.username.isNotEmpty ? comment.username[0] : '?',
+                    style: TextStyle(
+                      color: _primaryTextColor,
+                      fontSize: 14,
+                    ),
                   ),
                 ),
-              ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      children: [
-                        Text(
-                          comment.username,
-                          style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                                color: colorScheme.onSurfaceVariant,
-                              ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Text(
+                            comment.username,
+                            style: TextStyle(
+                              color: _secondaryTextColor,
+                              fontSize: 12,
+                            ),
+                          ),
+                          const Spacer(),
+                          Text(
+                            _formatTime(comment.time),
+                            style: TextStyle(
+                              color: _secondaryTextColor
+                                  .withValues(alpha: 0.6),
+                              fontSize: 11,
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        comment.content,
+                        style: TextStyle(
+                          color: _primaryTextColor,
+                          fontSize: 14,
+                          height: 1.4,
                         ),
-                        const Spacer(),
-                        Text(
-                          _formatTime(comment.time),
-                          style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                                color: colorScheme.onSurfaceVariant
-                                    .withValues(alpha: 0.6),
-                              ),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      comment.content,
-                      style: Theme.of(context).textTheme.bodyMedium,
-                    ),
-                    const SizedBox(height: 6),
-                  ],
+                      ),
+                      const SizedBox(height: 6),
+                    ],
+                  ),
                 ),
-              ),
-            ],
-          ),
-        );
-      },
+              ],
+            ),
+          );
+        },
+      ),
     );
   }
 

--- a/lib/modules/player/full_player.dart
+++ b/lib/modules/player/full_player.dart
@@ -209,31 +209,37 @@ class _FullPlayerState extends State<FullPlayer>
                     child: SizedBox(
                       width: size,
                       height: size,
-                      child: ClipRRect(
-                        borderRadius: BorderRadius.circular(16),
-                        child: currentSong.artworkUri != null
-                            ? CachedNetworkImage(
-                                imageUrl: currentSong.artworkUri!,
-                                fit: BoxFit.cover,
-                                placeholder: (_, _) => Container(
-                                  color: colorScheme.surfaceContainerHighest,
+                      // 暂停缩放动画（与 AM 风格统一：播放 1.0 / 暂停 0.85 带回弹）
+                      child: AnimatedScale(
+                        scale: playerProvider.isPlaying ? 1.0 : 0.85,
+                        duration: const Duration(milliseconds: 500),
+                        curve: Curves.easeOutBack,
+                        child: ClipRRect(
+                          borderRadius: BorderRadius.circular(16),
+                          child: currentSong.artworkUri != null
+                              ? CachedNetworkImage(
+                                  imageUrl: currentSong.artworkUri!,
+                                  fit: BoxFit.cover,
+                                  placeholder: (_, _) => Container(
+                                    color: colorScheme.surfaceContainerHighest,
+                                    child: Icon(Icons.music_note,
+                                      size: 48, color: colorScheme.onSurfaceVariant),
+                                  ),
+                                  errorWidget: (_, _, _) => Container(
+                                    color: colorScheme.surfaceContainerHighest,
+                                    child: Icon(Icons.music_note,
+                                      size: 48, color: colorScheme.onSurfaceVariant),
+                                  ),
+                                )
+                              : Container(
+                                  decoration: BoxDecoration(
+                                    color: colorScheme.surfaceContainerHighest,
+                                    borderRadius: BorderRadius.circular(16),
+                                  ),
                                   child: Icon(Icons.music_note,
                                     size: 48, color: colorScheme.onSurfaceVariant),
                                 ),
-                                errorWidget: (_, _, _) => Container(
-                                  color: colorScheme.surfaceContainerHighest,
-                                  child: Icon(Icons.music_note,
-                                    size: 48, color: colorScheme.onSurfaceVariant),
-                                ),
-                              )
-                            : Container(
-                                decoration: BoxDecoration(
-                                  color: colorScheme.surfaceContainerHighest,
-                                  borderRadius: BorderRadius.circular(16),
-                                ),
-                                child: Icon(Icons.music_note,
-                                  size: 48, color: colorScheme.onSurfaceVariant),
-                              ),
+                        ),
                       ),
                     ),
                   );
@@ -417,40 +423,46 @@ class _FullPlayerState extends State<FullPlayer>
                   ),
                   child: AspectRatio(
                     aspectRatio: 1,
-                    child: ClipRRect(
-                      borderRadius: BorderRadius.circular(16),
-                      child: currentSong.artworkUri != null
-                          ? CachedNetworkImage(
-                              imageUrl: currentSong.artworkUri!,
-                              fit: BoxFit.cover,
-                              placeholder: (_, _) => Container(
-                                color: colorScheme.surfaceContainerHighest,
+                    // 暂停缩放动画（与 AM 风格统一：播放 1.0 / 暂停 0.85 带回弹）
+                    child: AnimatedScale(
+                      scale: playerProvider.isPlaying ? 1.0 : 0.85,
+                      duration: const Duration(milliseconds: 500),
+                      curve: Curves.easeOutBack,
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(16),
+                        child: currentSong.artworkUri != null
+                            ? CachedNetworkImage(
+                                imageUrl: currentSong.artworkUri!,
+                                fit: BoxFit.cover,
+                                placeholder: (_, _) => Container(
+                                  color: colorScheme.surfaceContainerHighest,
+                                  child: Icon(
+                                    Icons.music_note,
+                                    size: iconSize,
+                                    color: colorScheme.onSurfaceVariant,
+                                  ),
+                                ),
+                                errorWidget: (_, _, _) => Container(
+                                  color: colorScheme.surfaceContainerHighest,
+                                  child: Icon(
+                                    Icons.music_note,
+                                    size: iconSize,
+                                    color: colorScheme.onSurfaceVariant,
+                                  ),
+                                ),
+                              )
+                            : Container(
+                                decoration: BoxDecoration(
+                                  color: colorScheme.surfaceContainerHighest,
+                                  borderRadius: BorderRadius.circular(16),
+                                ),
                                 child: Icon(
                                   Icons.music_note,
                                   size: iconSize,
                                   color: colorScheme.onSurfaceVariant,
                                 ),
                               ),
-                              errorWidget: (_, _, _) => Container(
-                                color: colorScheme.surfaceContainerHighest,
-                                child: Icon(
-                                  Icons.music_note,
-                                  size: iconSize,
-                                  color: colorScheme.onSurfaceVariant,
-                                ),
-                              ),
-                            )
-                          : Container(
-                              decoration: BoxDecoration(
-                                color: colorScheme.surfaceContainerHighest,
-                                borderRadius: BorderRadius.circular(16),
-                              ),
-                              child: Icon(
-                                Icons.music_note,
-                                size: iconSize,
-                                color: colorScheme.onSurfaceVariant,
-                              ),
-                            ),
+                      ),
                     ),
                   ),
                 );
@@ -461,40 +473,46 @@ class _FullPlayerState extends State<FullPlayer>
             Expanded(
               child: AspectRatio(
                 aspectRatio: 1,
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(16),
-                  child: currentSong.artworkUri != null
-                      ? CachedNetworkImage(
-                          imageUrl: currentSong.artworkUri!,
-                          fit: BoxFit.cover,
-                          placeholder: (_, _) => Container(
-                            color: colorScheme.surfaceContainerHighest,
+                // 暂停缩放动画（与 AM 风格统一：播放 1.0 / 暂停 0.85 带回弹）
+                child: AnimatedScale(
+                  scale: playerProvider.isPlaying ? 1.0 : 0.85,
+                  duration: const Duration(milliseconds: 500),
+                  curve: Curves.easeOutBack,
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(16),
+                    child: currentSong.artworkUri != null
+                        ? CachedNetworkImage(
+                            imageUrl: currentSong.artworkUri!,
+                            fit: BoxFit.cover,
+                            placeholder: (_, _) => Container(
+                              color: colorScheme.surfaceContainerHighest,
+                              child: Icon(
+                                Icons.music_note,
+                                size: iconSize,
+                                color: colorScheme.onSurfaceVariant,
+                              ),
+                            ),
+                            errorWidget: (_, _, _) => Container(
+                              color: colorScheme.surfaceContainerHighest,
+                              child: Icon(
+                                Icons.music_note,
+                                size: iconSize,
+                                color: colorScheme.onSurfaceVariant,
+                              ),
+                            ),
+                          )
+                        : Container(
+                            decoration: BoxDecoration(
+                              color: colorScheme.surfaceContainerHighest,
+                              borderRadius: BorderRadius.circular(16),
+                            ),
                             child: Icon(
                               Icons.music_note,
                               size: iconSize,
                               color: colorScheme.onSurfaceVariant,
                             ),
                           ),
-                          errorWidget: (_, _, _) => Container(
-                            color: colorScheme.surfaceContainerHighest,
-                            child: Icon(
-                              Icons.music_note,
-                              size: iconSize,
-                              color: colorScheme.onSurfaceVariant,
-                            ),
-                          ),
-                        )
-                      : Container(
-                          decoration: BoxDecoration(
-                            color: colorScheme.surfaceContainerHighest,
-                            borderRadius: BorderRadius.circular(16),
-                          ),
-                          child: Icon(
-                            Icons.music_note,
-                            size: iconSize,
-                            color: colorScheme.onSurfaceVariant,
-                          ),
-                        ),
+                  ),
                 ),
               ),
             ),

--- a/lib/modules/player/full_player_am.dart
+++ b/lib/modules/player/full_player_am.dart
@@ -1,0 +1,1679 @@
+import 'dart:ui';
+
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:provider/provider.dart';
+
+import '../../core/layout/responsive_layout.dart';
+import '../../providers/favorites_provider.dart';
+import '../../providers/kugou_provider.dart';
+import '../../providers/player_provider.dart';
+import '../../providers/downloads_provider.dart';
+import '../../services/kugou_api/kugou_api_client.dart';
+import '../../services/kugou_api/kugou_models.dart';
+import '../../widgets/apple_lyrics/animation/spring.dart';
+import '../../widgets/apple_lyrics/apple_lyrics_view.dart';
+import '../../widgets/apple_lyrics/layout/lyric_preferences_panel.dart';
+import '../../widgets/apple_lyrics/models/lyric_line.dart';
+import '../../widgets/apple_lyrics/parsers/lyric_parser_chain.dart';
+import 'comments_view.dart';
+
+const List<AudioQuality> _audioQualities = [
+  AudioQuality.standard,
+  AudioQuality.high,
+  AudioQuality.flac,
+];
+
+class AmStyleFullPlayer extends StatefulWidget {
+  const AmStyleFullPlayer({super.key});
+
+  @override
+  State<AmStyleFullPlayer> createState() => _AmStyleFullPlayerState();
+}
+
+class _AmStyleFullPlayerState extends State<AmStyleFullPlayer>
+    with TickerProviderStateMixin, WidgetsBindingObserver {
+  late TabController _tabController;
+  // Apple Music 风格歌词：已解析的 LyricLine 列表，由 LyricParserChain.parse 产出
+  List<LyricLine> _parsedLyrics = const [];
+  bool _isLoadingLyrics = false;
+  String? _lastSongId;
+  // 当前歌词格式（KRC / LRC / plaintext），用于底部标注；null 表示尚未检测
+  LyricFormat? _lyricFormat;
+
+  // === Task 19: 上滑展开 / 下拉收起手势 ===
+  // 当前是否处于展开（全屏）状态。默认 true，进入页面即全屏。
+  bool _isExpanded = true;
+  // 累计垂直拖动距离（px）。正值=下拉，负值=上拉。释放后归零。
+  double _dragDistance = 0;
+  // 弹簧驱动的展开进度：1.0=全屏，0.0=迷你条。
+  // 使用 Spring 类（Task 6 引擎），参数 mass=1, damping=20, stiffness=100（临界阻尼）。
+  late final Spring _expansionSpring = Spring(
+    mass: 1,
+    damping: 20,
+    stiffness: 100,
+    initialPosition: 1.0,
+  );
+  // 弹簧动画 ticker，仅在动画期间活跃。
+  late final Ticker _springTicker;
+  // 上次 tick 时间戳，用于计算真实 dt（避免帧率不同导致动画快慢不一致）。
+  Duration? _lastTickElapsed;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _tabController = TabController(length: 3, vsync: this);
+    // 创建弹簧驱动 ticker（muted 机制自动处理路由不可见时暂停）
+    _springTicker = createTicker(_onSpringTick);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final song = context.read<PlayerProvider>().currentSong;
+      if (song != null) {
+        _fetchLyrics(song);
+      }
+      context.read<PlayerProvider>().addListener(_onPlayerSongChanged);
+    });
+  }
+
+  void _onPlayerSongChanged() {
+    if (!mounted) return;
+    final song = context.read<PlayerProvider>().currentSong;
+    if (song != null && song.id != _lastSongId) {
+      _fetchLyrics(song);
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant AmStyleFullPlayer oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final song = context.read<PlayerProvider>().currentSong;
+    if (song != null && song.id != _lastSongId) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _fetchLyrics(song);
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    try {
+      context.read<PlayerProvider>().removeListener(_onPlayerSongChanged);
+    } catch (_) {}
+    WidgetsBinding.instance.removeObserver(this);
+    _springTicker.dispose();
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _fetchLyrics(dynamic song) async {
+    final songId = song.id as String;
+    if (songId == _lastSongId) return;
+    _lastSongId = songId;
+
+    setState(() {
+      _isLoadingLyrics = true;
+      _parsedLyrics = const [];
+      _lyricFormat = null;
+    });
+
+    try {
+      final kugouProvider = context.read<KugouProvider>();
+      await kugouProvider.getLyric(songId, songName: song.title);
+
+      if (mounted) {
+        // 优先取 KRC 明文（逐字），降级 LRC 明文（行级），最后降级 displayLyric
+        final lyric = kugouProvider.lyric;
+        final lyricText = lyric?.displayKrcLyric ??
+            lyric?.displayLrcLyric ??
+            lyric?.displayLyric ??
+            '';
+        setState(() {
+          _isLoadingLyrics = false;
+          // 解析器链自动检测格式（KRC/LRC/纯文本）并输出统一 List<LyricLine>
+          _parsedLyrics = LyricParserChain.parse(lyricText);
+          // 同步记录格式，用于底部标注
+          _lyricFormat = LyricParserChain.detectFormat(lyricText);
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _isLoadingLyrics = false;
+          _parsedLyrics = const [];
+          _lyricFormat = null;
+        });
+      }
+    }
+  }
+
+  // === Task 19: 弹簧驱动方法 ===
+
+  /// 启动弹簧动画（如 ticker 未运行则启动）。
+  void _startSpringAnimation() {
+    if (!_springTicker.isActive) {
+      _lastTickElapsed = null;
+      _springTicker.start();
+    }
+  }
+
+  /// Ticker 每帧回调：用真实 dt 推进 Spring，触发重绘，稳定后停止 ticker。
+  void _onSpringTick(Duration elapsed) {
+    final last = _lastTickElapsed ?? elapsed;
+    // 微秒转秒，做 sanity check（dt > 1s 通常表示首帧或卡顿，跳过避免数值发散）
+    final dt = (elapsed - last).inMicroseconds / 1e6;
+    _lastTickElapsed = elapsed;
+    if (dt > 0 && dt < 1.0) {
+      _expansionSpring.tick(dt);
+    }
+    setState(() {});
+    if (_expansionSpring.isSettled) {
+      _springTicker.stop();
+      _lastTickElapsed = null;
+    }
+  }
+
+  /// 收起为迷你条：直接 Navigator.pop 退出 FullPlayer 路由，让主页常驻的
+  /// MiniPlayer 接管显示。
+  ///
+  /// 之前用弹簧动画 + 内嵌 _buildMiniBar 的方案，会导致 FullPlayer 不出栈，
+  /// 主页 MiniPlayer 与 FullPlayer 内嵌迷你条同时显示（双重 mini player bug）。
+  /// 改为直接 pop：简单可靠，符合 Apple Music 下拉直接收起的行为。
+  void _collapse() {
+    if (!_isExpanded) return;
+    Navigator.of(context).maybePop();
+  }
+
+  /// 展开为全屏页：弹簧目标设为 1.0。
+  void _expand() {
+    if (_isExpanded) return;
+    _isExpanded = true;
+    _expansionSpring.setTarget(1.0);
+    _startSpringAnimation();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final playerProvider = context.watch<PlayerProvider>();
+    final currentSong = playerProvider.currentSong;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    if (currentSong == null) {
+      return Scaffold(
+        backgroundColor: colorScheme.surface,
+        appBar: AppBar(leading: const BackButton()),
+        body: const Center(child: Text('暂无播放')),
+      );
+    }
+
+    // Spring 驱动的展开进度：1.0=全屏，0.0=迷你条
+    final expansion = _expansionSpring.position.clamp(0.0, 1.0);
+    final fullOpacity = expansion;
+    final miniOpacity = 1.0 - expansion;
+
+    // 用 Stack 叠加全屏布局与迷你条布局，由弹簧进度驱动透明度交叉淡入淡出。
+    // IgnorePointer 防止隐藏层拦截手势。
+    // 外层用 Scaffold(backgroundColor: Colors.black) 包裹：
+    // 1. 提供稳定不透明背景，避免预测返回手势时透出底层路由
+    // 2. 与 _buildFullLayout 内部的 Scaffold(backgroundColor: Colors.black) 一致
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: Stack(
+        children: [
+          // 1. 全屏 Apple Music 风格布局
+          Opacity(
+            opacity: fullOpacity,
+            child: IgnorePointer(
+              ignoring: fullOpacity < 0.5,
+              child: _buildFullLayout(playerProvider, currentSong, colorScheme),
+            ),
+          ),
+          // 2. 迷你条布局（底部对齐，其余区域透明，让底层路由可见）
+          Opacity(
+            opacity: miniOpacity,
+            child: IgnorePointer(
+              ignoring: miniOpacity < 0.5,
+              child: Align(
+                alignment: Alignment.bottomCenter,
+                child: _buildMiniBar(playerProvider, currentSong, colorScheme),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 全屏 Apple Music 风格布局：模糊封面背景 + 蒙版 + 三套响应式布局。
+  /// 对应 spec.md "Requirement: 模糊封面背景"。
+  Widget _buildFullLayout(
+    PlayerProvider playerProvider,
+    dynamic currentSong,
+    ColorScheme colorScheme,
+  ) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: Stack(
+        children: [
+          // 1. 模糊封面背景层（Apple Music 风格）
+          _buildBlurredBackground(currentSong),
+          // 2. 半透明蒙版 rgba(0,0,0,0.35)
+          _buildDarkOverlay(),
+          // 3. 主体内容（保留原有 compact/landscape/expanded 三套布局）
+          ResponsiveLayout(
+            compact: (_) =>
+                _buildCompactLayout(playerProvider, currentSong, colorScheme),
+            medium: (_) =>
+                _buildLandscapeLayout(playerProvider, currentSong, colorScheme),
+            expanded: (_) =>
+                _buildExpandedLayout(playerProvider, currentSong, colorScheme),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// Apple Music 风格模糊封面背景层。
+  ///
+  /// 使用 [ImageFilter.blur]（sigmaX/Y=50）对封面做高斯模糊，
+  /// 封面放大填充屏幕并居中裁剪。封面不可用时降级纯黑背景。
+  /// 对应 spec.md "Requirement: 模糊封面背景"。
+  ///
+  /// **性能**：包一层 [RepaintBoundary]，让模糊背景作为独立 Layer 缓存，
+  /// 避免上层每帧 setState（歌词逐字动画）触发模糊重算（25fps 卡顿主因）。
+  /// RepaintBoundary 在子树不变时复用同一 Layer，Image.network 加载完成
+  /// 后模糊结果会被缓存，后续每帧只需合成已有 layer。
+  Widget _buildBlurredBackground(dynamic currentSong) {
+    final artworkUri = currentSong.artworkUri as String?;
+    if (artworkUri == null || artworkUri.isEmpty) {
+      return const Positioned.fill(child: ColoredBox(color: Colors.black));
+    }
+    return Positioned.fill(
+      child: RepaintBoundary(
+        child: ImageFiltered(
+          imageFilter: ImageFilter.blur(sigmaX: 50, sigmaY: 50),
+          child: Image.network(
+            artworkUri,
+            fit: BoxFit.cover,
+            errorBuilder: (_, __, ___) =>
+                const ColoredBox(color: Colors.black),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// 半透明蒙版层，叠加在模糊封面背景之上。
+  ///
+  /// 颜色 rgba(0,0,0,0.35) 对应 `Color(0x59000000)`
+  /// （0x59 = 89 ≈ 0.35 * 255）。
+  Widget _buildDarkOverlay() {
+    return const Positioned.fill(
+      child: ColoredBox(color: Color(0x59000000)),
+    );
+  }
+
+  /// 迷你条布局（Task 19）：封面缩略图 + 标题/艺术家 + 播放/暂停 + 下一首 + 顶部进度条。
+  /// 高度约 60px，底部对齐。上滑超过阈值或点击 → 展开为全屏页。
+  ///
+  /// 对应 spec.md "Requirement: 上滑展开 / 下拉收起" 的迷你状态视图。
+  Widget _buildMiniBar(
+    PlayerProvider playerProvider,
+    dynamic currentSong,
+    ColorScheme colorScheme,
+  ) {
+    final duration = playerProvider.duration ?? Duration.zero;
+    final position = playerProvider.position;
+    final progress = duration.inMilliseconds > 0
+        ? (position.inMilliseconds / duration.inMilliseconds).clamp(0.0, 1.0)
+        : 0.0;
+
+    return GestureDetector(
+      // 上滑展开 / 点击展开（与下拉收起对称的阈值：±100 px / ±100 px/s）
+      onVerticalDragUpdate: (details) {
+        _dragDistance += details.delta.dy;
+      },
+      onVerticalDragEnd: (details) {
+        final velocity = details.primaryVelocity ?? 0;
+        // 迷你状态：上拉速度 < -100 或上拉距离 < -100 → 展开
+        if (velocity < -100 || _dragDistance < -100) {
+          _expand();
+        }
+        _dragDistance = 0;
+      },
+      onTap: () => _expand(),
+      behavior: HitTestBehavior.opaque,
+      child: Container(
+        decoration: BoxDecoration(
+          color: colorScheme.surfaceContainerLow,
+          border: Border(
+            top: BorderSide(color: colorScheme.outlineVariant, width: 0.5),
+          ),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // 顶部进度条（与 mini_player.dart 样式一致）
+            LinearProgressIndicator(
+              value: progress,
+              minHeight: 2,
+              backgroundColor: colorScheme.surfaceContainerHighest,
+              color: colorScheme.primary,
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              child: Row(
+                children: [
+                  // 封面缩略图 44x44
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(6),
+                    child: SizedBox(
+                      width: 44,
+                      height: 44,
+                      child: currentSong.artworkUri != null
+                          ? CachedNetworkImage(
+                              imageUrl: currentSong.artworkUri!,
+                              fit: BoxFit.cover,
+                              placeholder: (_, _) => Container(
+                                color: colorScheme.surfaceContainerHighest,
+                                child: Icon(Icons.music_note,
+                                    size: 20,
+                                    color: colorScheme.onSurfaceVariant),
+                              ),
+                              errorWidget: (_, _, _) => Container(
+                                color: colorScheme.surfaceContainerHighest,
+                                child: Icon(Icons.music_note,
+                                    size: 20,
+                                    color: colorScheme.onSurfaceVariant),
+                              ),
+                            )
+                          : Container(
+                              color: colorScheme.surfaceContainerHighest,
+                              child: Icon(Icons.music_note,
+                                  size: 20,
+                                  color: colorScheme.onSurfaceVariant),
+                            ),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  // 标题 + 艺术家
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          currentSong.displayName,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                        Text(
+                          currentSong.artist,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context)
+                              .textTheme
+                              .bodySmall
+                              ?.copyWith(
+                                  color: colorScheme.onSurfaceVariant),
+                        ),
+                      ],
+                    ),
+                  ),
+                  // 播放/暂停按钮（迷你条状态下也要能控制播放）
+                  IconButton(
+                    icon: Icon(playerProvider.isPlaying
+                        ? Icons.pause
+                        : Icons.play_arrow),
+                    onPressed: () {
+                      if (playerProvider.isPlaying) {
+                        playerProvider.pause();
+                      } else {
+                        playerProvider.resume();
+                      }
+                    },
+                  ),
+                  // 下一首按钮
+                  IconButton(
+                    icon: const Icon(Icons.skip_next),
+                    onPressed: () => playerProvider.next(),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCompactLayout(
+    PlayerProvider playerProvider,
+    dynamic currentSong,
+    ColorScheme colorScheme,
+  ) {
+    return SafeArea(
+      child: Column(
+        children: [
+          _buildTopBar(),
+          Expanded(
+            child: TabBarView(
+              controller: _tabController,
+              children: [
+                GestureDetector(
+                  onTap: () => _tabController.animateTo(1),
+                  behavior: HitTestBehavior.opaque,
+                  child: _buildArtworkView(
+                    playerProvider,
+                    currentSong,
+                    colorScheme,
+                    isExpanded: true,
+                  ),
+                ),
+                GestureDetector(
+                  onTap: () => _tabController.animateTo(0),
+                  behavior: HitTestBehavior.translucent,
+                  child: _isLoadingLyrics
+                      ? const Center(child: CircularProgressIndicator())
+                      : AppleLyricsView(
+                          lines: _parsedLyrics,
+                          currentTimeMs: playerProvider.position.inMilliseconds,
+                          isPlaying: playerProvider.isPlaying,
+                          onSeek: (ms) =>
+                              playerProvider.seek(Duration(milliseconds: ms)),
+                        ),
+                ),
+                CommentsView(
+                  songHash: currentSong.id,
+                  albumAudioId: currentSong.albumAudioId,
+                  artworkUri: currentSong.artworkUri,
+                ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(bottom: 16),
+            child: _buildControls(playerProvider, colorScheme),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 手机横屏 / 小尺寸宽屏布局：左侧封面，右侧信息+歌词/评论+控制栏
+  Widget _buildLandscapeLayout(
+    PlayerProvider playerProvider,
+    dynamic currentSong,
+    ColorScheme colorScheme,
+  ) {
+    return SafeArea(
+      child: Row(
+        children: [
+          // ── 左侧：封面 ──
+          Expanded(
+            flex: 4,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  // 横屏时封面最大不超过可用宽度，保持正方形
+                  final size = constraints.maxWidth.clamp(120.0, 300.0);
+                  return Center(
+                    child: SizedBox(
+                    width: size,
+                    height: size,
+                    // 横屏封面缩放动画（与竖屏一致，暂停 0.85 / 播放 1.0 带回弹）
+                    child: AnimatedScale(
+                      scale: playerProvider.isPlaying ? 1.0 : 0.85,
+                      duration: const Duration(milliseconds: 500),
+                      curve: Curves.easeOutBack,
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(16),
+                        child: currentSong.artworkUri != null
+                            ? CachedNetworkImage(
+                                imageUrl: currentSong.artworkUri!,
+                                fit: BoxFit.cover,
+                                placeholder: (_, _) => Container(
+                                  color: Colors.white12,
+                                  child: Icon(Icons.music_note,
+                                    size: 48, color: Colors.white54),
+                                ),
+                                errorWidget: (_, _, _) => Container(
+                                  color: Colors.white12,
+                                  child: Icon(Icons.music_note,
+                                    size: 48, color: Colors.white54),
+                                ),
+                              )
+                            : Container(
+                                decoration: BoxDecoration(
+                                  color: Colors.white12,
+                                  borderRadius: BorderRadius.circular(16),
+                                ),
+                                child: Icon(Icons.music_note,
+                                    size: 48, color: Colors.white54),
+                              ),
+                      ),
+                    ),
+                  ),
+                  );
+                },
+              ),
+            ),
+          ),
+          // ── 右侧：Tab + 内容 + 控制 ──
+          Expanded(
+            flex: 6,
+            child: Column(
+              children: [
+                // 标签栏（封面/歌词/评论）
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  child: TabBar(
+                    controller: _tabController,
+                    tabs: const [Tab(text: '封面'), Tab(text: '歌词'), Tab(text: '评论')],
+                    labelStyle: Theme.of(context).textTheme.labelMedium,
+                    // 模糊深色背景下用白色文字与指示器（不读 MD3 主题色）
+                    labelColor: Colors.white,
+                    unselectedLabelColor: Colors.white70,
+                    indicatorColor: Colors.white,
+                    indicatorSize: TabBarIndicatorSize.label,
+                    isScrollable: false,
+                    tabAlignment: TabAlignment.center,
+                  ),
+                ),
+
+                // 内容区（歌曲信息 / 歌词 / 评论）
+                Expanded(
+                  child: TabBarView(
+                    controller: _tabController,
+                    children: [
+                      GestureDetector(
+                        onTap: () => _tabController.animateTo(1),
+                        behavior: HitTestBehavior.opaque,
+                        child: _buildSongInfo(playerProvider, currentSong, colorScheme),
+                      ),
+                      _isLoadingLyrics
+                          ? const Center(child: CircularProgressIndicator())
+                          : AppleLyricsView(
+                              lines: _parsedLyrics,
+                              currentTimeMs: playerProvider.position.inMilliseconds,
+                              isPlaying: playerProvider.isPlaying,
+                              onSeek: (ms) =>
+                                  playerProvider.seek(Duration(milliseconds: ms)),
+                            ),
+                      CommentsView(
+                        songHash: currentSong.id,
+                        albumAudioId: currentSong.albumAudioId,
+                        artworkUri: currentSong.artworkUri,
+                      ),
+                    ],
+                  ),
+                ),
+
+                // 控制区
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: _buildControls(playerProvider, colorScheme, isExpanded: true),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildExpandedLayout(
+    PlayerProvider playerProvider,
+    dynamic currentSong,
+    ColorScheme colorScheme,
+  ) {
+    return SafeArea(
+      child: Row(
+        children: [
+          Expanded(
+            flex: 4,
+            child: Center(
+              child: _buildArtworkView(
+                playerProvider,
+                currentSong,
+                colorScheme,
+                isExpanded: true,
+              ),
+            ),
+          ),
+          Expanded(
+            flex: 6,
+            child: Column(
+              children: [
+                _buildTopBar(),
+                Expanded(
+                  child: TabBarView(
+                    controller: _tabController,
+                    children: [
+                      _buildSongInfo(playerProvider, currentSong, colorScheme),
+                      _isLoadingLyrics
+                          ? const Center(child: CircularProgressIndicator())
+                          : AppleLyricsView(
+                              lines: _parsedLyrics,
+                              currentTimeMs: playerProvider.position.inMilliseconds,
+                              isPlaying: playerProvider.isPlaying,
+                              onSeek: (ms) =>
+                                  playerProvider.seek(Duration(milliseconds: ms)),
+                            ),
+                      CommentsView(
+                        songHash: currentSong.id,
+                        albumAudioId: currentSong.albumAudioId,
+                        artworkUri: currentSong.artworkUri,
+                      ),
+                    ],
+                  ),
+                ),
+                _buildControls(playerProvider, colorScheme, isExpanded: true),
+                const SizedBox(height: 8),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTopBar() {
+    // Apple Music 风格顶部栏：下拉手柄（Task 19 绑定垂直拖动手势）+ 导航行
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // 顶部居中下拉手柄：下拉速度 > 100 px/s 或累计下拉距离 > 100 px → 收起为迷你条
+        GestureDetector(
+          onVerticalDragUpdate: (details) {
+            _dragDistance += details.delta.dy;
+          },
+          onVerticalDragEnd: (details) {
+            final velocity = details.primaryVelocity ?? 0;
+            // 全屏状态：下拉速度 > 100 或下拉距离 > 100 → 收起
+            if (velocity > 100 || _dragDistance > 100) {
+              _collapse();
+            }
+            _dragDistance = 0;
+          },
+          behavior: HitTestBehavior.opaque,
+          child: Padding(
+            padding: const EdgeInsets.only(top: 12, bottom: 8),
+            child: Center(
+              child: Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: Colors.white54,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8),
+          child: Row(
+            children: [
+              IconButton(
+                icon: const Icon(Icons.keyboard_arrow_down, color: Colors.white),
+                // 点击下拉按钮 → 收起为迷你条（Task 19）
+                onPressed: _collapse,
+              ),
+              Expanded(
+                child: TabBar(
+                  controller: _tabController,
+                  tabs: const [
+                    Tab(text: '封面'),
+                    Tab(text: '歌词'),
+                    Tab(text: '评论'),
+                  ],
+                  labelStyle: Theme.of(context).textTheme.labelMedium,
+                  // 模糊深色背景下用白色文字与指示器
+                  labelColor: Colors.white,
+                  unselectedLabelColor: Colors.white70,
+                  indicatorColor: Colors.white,
+                  indicatorSize: TabBarIndicatorSize.label,
+                ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.more_vert, color: Colors.white),
+                onPressed: () => _showMoreMenu(context),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildArtworkView(
+    PlayerProvider playerProvider,
+    dynamic currentSong,
+    ColorScheme colorScheme, {
+    bool isExpanded = false,
+  }) {
+    final horizontalPadding = isExpanded ? 16.0 : 32.0;
+    final verticalPadding = isExpanded ? 8.0 : 16.0;
+    final textSpacing = isExpanded ? 8.0 : 24.0;
+    final iconSize = isExpanded ? 48.0 : 64.0;
+
+    return Padding(
+      padding: EdgeInsets.symmetric(
+        horizontal: horizontalPadding,
+        vertical: verticalPadding,
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          if (!isExpanded) const Spacer(),
+          if (isExpanded) ...[
+            const Spacer(),
+            LayoutBuilder(
+              builder: (context, constraints) {
+                final maxSize = (constraints.maxWidth - 32).clamp(0.0, 380.0);
+                return ConstrainedBox(
+                  constraints: BoxConstraints(
+                    maxWidth: maxSize,
+                    maxHeight: maxSize,
+                  ),
+                  child: AspectRatio(
+                    aspectRatio: 1,
+                    // 专辑封面缩放动画（grill-me 第三轮）：
+                    // 暂停时 scale=0.85，播放时 scale=1.0，带超出回弹效果。
+                    // 用 AnimatedScale + easeOutBack 曲线，overshoot 约 1.7，
+                    // 暂停→播放：1.0 ← 0.85（中间略超 1.05），营造"放大回弹"感
+                    // 播放→暂停：0.85 ← 1.0（中间略低 0.8），营造"缩小回弹"感
+                    child: AnimatedScale(
+                      scale: playerProvider.isPlaying ? 1.0 : 0.85,
+                      duration: const Duration(milliseconds: 500),
+                      curve: Curves.easeOutBack,
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(16),
+                        child: currentSong.artworkUri != null
+                            ? CachedNetworkImage(
+                                imageUrl: currentSong.artworkUri!,
+                                fit: BoxFit.cover,
+                                placeholder: (_, _) => Container(
+                                  color: Colors.white12,
+                                  child: Icon(
+                                    Icons.music_note,
+                                    size: iconSize,
+                                    color: Colors.white54,
+                                  ),
+                                ),
+                                errorWidget: (_, _, _) => Container(
+                                  color: Colors.white12,
+                                  child: Icon(
+                                    Icons.music_note,
+                                    size: iconSize,
+                                    color: Colors.white54,
+                                  ),
+                                ),
+                              )
+                            : Container(
+                                decoration: BoxDecoration(
+                                  color: Colors.white12,
+                                  borderRadius: BorderRadius.circular(16),
+                                ),
+                                child: Icon(
+                                  Icons.music_note,
+                                  size: iconSize,
+                                  color: Colors.white54,
+                                ),
+                              ),
+                      ),
+                    ),
+                  ),
+                );
+              },
+            ),
+            const Spacer(),
+          ] else
+            Expanded(
+              child: AspectRatio(
+                aspectRatio: 1,
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(16),
+                  child: currentSong.artworkUri != null
+                      ? CachedNetworkImage(
+                          imageUrl: currentSong.artworkUri!,
+                          fit: BoxFit.cover,
+                          placeholder: (_, _) => Container(
+                            color: Colors.white12,
+                            child: Icon(
+                              Icons.music_note,
+                              size: iconSize,
+                              color: Colors.white54,
+                            ),
+                          ),
+                          errorWidget: (_, _, _) => Container(
+                            color: Colors.white12,
+                            child: Icon(
+                              Icons.music_note,
+                              size: iconSize,
+                              color: Colors.white54,
+                            ),
+                          ),
+                        )
+                      : Container(
+                          decoration: BoxDecoration(
+                            color: Colors.white12,
+                            borderRadius: BorderRadius.circular(16),
+                          ),
+                          child: Icon(
+                            Icons.music_note,
+                            size: iconSize,
+                            color: Colors.white54,
+                          ),
+                        ),
+                ),
+              ),
+            ),
+          SizedBox(height: textSpacing),
+          Text(
+            currentSong.displayName,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: (isExpanded
+                    ? Theme.of(context).textTheme.titleMedium
+                    : Theme.of(context).textTheme.titleLarge)
+                ?.copyWith(color: Colors.white),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            currentSong.artist,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: Colors.white70,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          if (!isExpanded) const Spacer(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSongInfo(
+    PlayerProvider playerProvider,
+    dynamic currentSong,
+    ColorScheme colorScheme,
+  ) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              currentSong.displayName,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context)
+                  .textTheme
+                  .titleLarge
+                  ?.copyWith(color: Colors.white),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 4),
+            Text(
+              currentSong.artist,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                color: Colors.white70,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 2),
+            Text(
+              currentSong.album,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: Colors.white70,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildControls(
+    PlayerProvider playerProvider,
+    ColorScheme colorScheme, {
+    bool isExpanded = false,
+  }) {
+    final duration = playerProvider.duration ?? Duration.zero;
+    final position = playerProvider.position;
+    final horizontalPadding = isExpanded ? 16.0 : 24.0;
+    final verticalSpacing = isExpanded ? 4.0 : 8.0;
+
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _buildProgressBar(playerProvider, position, duration, colorScheme),
+          SizedBox(height: verticalSpacing),
+          _buildMainControls(
+            playerProvider,
+            colorScheme,
+            isExpanded: isExpanded,
+          ),
+          SizedBox(height: verticalSpacing),
+          _buildSecondaryControls(
+            playerProvider,
+            colorScheme,
+            isExpanded: isExpanded,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildProgressBar(
+    PlayerProvider playerProvider,
+    Duration position,
+    Duration duration,
+    ColorScheme colorScheme,
+  ) {
+    // Apple Music 风格：深色背景下进度条与时间标签用白色
+    return Row(
+      children: [
+        SizedBox(
+          width: 40,
+          child: Text(
+            _formatDuration(position),
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: Colors.white,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ),
+        Expanded(
+          child: Slider(
+            value: duration.inMilliseconds > 0
+                ? (position.inMilliseconds / duration.inMilliseconds).clamp(
+                    0.0,
+                    1.0,
+                  )
+                : 0.0,
+            activeColor: Colors.white,
+            inactiveColor: Colors.white24,
+            onChanged: (value) {
+              final newPosition = Duration(
+                milliseconds: (duration.inMilliseconds * value).round(),
+              );
+              playerProvider.seek(newPosition);
+              // AppleLyricsView 内部通过 currentTimeMs 参数自动跟随滚动，无需外部强制
+            },
+          ),
+        ),
+        SizedBox(
+          width: 40,
+          child: Text(
+            _formatDuration(duration),
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: Colors.white,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildMainControls(
+    PlayerProvider playerProvider,
+    ColorScheme colorScheme, {
+    bool isExpanded = false,
+  }) {
+    // Apple Music HIG 风格：大按钮居中，白色图标，圆形白色播放按钮
+    final spacing = isExpanded ? 4.0 : 8.0;
+    final skipIconSize = isExpanded ? 28.0 : 36.0;
+    final playIconSize = isExpanded ? 40.0 : 48.0;
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        IconButton(
+          icon: Icon(
+            playerProvider.shuffleEnabled
+                ? Icons.shuffle
+                : Icons.shuffle_outlined,
+            // 深色背景下：启用时纯白，未启用时半透明白
+            color: playerProvider.shuffleEnabled
+                ? Colors.white
+                : Colors.white70,
+          ),
+          onPressed: () => playerProvider.toggleShuffle(),
+        ),
+        SizedBox(width: spacing),
+        IconButton(
+          iconSize: skipIconSize,
+          icon: const Icon(Icons.skip_previous, color: Colors.white),
+          onPressed: () => playerProvider.previous(),
+        ),
+        SizedBox(width: spacing),
+        // Apple Music 标志性白色圆形播放按钮，黑色图标
+        IconButton.filled(
+          iconSize: playIconSize,
+          icon: Icon(playerProvider.isPlaying ? Icons.pause : Icons.play_arrow),
+          onPressed: () {
+            if (playerProvider.isPlaying) {
+              playerProvider.pause();
+            } else {
+              playerProvider.resume();
+            }
+          },
+          style: IconButton.styleFrom(
+            backgroundColor: Colors.white,
+            foregroundColor: Colors.black,
+          ),
+        ),
+        SizedBox(width: spacing),
+        IconButton(
+          iconSize: skipIconSize,
+          icon: const Icon(Icons.skip_next, color: Colors.white),
+          onPressed: () => playerProvider.next(),
+        ),
+        SizedBox(width: spacing),
+        IconButton(
+          icon: Icon(
+            _getLoopModeIcon(playerProvider.loopMode),
+            color: playerProvider.loopMode != AppLoopMode.off
+                ? Colors.white
+                : Colors.white70,
+          ),
+          onPressed: () => playerProvider.toggleLoopMode(),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSecondaryControls(
+    PlayerProvider playerProvider,
+    ColorScheme colorScheme, {
+    bool isExpanded = false,
+  }) {
+    final song = playerProvider.currentSong;
+    final isFavorited =
+        song != null && context.watch<FavoritesProvider>().isFavorite(song.id);
+    // Apple Music 风格：深色背景下副控制栏用白色图标与文字
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Row(
+          children: [
+            IconButton(
+              icon: Icon(
+                isFavorited ? Icons.favorite : Icons.favorite_border,
+                color: isFavorited ? Colors.redAccent : Colors.white,
+              ),
+              onPressed: song != null
+                  ? () => context.read<FavoritesProvider>().toggleFavorite(song)
+                  : null,
+            ),
+            IconButton(
+              icon: const Icon(Icons.download, color: Colors.white),
+              onPressed: song != null ? () => _downloadSong(song) : null,
+            ),
+            IconButton(
+              icon: const Icon(Icons.volume_up, color: Colors.white),
+              onPressed: () => _showVolumeDialog(playerProvider),
+            ),
+          ],
+        ),
+        Expanded(
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              TextButton(
+                onPressed: () => _showSpeedDialog(playerProvider),
+                child: Text(
+                  '${playerProvider.speed}x',
+                  style: TextStyle(
+                    fontSize: isExpanded ? 12 : 14,
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              TextButton(
+                onPressed: () => _showQualityDialog(playerProvider),
+                child: Text(
+                  playerProvider.audioQualityLabel,
+                  style: TextStyle(
+                    fontSize: isExpanded ? 12 : 14,
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        IconButton(
+          icon: const Icon(Icons.playlist_play, color: Colors.white),
+          onPressed: () => _showPlaylist(playerProvider),
+        ),
+      ],
+    );
+  }
+
+  void _showVolumeDialog(PlayerProvider playerProvider) {
+    showDialog(
+      context: context,
+      builder: (context) {
+        return Dialog(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(28),
+          ),
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 280),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 20),
+              child: StatefulBuilder(
+                builder: (context, setState) {
+                  final volume = playerProvider.volume;
+                  final percent = (volume * 100).round();
+                  final icon = volume <= 0
+                      ? Icons.volume_off
+                      : volume < 0.5
+                      ? Icons.volume_down
+                      : Icons.volume_up;
+                  return Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        icon,
+                        size: 32,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                      const SizedBox(height: 8),
+                      Slider(
+                        value: volume,
+                        onChanged: (value) {
+                          playerProvider.setVolume(value);
+                          setState(() {});
+                        },
+                      ),
+                      Text(
+                        '$percent%',
+                        style: Theme.of(context).textTheme.labelMedium,
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  void _showSpeedDialog(PlayerProvider playerProvider) {
+    final speeds = [0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0, 3.0, 4.0];
+    showDialog(
+      context: context,
+      builder: (context) {
+        return SimpleDialog(
+          title: const Center(child: Text('播放速度')),
+          children: speeds.map((speed) {
+            return SimpleDialogOption(
+              onPressed: () {
+                playerProvider.setSpeed(speed);
+                Navigator.pop(context);
+              },
+              child: Text(
+                speed == 1.0 ? '1.0x (正常)' : '${speed}x',
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: playerProvider.speed == speed
+                      ? Theme.of(context).colorScheme.primary
+                      : null,
+                ),
+              ),
+            );
+          }).toList(),
+        );
+      },
+    );
+  }
+
+  void _showQualityDialog(PlayerProvider playerProvider) {
+    showDialog(
+      context: context,
+      builder: (context) {
+        return SimpleDialog(
+          title: const Center(child: Text('音质选择')),
+          children: _audioQualities.map((quality) {
+            return SimpleDialogOption(
+              onPressed: () {
+                playerProvider.setAudioQuality(quality);
+                Navigator.pop(context);
+              },
+              child: Text(
+                quality.label,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: playerProvider.audioQuality == quality
+                      ? Theme.of(context).colorScheme.primary
+                      : null,
+                  fontWeight: playerProvider.audioQuality == quality
+                      ? FontWeight.bold
+                      : null,
+                ),
+              ),
+            );
+          }).toList(),
+        );
+      },
+    );
+  }
+
+  IconData _getLoopModeIcon(AppLoopMode mode) {
+    switch (mode) {
+      case AppLoopMode.off:
+        // 不循环：空心箭头
+        return Icons.repeat_outlined;
+      case AppLoopMode.one:
+        // 单曲循环：带数字1
+        return Icons.repeat_one;
+      case AppLoopMode.all:
+        // 列表循环：实心箭头，播完回到第一首
+        return Icons.repeat;
+    }
+  }
+
+  String _formatDuration(Duration duration) {
+    final minutes = duration.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final seconds = duration.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return '$minutes:$seconds';
+  }
+
+  void _downloadSong(dynamic song) {
+    final downloadsProvider = context.read<DownloadsProvider>();
+    final isDownloaded = downloadsProvider.isDownloaded(song.id);
+    final isDownloading = downloadsProvider.isDownloading(song.id);
+
+    if (isDownloaded) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('已下载: ${song.title}'),
+          duration: const Duration(seconds: 2),
+        ),
+      );
+      return;
+    }
+
+    if (isDownloading) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('正在下载: ${song.title}'),
+          duration: const Duration(seconds: 2),
+        ),
+      );
+      return;
+    }
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('开始下载: ${song.title}'),
+        duration: const Duration(seconds: 2),
+      ),
+    );
+    // 触发下载
+    downloadsProvider.downloadSong(song);
+  }
+
+  void _showMoreMenu(BuildContext context) {
+    final song = context.read<PlayerProvider>().currentSong;
+    if (song == null) return;
+
+    showModalBottomSheet(
+      context: context,
+      builder: (context) {
+        // 歌词类型标签：KRC / LRC / 静态 / 未加载
+        final lyricTypeLabel = switch (_lyricFormat) {
+          LyricFormat.krc => 'KRC 逐字歌词',
+          LyricFormat.lrc => 'LRC 行级歌词',
+          LyricFormat.plaintext => '静态歌词',
+          null => _isLoadingLyrics ? '歌词加载中' : '未加载',
+        };
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // 歌词类型展示（只读，trailing 显示类型，点击无操作）
+              ListTile(
+                leading: const Icon(Icons.label_outline),
+                title: const Text('歌词类型'),
+                trailing: Text(
+                  lyricTypeLabel,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+                ),
+              ),
+              ListTile(
+                leading: const Icon(Icons.lyrics),
+                title: const Text('歌词显示设置'),
+                onTap: () {
+                  Navigator.pop(context);
+                  _showLyricPreferencesSheet(context);
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.playlist_add),
+                title: const Text('添加到歌单'),
+                onTap: () {
+                  Navigator.pop(context);
+                  _showAddToPlaylistDialog(context, song);
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.share),
+                title: const Text('分享'),
+                onTap: () {
+                  Navigator.pop(context);
+                  // TODO: 实现分享功能
+                  ScaffoldMessenger.of(
+                    context,
+                  ).showSnackBar(const SnackBar(content: Text('分享功能开发中')));
+                },
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  /// 弹出歌词字号/行间距调节面板（从播放页右上角菜单进入）。
+  void _showLyricPreferencesSheet(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) => SafeArea(
+        child: const LyricPreferencesPanel(),
+      ),
+    );
+  }
+
+  void _showAddToPlaylistDialog(BuildContext context, dynamic song) async {
+    final api = KugouApiClient();
+    if (!api.isLoggedIn) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('请先登录'),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+      return;
+    }
+
+    showDialog(
+      context: context,
+      builder: (dialogContext) {
+        return FutureBuilder<Map<String, dynamic>?>(
+          future: api.getUserPlaylist(pagesize: 50),
+          builder: (context, snapshot) {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return const AlertDialog(
+                content: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    CircularProgressIndicator(),
+                    SizedBox(height: 16),
+                    Text('加载歌单中...'),
+                  ],
+                ),
+              );
+            }
+
+            if (snapshot.hasError || snapshot.data == null) {
+              return AlertDialog(
+                title: const Text('错误'),
+                content: const Text('获取歌单失败'),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.pop(dialogContext),
+                    child: const Text('关闭'),
+                  ),
+                ],
+              );
+            }
+
+            final data = snapshot.data!['data'];
+            List<dynamic> rawPlaylists = [];
+            if (data is List) {
+              rawPlaylists = data;
+            } else if (data is Map) {
+              rawPlaylists =
+                  data['info'] ?? data['list'] ?? data['special_list'] ?? [];
+            }
+
+            // 使用 KugouPlaylistBrief 模型解析，确保字段名映射正确
+            // 只显示用户自己创建的歌单 (type=0)
+            final playlists = <Map<String, dynamic>>[];
+            for (final item in rawPlaylists) {
+              final json = item as Map<String, dynamic>;
+              final brief = KugouPlaylistBrief.fromJson(json);
+              if (brief.type != 0) continue;
+              // 将模型数据转回 Map 以便 UI 使用（包含正确的字段值）
+              playlists.add({
+                'name': brief.name,
+                'songCount': brief.songCount,
+                'listid': brief.listId.isEmpty ? brief.id : brief.listId,
+                'specialid': brief.id,
+                'global_collection_id': brief.globalCollectionId,
+                'type': brief.type,
+                // 保留原始 JSON 用于 API 调用
+                ...json,
+              });
+            }
+
+            if (playlists.isEmpty) {
+              return AlertDialog(
+                title: const Text('我的歌单'),
+                content: const Text('暂无歌单，请先创建歌单'),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.pop(dialogContext),
+                    child: const Text('关闭'),
+                  ),
+                ],
+              );
+            }
+
+            return AlertDialog(
+              title: const Text('添加到歌单'),
+              content: SizedBox(
+                width: 300,
+                height: 400,
+                child: ListView.builder(
+                  itemCount: playlists.length,
+                  itemBuilder: (context, index) {
+                    final playlist = playlists[index];
+                    final name =
+                        (playlist['name'] ?? playlist['specialname'] ?? '未知歌单')
+                            .toString();
+                    // 优先使用模型解析后的 songCount，再尝试原始字段
+                    final songCount =
+                        playlist['songCount'] ??
+                        playlist['songcount'] ??
+                        playlist['song_count'] ??
+                        playlist['count'] ??
+                        0;
+
+                    return ListTile(
+                      leading: const Icon(Icons.queue_music),
+                      title: Text(name),
+                      subtitle: Text('$songCount 首'),
+                      onTap: () async {
+                        Navigator.pop(dialogContext);
+                        await _addSongToPlaylist(context, song, playlist);
+                      },
+                    );
+                  },
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(dialogContext),
+                  child: const Text('取消'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Future<void> _addSongToPlaylist(
+    BuildContext context,
+    dynamic song,
+    Map<String, dynamic> playlist,
+  ) async {
+    final api = KugouApiClient();
+    final listid =
+        playlist['listid']?.toString() ?? playlist['list_id']?.toString() ?? '';
+
+    if (listid.isEmpty) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('歌单ID无效'),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+      return;
+    }
+
+    // 乐观更新：立即显示成功，后台同步到酷狗服务器
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('已添加到「${playlist['name']}」'),
+        behavior: SnackBarBehavior.floating,
+        duration: const Duration(seconds: 2),
+      ),
+    );
+
+    // 构造歌曲数据 — 酷狗API要求的格式：歌名|hash|albumId|albumAudioId
+    final songData =
+        '${song.title}|${song.id}|${song.albumId ?? 0}|${int.tryParse(song.albumAudioId ?? '') ?? 0}';
+
+    // 后台同步，不阻塞 UI
+    api
+        .addPlaylistTracks(listid, songData)
+        .then((result) {
+          // 同步失败时提示用户（静默失败，不影响已显示的乐观更新）
+          if (result == null) {
+            if (context.mounted) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: const Text('同步到服务器失败，将在下次启动时重试'),
+                  behavior: SnackBarBehavior.floating,
+                  duration: const Duration(seconds: 3),
+                ),
+              );
+            }
+          }
+        })
+        .catchError((_) {
+          // 网络错误等，同样静默处理
+        });
+  }
+
+  void _showPlaylist(PlayerProvider playerProvider) {
+    showDialog(
+      context: context,
+      builder: (dialogContext) {
+        final playlist = playerProvider.playlist;
+        return AlertDialog(
+          title: const Center(child: Text('播放列表')),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              playlist.isEmpty
+                  ? const Text('播放列表为空')
+                  : SizedBox(
+                      width: 300,
+                      height: 400,
+                      child: ListView.builder(
+                        itemCount: playlist.length,
+                        itemBuilder: (context, index) {
+                          final song = playlist[index];
+                          final isCurrent =
+                              index == playerProvider.currentIndex;
+                          return ListTile(
+                            leading: isCurrent
+                                ? const Icon(
+                                    Icons.play_arrow,
+                                    color: Colors.blue,
+                                  )
+                                : Text('${index + 1}'),
+                            title: Text(
+                              song.displayName,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: TextStyle(
+                                fontWeight: isCurrent ? FontWeight.bold : null,
+                                color: isCurrent ? Colors.blue : null,
+                              ),
+                            ),
+                            subtitle: Text(
+                              song.artist,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                            onTap: () {
+                              playerProvider.playSongAt(index);
+                              Navigator.pop(dialogContext);
+                            },
+                          );
+                        },
+                      ),
+                    ),
+              Padding(
+                padding: const EdgeInsets.only(top: 12),
+                child: SizedBox(
+                  width: 300,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      TextButton(
+                        onPressed: playlist.isEmpty
+                            ? null
+                            : () {
+                                playerProvider.clearPlaylist();
+                                Navigator.pop(dialogContext);
+                              },
+                        child: const Text('清空'),
+                      ),
+                      TextButton(
+                        onPressed: () => Navigator.pop(dialogContext),
+                        child: const Text('关闭'),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/modules/player/full_player_route.dart
+++ b/lib/modules/player/full_player_route.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../providers/theme_provider.dart';
+import 'full_player.dart';
+import 'full_player_am.dart';
+
+/// 全局标志：当前 FullPlayer 是否在路由栈顶。
+///
+/// 由 [BottomSlideMaterialPageRoute] 构造时设 true、dispose 时设 false，
+/// [_UpFadeMainRoute] 监听此值决定是否对 _MainLayout 应用「向上淡出」过渡。
+/// 仅对 FullPlayer 生效，其他路由（/search /settings /playlist）push 时
+/// _MainLayout 走默认过渡。
+final ValueNotifier<bool> isFullPlayerOnTop = ValueNotifier<bool>(false);
+
+/// 从底部滑入的 [MaterialPageRoute] 子类。
+///
+/// 用于 FullPlayer 路由，支持预测性返回手势（Android 14+）：
+///
+/// **关键设计**：
+/// 1. 继承 [MaterialPageRoute] → 保留与系统预测返回手势的对接
+///    （系统知道如何驱动 animation 反向播放实现预测动画）
+/// 2. 重写 [buildTransitions] → 用框架传入的 `animation` 驱动 [SlideTransition]
+///    - push 时：animation 0→1，页面从 Offset(0,1) 滑到 Offset.zero（从底部滑入）
+///    - 预测返回时：系统驱动 animation 1→0 反向播放，页面自然向下平移
+/// 3. 不使用自定义 AnimationController，完全依赖框架的 animation
+///
+/// **与 [PageRouteBuilder] + transitionsBuilder 的区别**：
+/// PageRouteBuilder 没有继承 _MaterialRouteTransitionMixin，缺少与系统手势的对接，
+/// 自定义 transition 会禁用预测返回。本类继承 MaterialPageRoute 保留对接。
+///
+/// **作用域**：
+/// 只作用于 FullPlayer 路由，不影响其他 MaterialPageRoute（如 /search /settings）。
+class BottomSlideMaterialPageRoute<T> extends MaterialPageRoute<T> {
+  BottomSlideMaterialPageRoute({required super.builder}) {
+    // push 时立即标记，_UpFadeMainRoute 据此应用 up-fade
+    isFullPlayerOnTop.value = true;
+  }
+
+  @override
+  void dispose() {
+    // pop 后清除标记
+    isFullPlayerOnTop.value = false;
+    super.dispose();
+  }
+
+  @override
+  Widget buildTransitions(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    // 用 animation 驱动垂直偏移：
+    // - 正向（push）：Offset(0, 1) → Offset.zero，从底部滑入
+    // - 反向（pop / 预测返回）：Offset.zero → Offset(0, 1)，向下平移
+    //
+    // reverseCurve 用 easeInCubic 让收起时加速，符合「下拉收起」的物理感
+    final position = Tween<Offset>(
+      begin: const Offset(0, 1),
+      end: Offset.zero,
+    ).animate(
+      CurvedAnimation(
+        parent: animation,
+        curve: Curves.easeOutCubic,
+        reverseCurve: Curves.easeInCubic,
+      ),
+    );
+    return SlideTransition(position: position, child: child);
+  }
+}
+
+/// 根据 [ThemeProvider.useAmStylePlayer] 开关选择 FullPlayer 实现：
+/// - false（默认）：原版 MD3 风格 [FullPlayer]
+/// - true：Apple Music 风格 [AmStyleFullPlayer]
+///
+/// 切换开关后，已 push 的路由不会自动换 widget，下次 push 时才走新分支
+/// （符合「设置项」预期，实现简单可靠）。
+///
+/// 两个版本都用 [BottomSlideMaterialPageRoute]，统一从底部滑入 + 支持预测返回手势。
+BottomSlideMaterialPageRoute<void> fullPlayerRoute(BuildContext context) {
+  final useAm = context.read<ThemeProvider>().useAmStylePlayer;
+  return BottomSlideMaterialPageRoute(
+    builder: (_) => useAm ? const AmStyleFullPlayer() : const FullPlayer(),
+  );
+}

--- a/lib/modules/player/mini_player.dart
+++ b/lib/modules/player/mini_player.dart
@@ -5,7 +5,7 @@ import 'package:provider/provider.dart';
 import '../../core/services/desktop_lyric_service.dart';
 import '../../core/services/media_notification_service.dart';
 import '../../providers/player_provider.dart';
-import 'full_player.dart';
+import 'full_player_route.dart';
 
 class MiniPlayer extends StatelessWidget {
   const MiniPlayer({super.key});
@@ -26,162 +26,159 @@ class MiniPlayer extends StatelessWidget {
 
     return GestureDetector(
       onTap: () {
-        Navigator.of(context).push(
-          PageRouteBuilder(
-            opaque: false,
-            pageBuilder: (_, _, _) => const FullPlayer(),
-            transitionsBuilder: (_, animation, _, child) {
-              return SlideTransition(
-                position:
-                    Tween<Offset>(
-                      begin: const Offset(0, 1),
-                      end: Offset.zero,
-                    ).animate(
-                      CurvedAnimation(
-                        parent: animation,
-                        curve: Curves.easeOutCubic,
-                      ),
-                    ),
-                child: child,
-              );
-            },
-          ),
-        );
+        // 使用 BottomSlideMaterialPageRoute（MaterialPageRoute 子类）：
+        // - 继承 MaterialPageRoute 保留与系统预测返回手势的对接
+        // - 重写 buildTransitions 用 animation 驱动 SlideTransition
+        //   push 时从底部滑入，预测返回时系统驱动 animation 反向播放，
+        //   页面自然跟随手势向下平移（而非默认的整页缩小）
+        // fullPlayerRoute 根据 ThemeProvider.useAmStylePlayer 开关
+        // 选择 AM 风格或原版 MD3 风格 FullPlayer widget
+        Navigator.of(context).push(fullPlayerRoute(context));
       },
       child: Container(
+        // Container 在外提供整体背景色与顶部 border：
+        // 颜色会自然填充 SafeArea 在底部留出的系统手势条区域，
+        // 避免手势条区域露出 Scaffold 背景色与主体形成颜色断层
         decoration: BoxDecoration(
           color: colorScheme.surfaceContainerLow,
           border: Border(
             top: BorderSide(color: colorScheme.outlineVariant, width: 0.5),
           ),
         ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            LinearProgressIndicator(
-              value: progress.clamp(0.0, 1.0),
-              minHeight: 2,
-              backgroundColor: colorScheme.surfaceContainerHighest,
-              color: colorScheme.primary,
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-              child: Row(
-                children: [
-                  ClipRRect(
-                    borderRadius: BorderRadius.circular(6),
-                    child: SizedBox(
-                      width: 44,
-                      height: 44,
-                      child: currentSong.artworkUri != null
-                          ? CachedNetworkImage(
-                              imageUrl: currentSong.artworkUri!,
-                              fit: BoxFit.cover,
-                              placeholder: (_, _) => Container(
-                                color: colorScheme.surfaceContainerHighest,
-                                child: Icon(
-                                  Icons.music_note,
-                                  size: 20,
-                                  color: colorScheme.onSurfaceVariant,
-                                ),
-                              ),
-                              errorWidget: (_, _, _) => Container(
-                                color: colorScheme.surfaceContainerHighest,
-                                child: Icon(
-                                  Icons.music_note,
-                                  size: 20,
-                                  color: colorScheme.onSurfaceVariant,
-                                ),
-                              ),
-                            )
-                          : Container(
-                              color: colorScheme.surfaceContainerHighest,
-                              child: Icon(
-                                Icons.music_note,
-                                size: 20,
-                                color: colorScheme.onSurfaceVariant,
-                              ),
-                            ),
-                    ),
-                  ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text(
-                          currentSong.title,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: Theme.of(context).textTheme.bodyMedium,
-                        ),
-                        Text(
-                          currentSong.artist,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: Theme.of(context).textTheme.bodySmall
-                              ?.copyWith(color: colorScheme.onSurfaceVariant),
-                        ),
-                      ],
-                    ),
-                  ),
-                  IconButton(
-                    icon: Icon(
-                      playerProvider.isPlaying ? Icons.pause : Icons.play_arrow,
-                    ),
-                    onPressed: () {
-                      if (playerProvider.isPlaying) {
-                        playerProvider.pause();
-                      } else {
-                        playerProvider.resume();
-                      }
-                    },
-                  ),
-                  IconButton(
-                    tooltip: DesktopLyricService.instance.enabled
-                        ? '关闭桌面歌词'
-                        : '开启桌面歌词',
-                    icon: Icon(
-                      DesktopLyricService.instance.enabled
-                          ? Icons.lyrics
-                          : Icons.lyrics_outlined,
-                      color: DesktopLyricService.instance.enabled
-                          ? colorScheme.primary
-                          : null,
-                    ),
-                    onPressed: () async {
-                      await DesktopLyricService.instance.toggle();
-                      if (context.mounted) {
-                        (context as Element).markNeedsBuild();
-                        // 同步通知栏"桌面歌词"按钮状态
-                        final player = context.read<PlayerProvider>();
-                        final song = player.currentSong;
-                        await MediaNotificationService.updateNotification(
-                          title: song?.title ?? '',
-                          artist: song?.artist ?? '',
-                          artUrl: song?.artworkUri,
-                          isPlaying: player.isPlaying,
-                          position: player.position,
-                          duration: player.duration ?? Duration.zero,
-                          desktopLyricEnabled:
-                              DesktopLyricService.instance.enabled,
-                        );
-                      }
-                    },
-                  ),
-                  IconButton(
-                    icon: const Icon(Icons.skip_next),
-                    onPressed: () {
-                      playerProvider.next();
-                    },
-                  ),
-                ],
+        child: SafeArea(
+          // 仅吸收底部系统手势条/Home Indicator 高度
+          top: false,
+          bottom: true,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              LinearProgressIndicator(
+                value: progress.clamp(0.0, 1.0),
+                minHeight: 2,
+                backgroundColor: colorScheme.surfaceContainerHighest,
+                color: colorScheme.primary,
               ),
-            ),
-          ],
-        ),
-      ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                child: Row(
+                  children: [
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(6),
+                      child: SizedBox(
+                        width: 44,
+                        height: 44,
+                        child: currentSong.artworkUri != null
+                            ? CachedNetworkImage(
+                                imageUrl: currentSong.artworkUri!,
+                                fit: BoxFit.cover,
+                                placeholder: (_, _) => Container(
+                                  color: colorScheme.surfaceContainerHighest,
+                                  child: Icon(
+                                    Icons.music_note,
+                                    size: 20,
+                                    color: colorScheme.onSurfaceVariant,
+                                  ),
+                                ),
+                                errorWidget: (_, _, _) => Container(
+                                  color: colorScheme.surfaceContainerHighest,
+                                  child: Icon(
+                                    Icons.music_note,
+                                    size: 20,
+                                    color: colorScheme.onSurfaceVariant,
+                                  ),
+                                ),
+                              )
+                            : Container(
+                                color: colorScheme.surfaceContainerHighest,
+                                child: Icon(
+                                  Icons.music_note,
+                                  size: 20,
+                                  color: colorScheme.onSurfaceVariant,
+                                ),
+                              ),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(
+                            currentSong.displayName,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: Theme.of(context).textTheme.bodyMedium,
+                          ),
+                          Text(
+                            currentSong.artist,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: Theme.of(context).textTheme.bodySmall
+                                ?.copyWith(color: colorScheme.onSurfaceVariant),
+                          ),
+                        ],
+                      ),
+                    ),
+                    IconButton(
+                      icon: Icon(
+                        playerProvider.isPlaying
+                            ? Icons.pause
+                            : Icons.play_arrow,
+                      ),
+                      onPressed: () {
+                        if (playerProvider.isPlaying) {
+                          playerProvider.pause();
+                        } else {
+                          playerProvider.resume();
+                        }
+                      },
+                    ),
+                    IconButton(
+                      tooltip: DesktopLyricService.instance.enabled
+                          ? '关闭桌面歌词'
+                          : '开启桌面歌词',
+                      icon: Icon(
+                        DesktopLyricService.instance.enabled
+                            ? Icons.lyrics
+                            : Icons.lyrics_outlined,
+                        color: DesktopLyricService.instance.enabled
+                            ? colorScheme.primary
+                            : null,
+                      ),
+                      onPressed: () async {
+                        await DesktopLyricService.instance.toggle();
+                        if (context.mounted) {
+                          (context as Element).markNeedsBuild();
+                          // 同步通知栏"桌面歌词"按钮状态
+                          final player = context.read<PlayerProvider>();
+                          final song = player.currentSong;
+                          await MediaNotificationService.updateNotification(
+                            title: song?.title ?? '',
+                            artist: song?.artist ?? '',
+                            artUrl: song?.artworkUri,
+                            isPlaying: player.isPlaying,
+                            position: player.position,
+                            duration: player.duration ?? Duration.zero,
+                            desktopLyricEnabled:
+                                DesktopLyricService.instance.enabled,
+                          );
+                        }
+                      },
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.skip_next),
+                      onPressed: () {
+                        playerProvider.next();
+                      },
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ), // SafeArea
+      ), // Container
     );
   }
 }

--- a/lib/modules/playlist/playlist_page.dart
+++ b/lib/modules/playlist/playlist_page.dart
@@ -35,9 +35,21 @@ class _PlaylistPageState extends State<PlaylistPage> {
   bool _isCollected = false;
   String? _collectedListId;
 
+  /// 顶栏渐变 ScrollController：监听 CustomScrollView 滚动 offset，
+  /// 用于 SliverAppBar pinned 后 fade-in 显示歌单名称
+  final ScrollController _scrollController = ScrollController();
+  double _scrollOffset = 0;
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
   @override
   void initState() {
     super.initState();
+    _scrollController.addListener(_onScroll);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       // 只有普通歌单才需要查收藏状态。「我收藏」里进来的歌单跳过。
       if (!widget.isInMyFavorites) {
@@ -45,6 +57,15 @@ class _PlaylistPageState extends State<PlaylistPage> {
       }
       _fetchSongs();
     });
+  }
+
+  /// 滚动监听：更新 _scrollOffset 触发重绘，驱动顶栏 fade-in 歌单名称
+  void _onScroll() {
+    if (!mounted) return;
+    final offset = _scrollController.offset;
+    if ((offset - _scrollOffset).abs() > 0.5) {
+      setState(() => _scrollOffset = offset);
+    }
   }
 
   // ==================== 收藏本地缓存（解决后端 user/playlist 列表 ~1-2 分钟缓存才同步的问题）====================
@@ -366,10 +387,34 @@ class _PlaylistPageState extends State<PlaylistPage> {
               children: [
                 Expanded(
                   child: CustomScrollView(
+                    controller: _scrollController,
                     slivers: [
                       SliverAppBar(
                         expandedHeight: 280,
                         pinned: true,
+                        // pinned 后顶栏背景色：滚动到 expandedHeight - kToolbarHeight
+                        // 之后从透明渐变到 surface
+                        backgroundColor: Color.lerp(
+                          Colors.transparent,
+                          colorScheme.surface,
+                          (_scrollOffset - (280 - kToolbarHeight))
+                              .clamp(0.0, 60.0) / 60,
+                        )!,
+                        surfaceTintColor: Colors.transparent,
+                        scrolledUnderElevation: 0,
+                        // pinned 后顶栏标题：滚动超过阈值后 fade-in 显示歌单名称
+                        title: Opacity(
+                          opacity: ((_scrollOffset - (280 - kToolbarHeight)) /
+                                  60.0)
+                              .clamp(0.0, 1.0),
+                          child: Text(
+                            displayPlaylist.name,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: textTheme.titleLarge
+                                ?.copyWith(fontWeight: FontWeight.w600),
+                          ),
+                        ),
                         flexibleSpace: FlexibleSpaceBar(
                           background: Container(
                             decoration: BoxDecoration(
@@ -448,7 +493,7 @@ class _PlaylistPageState extends State<PlaylistPage> {
                                         children: [
                                           Text(
                                             displayPlaylist.name,
-                                            maxLines: 2,
+                                            maxLines: 4,
                                             overflow: TextOverflow.ellipsis,
                                             style: textTheme.headlineSmall
                                                 ?.copyWith(

--- a/lib/modules/settings/settings_page.dart
+++ b/lib/modules/settings/settings_page.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:http/http.dart' as http;
@@ -10,16 +9,14 @@ import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../../core/services/lyricon_provider_service.dart';
+import '../../core/theme/app_theme.dart';
 import '../../data/repositories/settings_repository.dart';
 import '../../providers/kugou_provider.dart';
 import '../../providers/theme_provider.dart';
-
-/// 编译时通过 `--dart-define=APP_VERSION=3.3.0` 注入的版本号。
-/// 优先级低于 PackageInfo（运行时实际读取），仅作回退显示用。
-const String kBuildAppVersion = String.fromEnvironment(
-  'APP_VERSION',
-  defaultValue: '0.0.0',
-);
+import '../../widgets/apple_lyrics/layout/lyric_preferences_panel.dart';
+import '../../widgets/apple_lyrics/preview/lyrics_preview_page.dart';
+import '../../widgets/seed_color_picker.dart';
 
 class SettingsPage extends StatefulWidget {
   const SettingsPage({super.key});
@@ -38,19 +35,67 @@ class _SettingsPageState extends State<SettingsPage> {
   bool _isTestingConnection = false;
   String? _connectionResult;
   bool _autoReceiveVip = true;
+  bool _useDynamicColor = false;
+  // Apple Music 风格播放页开关（默认关闭，开启后用 AM 风格 FullPlayer）
+  bool _useAmStylePlayer = false;
   String _appVersion = '';
+  // Lyricon 词幕推送相关状态
+  bool _lyriconEnabled = false;
+  bool _lyriconDisplayTranslation = true;
+  bool _lyriconDisplayRoma = false;
 
   @override
   void initState() {
     super.initState();
     _loadSettings();
     _loadVersion();
+    _loadLyriconSettings();
+    LyriconProviderService.instance.addListener(_onLyriconStateChanged);
   }
 
   @override
   void dispose() {
+    LyriconProviderService.instance.removeListener(_onLyriconStateChanged);
     _apiServerController.dispose();
     super.dispose();
+  }
+
+  /// Lyricon 服务状态变化回调：触发 UI 刷新
+  void _onLyriconStateChanged() {
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  /// 从 SettingsRepository 加载 Lyricon 三个偏好
+  Future<void> _loadLyriconSettings() async {
+    final enabled = await _settingsRepository.getLyriconEnabled();
+    final displayTranslation =
+        await _settingsRepository.getLyriconDisplayTranslation();
+    final displayRoma = await _settingsRepository.getLyriconDisplayRoma();
+    if (mounted) {
+      setState(() {
+        _lyriconEnabled = enabled;
+        _lyriconDisplayTranslation = displayTranslation;
+        _lyriconDisplayRoma = displayRoma;
+      });
+    }
+  }
+
+  /// Lyricon 连接状态 → 中文文案
+  String _getLyriconStateText() {
+    switch (LyriconProviderService.instance.state) {
+      case LyriconConnectionState.disabled:
+        return '未启用';
+      case LyriconConnectionState.connecting:
+        return '连接中...';
+      case LyriconConnectionState.connected:
+        return '已连接';
+      case LyriconConnectionState.disconnected:
+        return '已断开';
+      case LyriconConnectionState.timeout:
+        return '连接超时，请检查 Lyricon / LSPosed 配置';
+    }
   }
 
   Future<void> _loadSettings() async {
@@ -58,12 +103,18 @@ class _SettingsPageState extends State<SettingsPage> {
     final quality = await _settingsRepository.getDefaultQuality();
     final autoReceiveVip = await _settingsRepository.getAutoReceiveVip();
     final apiServerUrl = await _settingsRepository.getApiServerUrl();
+    // 从 ThemeProvider 同步「使用系统主题色」开关状态
+    final useDynamicColor = context.read<ThemeProvider>().useDynamicColor;
+    // 从 ThemeProvider 同步「Apple Music 风格播放页」开关状态
+    final useAmStylePlayer = context.read<ThemeProvider>().useAmStylePlayer;
 
     setState(() {
       _themeMode = themeMode;
       _defaultQuality = quality;
       _autoReceiveVip = autoReceiveVip;
       _apiServerController.text = apiServerUrl;
+      _useDynamicColor = useDynamicColor;
+      _useAmStylePlayer = useAmStylePlayer;
     });
   }
 
@@ -78,7 +129,7 @@ class _SettingsPageState extends State<SettingsPage> {
     } catch (_) {
       if (mounted) {
         setState(() {
-          _appVersion = kBuildAppVersion;
+          _appVersion = '3.2.0';
         });
       }
     }
@@ -127,6 +178,9 @@ class _SettingsPageState extends State<SettingsPage> {
           _buildSectionHeader('外观'),
           _buildAppearanceSection(colorScheme),
           const Divider(),
+          _buildSectionHeader('歌词'),
+          _buildLyricSection(colorScheme),
+          const Divider(),
           _buildSectionHeader('播放'),
           _buildPlaybackSection(colorScheme),
           const Divider(),
@@ -156,7 +210,88 @@ class _SettingsPageState extends State<SettingsPage> {
     );
   }
 
+  /// 歌词设置 section：点击进入字号/行间距调节面板。
+  Widget _buildLyricSection(ColorScheme colorScheme) {
+    return Column(
+      children: [
+        ListTile(
+          leading: const Icon(Icons.lyrics),
+          title: const Text('歌词显示'),
+          subtitle: const Text('字号、行间距'),
+          trailing: const Icon(Icons.chevron_right, size: 18),
+          onTap: () {
+            showModalBottomSheet(
+              context: context,
+              isScrollControlled: true,
+              builder: (context) => SafeArea(
+                child: const LyricPreferencesPanel(),
+              ),
+            );
+          },
+        ),
+        // Lyricon 词幕推送主开关
+        SwitchListTile(
+          title: const Text('Lyricon 词幕推送'),
+          subtitle: const Text('向 Lyricon 提供方实时推送歌词'),
+          value: _lyriconEnabled,
+          onChanged: (value) {
+            setState(() {
+              _lyriconEnabled = value;
+            });
+            LyriconProviderService.instance.setEnabled(value);
+            _settingsRepository.setLyriconEnabled(value);
+          },
+        ),
+        // 主开关下方显示当前连接状态
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: Text(
+              _getLyriconStateText(),
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+        ),
+        // 次级开关：翻译歌词（主开关关闭时禁用）
+        SwitchListTile(
+          title: const Text('翻译歌词'),
+          value: _lyriconDisplayTranslation,
+          onChanged: _lyriconEnabled
+              ? (value) {
+                  setState(() {
+                    _lyriconDisplayTranslation = value;
+                  });
+                  LyriconProviderService.instance.setDisplayTranslation(value);
+                  _settingsRepository.setLyriconDisplayTranslation(value);
+                }
+              : null,
+        ),
+        // 次级开关：罗马音（主开关关闭时禁用）
+        SwitchListTile(
+          title: const Text('罗马音'),
+          value: _lyriconDisplayRoma,
+          onChanged: _lyriconEnabled
+              ? (value) {
+                  setState(() {
+                    _lyriconDisplayRoma = value;
+                  });
+                  LyriconProviderService.instance.setDisplayRoma(value);
+                  _settingsRepository.setLyriconDisplayRoma(value);
+                }
+              : null,
+        ),
+      ],
+    );
+  }
+
   Widget _buildAppearanceSection(ColorScheme colorScheme) {
+    final themeProvider = context.read<ThemeProvider>();
+    // 仅 ThemeMode.light 时禁用 OLED 开关；dark 与 system 均可勾选。
+    // system 模式下勾选后，等系统切到深色时 darkTheme 自动应用纯黑（MaterialApp 机制）。
+    final canToggleOled = _themeMode != ThemeMode.light;
     return Column(
       children: [
         Padding(
@@ -203,8 +338,77 @@ class _SettingsPageState extends State<SettingsPage> {
             },
           ),
         ),
+        // 主题色入口：点击弹出 8 色预设面板。
+        // 系统色开启时用 IgnorePointer 禁用点击（不灰显，色块仍显示当前 effectiveSeedColor）。
+        IgnorePointer(
+          ignoring: themeProvider.useDynamicColor,
+          child: ListTile(
+            leading: const Icon(Icons.palette),
+            title: const Text('主题色'),
+            subtitle: Text(
+              themeProvider.useDynamicColor
+                  ? '跟随系统壁纸取色'
+                  : '手动选择种子色',
+            ),
+            trailing: Container(
+              width: 24,
+              height: 24,
+              decoration: BoxDecoration(
+                color: themeProvider.effectiveSeedColor,
+                shape: BoxShape.circle,
+                border: Border.all(color: colorScheme.outline, width: 1.5),
+              ),
+            ),
+            onTap: () => _showSeedColorPicker(themeProvider),
+          ),
+        ),
+        SwitchListTile(
+          title: const Text('使用系统主题色'),
+          subtitle: const Text('跟随系统壁纸取色（Android 12+ 莫奈色，HCT 多点量化）'),
+          value: _useDynamicColor,
+          onChanged: (v) {
+            setState(() => _useDynamicColor = v);
+            context.read<ThemeProvider>().setUseDynamicColor(v);
+          },
+        ),
+        // OLED 纯黑开关：light 模式禁用；dark 与 system 可勾选。
+        // system 模式下勾选后，系统切深色时自动生效，切浅色时不影响 lightTheme。
+        SwitchListTile(
+          title: const Text('OLED 纯黑深色'),
+          subtitle: const Text('将深色背景改为纯黑（仅深色模式生效，节省 OLED 电量）'),
+          value: themeProvider.useOledBlack,
+          onChanged: canToggleOled
+              ? (v) => themeProvider.setUseOledBlack(v)
+              : null,
+        ),
+        SwitchListTile(
+          title: const Text('Apple Music 风格播放页'),
+          subtitle: const Text('使用模糊封面背景 + 弹簧动画 + 逐字歌词（关闭则用原版 MD3 风格）'),
+          value: _useAmStylePlayer,
+          onChanged: (v) {
+            setState(() => _useAmStylePlayer = v);
+            context.read<ThemeProvider>().setUseAmStylePlayer(v);
+          },
+        ),
         const SizedBox(height: 8),
       ],
+    );
+  }
+
+  /// 弹出 8 色预设种子色选择面板。
+  /// 选择后调用 ThemeProvider.setManualSeedColor 持久化并立即生效。
+  void _showSeedColorPicker(ThemeProvider themeProvider) {
+    showModalBottomSheet(
+      context: context,
+      showDragHandle: true,
+      builder: (ctx) => SeedColorPicker(
+        currentColor:
+            themeProvider.manualSeedColor ?? AppTheme.defaultSeedColor,
+        onSelected: (color) {
+          themeProvider.setManualSeedColor(color);
+          Navigator.pop(ctx);
+        },
+      ),
     );
   }
 
@@ -397,7 +601,7 @@ class _SettingsPageState extends State<SettingsPage> {
       children: [
         ListTile(
           title: const Text('应用版本'),
-          subtitle: Text(_appVersion.isEmpty ? kBuildAppVersion : _appVersion),
+          subtitle: Text(_appVersion.isEmpty ? '3.2.0' : _appVersion),
           leading: const Icon(Icons.info_outline),
         ),
         ListTile(
@@ -414,7 +618,20 @@ class _SettingsPageState extends State<SettingsPage> {
             showLicensePage(
               context: context,
               applicationName: 'MD3Music',
-              applicationVersion: _appVersion.isEmpty ? kBuildAppVersion : _appVersion,
+              applicationVersion: _appVersion.isEmpty ? '3.2.0' : _appVersion,
+            );
+          },
+        ),
+        // 开发者入口：跳转 Apple Music 风格歌词渲染预览页（Task 22.5）
+        ListTile(
+          title: const Text('歌词预览（开发）'),
+          subtitle: const Text('Apple Music 风格歌词渲染调试'),
+          leading: const Icon(Icons.lyrics_outlined),
+          onTap: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (_) => const LyricsPreviewPage(),
+              ),
             );
           },
         ),

--- a/lib/modules/user/favorites_page.dart
+++ b/lib/modules/user/favorites_page.dart
@@ -6,6 +6,7 @@ import '../../providers/favorites_provider.dart';
 import '../../providers/playlist_collection_notifier.dart';
 import '../../services/kugou_api/kugou_api_client.dart';
 import '../../services/kugou_api/kugou_models.dart';
+import '../../widgets/scroll_aware_app_bar.dart';
 import '../playlist/playlist_page.dart';
 
 class FavoritesPage extends StatefulWidget {
@@ -27,6 +28,9 @@ class _FavoritesPageState extends State<FavoritesPage> {
   bool _isManaging = false;
   final Set<int> _selectedIndices = {};
 
+  /// 顶栏渐变 ScrollController：与 ScrollAwareAppBar 共享
+  final ScrollController _scrollController = ScrollController();
+
   @override
   void initState() {
     super.initState();
@@ -40,6 +44,7 @@ class _FavoritesPageState extends State<FavoritesPage> {
   @override
   void dispose() {
     context.read<PlaylistCollectionNotifier>().removeListener(_onCollectionChanged);
+    _scrollController.dispose();
     super.dispose();
   }
 
@@ -103,7 +108,7 @@ class _FavoritesPageState extends State<FavoritesPage> {
 
         if (list != null && list.isNotEmpty) {
           // 调试：打印每个歌单的原始字段，帮助确认过滤条件
-          for (final item in list!) {
+          for (final item in list) {
             final j = item as Map<String, dynamic>;
             debugPrint(
               '[Playlist] name=${j['specialname'] ?? j['name']} | '
@@ -238,13 +243,10 @@ class _FavoritesPageState extends State<FavoritesPage> {
 
   @override
   Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
     return Scaffold(
-      appBar: AppBar(
-        title: Text(
-          '我的收藏',
-          style: textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w600),
-        ),
+      appBar: ScrollAwareAppBar(
+        title: '我的收藏',
+        scrollController: _scrollController,
         actions: [
           if (!_isManaging)
             IconButton(
@@ -272,6 +274,7 @@ class _FavoritesPageState extends State<FavoritesPage> {
     return RefreshIndicator(
       onRefresh: () => _loadPlaylists(forceNoCache: true),
       child: ListView(
+        controller: _scrollController,
         children: [
           // 我创建的歌单
           if (created.isNotEmpty)
@@ -282,7 +285,6 @@ class _FavoritesPageState extends State<FavoritesPage> {
               onToggle: (v) => setState(() => _createdExpanded = v),
               playlists: created,
               baseIndex: 0,
-              showAdd: true,
             ),
 
           // 我收藏的歌单
@@ -294,7 +296,6 @@ class _FavoritesPageState extends State<FavoritesPage> {
               onToggle: (v) => setState(() => _collectedExpanded = v),
               playlists: collected,
               baseIndex: created.length,
-              showAdd: false,
             ),
         ],
       ),
@@ -308,10 +309,7 @@ class _FavoritesPageState extends State<FavoritesPage> {
     required ValueChanged<bool> onToggle,
     required List<KugouPlaylistBrief> playlists,
     required int baseIndex,
-    required bool showAdd,
   }) {
-    final displayCount = isExpanded ? playlists.length : (count > 5 ? 5 : count);
-
     return Column(
       children: [
         // 分组头部
@@ -321,7 +319,13 @@ class _FavoritesPageState extends State<FavoritesPage> {
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
             child: Row(
               children: [
-                Icon(isExpanded ? Icons.expand_less : Icons.expand_more, size: 20),
+                // 箭头图标加旋转动画
+                AnimatedRotation(
+                  turns: isExpanded ? 0.25 : 0.0,
+                  duration: const Duration(milliseconds: 200),
+                  curve: Curves.easeInOutCubic,
+                  child: const Icon(Icons.chevron_right, size: 22),
+                ),
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(title, style: Theme.of(context).textTheme.titleMedium),
@@ -331,7 +335,7 @@ class _FavoritesPageState extends State<FavoritesPage> {
                   color: Theme.of(context).colorScheme.onSurfaceVariant,
                 )),
                 const SizedBox(width: 8),
-                // 我创建的歌单：显示"+"和"管理"；收藏的歌单：只显示"管理"
+                // 管理模式下显示「删除 + 取消」，否则只显示「sort」管理按钮
                 if (_isManaging) ...[
                   IconButton(
                     icon: const Icon(Icons.delete_outline, size: 20),
@@ -345,12 +349,6 @@ class _FavoritesPageState extends State<FavoritesPage> {
                     child: const Text('取消'),
                   ),
                 ] else ...[
-                  if (showAdd)
-                    IconButton(
-                      icon: const Icon(Icons.add, size: 20),
-                      tooltip: '新建歌单',
-                      onPressed: _showCreatePlaylistDialog,
-                    ),
                   IconButton(
                     icon: const Icon(Icons.sort, size: 20),
                     tooltip: '管理歌单',
@@ -363,24 +361,33 @@ class _FavoritesPageState extends State<FavoritesPage> {
         ),
         Divider(height: 1, indent: 44, color: Theme.of(context).colorScheme.outlineVariant),
 
-        // 展开时显示列表
-        if (isExpanded)
-          ...List.generate(displayCount, (i) {
-            final playlist = playlists[i];
-            final idx = baseIndex + i;
-            final isSelected = _selectedIndices.contains(idx);
-            return _buildPlaylistTile(playlist, isSelected, idx, baseIndex);
-          }),
-
-        // 折叠且超过显示数量时，底部展开按钮
-        if (!isExpanded && count > 5)
-          Center(
-            child: TextButton.icon(
-              onPressed: () => onToggle(true),
-              icon: const Icon(Icons.keyboard_arrow_down, size: 18),
-              label: const Text('展开', style: TextStyle(fontSize: 13)),
-            ),
+        // 用 AnimatedSwitcher + SizeTransition 实现展开/收纳动画：
+        // AnimatedSize 在折叠时 child 立即变空 Column，动画过程无可视内容；
+        // SizeTransition 的 child 始终完整渲染所有 tiles，通过 sizeFactor
+        // 控制可见比例，折叠时 tiles 从顶部向下被裁切消失，展开时反向显现。
+        AnimatedSwitcher(
+          duration: const Duration(milliseconds: 280),
+          switchInCurve: Curves.easeInOutCubic,
+          switchOutCurve: Curves.easeInOutCubic,
+          transitionBuilder: (child, animation) => SizeTransition(
+            sizeFactor: animation,
+            axisAlignment: 1.0, // 顶部对齐，向下展开/向上收起
+            child: child,
           ),
+          child: isExpanded
+              ? Column(
+                  key: const ValueKey('expanded'),
+                  mainAxisSize: MainAxisSize.min,
+                  children: List.generate(playlists.length, (i) {
+                    final playlist = playlists[i];
+                    final idx = baseIndex + i;
+                    final isSelected = _selectedIndices.contains(idx);
+                    return _buildPlaylistTile(
+                        playlist, isSelected, idx, baseIndex);
+                  }),
+                )
+              : const SizedBox.shrink(key: ValueKey('collapsed')),
+        ),
       ],
     );
   }

--- a/lib/modules/user/user_center_page.dart
+++ b/lib/modules/user/user_center_page.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 
 import '../../providers/kugou_provider.dart';
 import '../../widgets/app_animation.dart';
+import '../../widgets/scroll_aware_app_bar.dart';
 import '../login/login_page.dart';
 import '../settings/settings_page.dart';
 import 'downloads_page.dart';
@@ -18,6 +19,9 @@ class UserCenterPage extends StatefulWidget {
 }
 
 class _UserCenterPageState extends State<UserCenterPage> {
+  /// 顶栏渐变 ScrollController：与 ScrollAwareAppBar 共享
+  final ScrollController _scrollController = ScrollController();
+
   @override
   void initState() {
     super.initState();
@@ -31,16 +35,20 @@ class _UserCenterPageState extends State<UserCenterPage> {
   }
 
   @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final tt = Theme.of(context).textTheme;
 
     return Scaffold(
-      appBar: AppBar(
-        title: Text(
-          '我的',
-          style: tt.titleLarge?.copyWith(fontWeight: FontWeight.w600),
-        ),
+      appBar: ScrollAwareAppBar(
+        title: '我的',
+        scrollController: _scrollController,
         actions: [
           IconButton(
             icon: const Icon(Icons.settings),
@@ -88,6 +96,7 @@ class _UserCenterPageState extends State<UserCenterPage> {
               await kugou.getVipMonthRecord();
             },
             child: CustomScrollView(
+              controller: _scrollController,
               slivers: [
                 _buildUserHeader(cs, tt, kugou),
                 _buildVipCard(cs, tt, kugou),

--- a/lib/providers/kugou_provider.dart
+++ b/lib/providers/kugou_provider.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 
@@ -210,7 +209,24 @@ class KugouProvider extends ChangeNotifier {
   KugouAlbumDetail? get albumDetail => _albumDetail;
   List<String> get searchSuggest => _searchSuggest;
   KugouPlayUrl? get songUrl => _songUrl;
-  KugouLyric? get lyric => _lyric;
+
+  /// 当前歌词（Task 15 双请求合并后的对象，同时携带 KRC 与 LRC 明文）。
+  /// 旧调用方继续使用此 getter，通过 [KugouLyric.displayLyric] 自动取
+  /// KRC 优先、降级 LRC 的文本——等价于 `krcLyric ?? lrcLyric`，
+  /// 因为 Task 15 返回的是同一个 `KugouLyric` 对象。
+  KugouLyric? get lyric => krcLyric ?? lrcLyric;
+
+  /// 携带 KRC 明文（逐字）的 `KugouLyric`（如有）。
+  /// 调用方应使用 `krcLyric?.displayKrcLyric` 取 KRC 明文文本。
+  /// Task 15 双请求返回的同一对象，KRC 部分可能为 null（仅 LRC 可用）。
+  KugouLyric? get krcLyric => _lyric;
+
+  /// 携带 LRC 明文（行级）的 `KugouLyric`（如有）。
+  /// 调用方应使用 `lrcLyric?.displayLrcLyric` 取 LRC 明文文本。
+  /// 与 [krcLyric] 引用同一对象，Task 15 合并后两者共享存储，
+  /// 由模型层 `displayKrcLyric` / `displayLrcLyric` 区分。
+  KugouLyric? get lrcLyric => _lyric;
+
   KugouCommentList? get comments => _comments;
   KugouPlaylistSongs? get playlistSongs => _playlistSongs;
   List<KugouSongDetail> get personalFmSongs => _personalFmSongs;
@@ -422,6 +438,12 @@ class KugouProvider extends ChangeNotifier {
     _lyricSongId = hash;
     notifyListeners();
     try {
+      // Task 15：默认 fmt='lrc' 时，API 客户端会并发发起 LRC + KRC 两个请求，
+      // 返回的 KugouLyric 同时携带 decodedContent（LRC 明文）与
+      // decodedKrcContent（KRC 明文）。任一请求失败不影响另一个。
+      // 这里只调用一次，结果统一存入 _lyric，由 [krcLyric] / [lrcLyric]
+      // getter 暴露，调用方通过 KugouLyric.displayKrcLyric / displayLrcLyric
+      // 显式分别取两种文本。
       final result = await _apiClient.getLyric(
         hash,
         songName: songName,

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -6,12 +6,16 @@ import 'package:provider/provider.dart';
 
 import '../core/services/audio_service.dart';
 import '../core/services/desktop_lyric_service.dart';
+import '../core/services/lyricon_provider_service.dart';
 import '../core/services/media_notification_service.dart';
 import '../data/models/song.dart';
 import '../data/repositories/history_repository.dart';
 import '../data/repositories/settings_repository.dart';
 import '../main.dart';
+import '../widgets/apple_lyrics/models/lyric_line.dart';
+import '../widgets/apple_lyrics/parsers/lyric_parser_chain.dart';
 import 'favorites_provider.dart';
+import 'kugou_provider.dart';
 import '../services/kugou_api/kugou_api_client.dart';
 
 enum AppLoopMode { off, one, all }
@@ -70,8 +74,17 @@ class PlayerProvider extends ChangeNotifier {
   // 未登录时尝试播放需联网歌曲,通知 UI 弹窗
   void Function()? onLoginRequired;
 
+  // —— Lyricon 钩子字段 ——
+  // 记录上次推送给 Lyricon 的歌曲，用于在 notifyListeners 回调中检测切歌
+  // （PlayerProvider 没有专门的切歌回调，用 addListener 监听自身是最小侵入方式）
+  Song? _lastLyriconSong;
+  // 歌词异步拉取的竞态 token：每次切歌自增，过期结果被丢弃
+  int _lyriconFetchToken = 0;
+
   PlayerProvider() {
     _initAudioService();
+    // 监听自身变化检测切歌 → 推送 Lyricon（仅 enabled 时实际推送）
+    addListener(_handleLyriconSongChange);
   }
 
   Future<void> _initAudioService() async {
@@ -127,6 +140,16 @@ class PlayerProvider extends ChangeNotifier {
           _position = position;
           _updateNotificationPosition();
           notifyListeners();
+          // 直接转发给 Lyricon，无节流。
+          // positionStream 本身就是 ~200ms 周期（just_audio 默认），是天然节流。
+          // MethodChannel 是异步的，不阻塞 Dart UI；setPosition 是 fire-and-forget。
+          // 仅在播放中推送，暂停时跳过避免无意义 IPC。
+          if (LyriconProviderService.instance.enabled && _isPlaying) {
+            try {
+              LyriconProviderService.instance
+                  .setPosition(position.inMilliseconds);
+            } catch (_) {}
+          }
         },
         onError: (e) {
                   },
@@ -146,6 +169,17 @@ class PlayerProvider extends ChangeNotifier {
           _isPlaying = isPlaying;
           _updateNotification();
           notifyListeners();
+          // 播放/暂停切换时立即推 Lyricon，避免等下一个 positionStream tick
+          // state 必须用 PlaybackStateCompat.STATE_PLAYING=3 / STATE_PAUSED=2
+          if (LyriconProviderService.instance.enabled) {
+            try {
+              LyriconProviderService.instance.setPlaybackState(
+                state: isPlaying ? 3 : 2,
+                position: _position.inMilliseconds,
+                speed: 1.0,
+              );
+            } catch (_) {}
+          }
         },
         onError: (e) {
                   },
@@ -216,7 +250,11 @@ class PlayerProvider extends ChangeNotifier {
                 .where((s) => s.id != currentSong?.id)
                 .toList();
             remaining.shuffle();
-            _playlist = [?currentSong, ...remaining];
+            // currentSong 可能为 null，使用 collection-if 条件添加
+            _playlist = [
+              if (currentSong != null) currentSong,
+              ...remaining,
+            ];
             _currentIndex = 0;
           } else {
             _currentIndex = 0;
@@ -497,6 +535,13 @@ class PlayerProvider extends ChangeNotifier {
       notifyListeners();
     }
     await _audioService?.seek(position);
+    // 同步进度到 Lyricon（仅 enabled 时推送，避免无意义 IPC；
+    // seek 由用户拖动进度条或切歌/上一首/下一首触发，频率自然不高，无需额外节流）
+    if (LyriconProviderService.instance.enabled) {
+      try {
+        LyriconProviderService.instance.seekTo(position.inMilliseconds);
+      } catch (_) {}
+    }
   }
 
   Future<bool> _resolveAndPlayCurrentSong() async {
@@ -671,7 +716,11 @@ class PlayerProvider extends ChangeNotifier {
           .where((s) => s.id != currentSong?.id)
           .toList();
       remaining.shuffle();
-      _playlist = [?currentSong, ...remaining];
+      // currentSong 可能为 null，使用 collection-if 条件添加
+      _playlist = [
+        if (currentSong != null) currentSong,
+        ...remaining,
+      ];
       _currentIndex = 0;
     } else {
       final currentSong = _currentSong;
@@ -778,13 +827,14 @@ class PlayerProvider extends ChangeNotifier {
     // Check favorite status from FavoritesProvider via global context
     bool isFavorited = false;
     try {
-      final ctx = appNavigatorKey?.currentContext;
+      final ctx = appNavigatorKey.currentContext;
       if (ctx != null) {
         isFavorited = ctx.read<FavoritesProvider>().isFavorite(song.id);
       }
     } catch (_) {}
     MediaNotificationService.updateNotification(
-      title: song.title,
+      // 使用 displayName 剥离 .mp3 等扩展名，与 _createAudioSource 行为保持一致
+      title: song.displayName,
       artist: song.artist,
       artUrl: song.artworkUri,
       isPlaying: _isPlaying,
@@ -810,7 +860,8 @@ class PlayerProvider extends ChangeNotifier {
       return createAudioSourceWeb(
         id: song.id,
         url: playbackUrl ?? '',
-        title: song.title,
+        // 使用 displayName 剥离 .mp3 等扩展名，避免系统通知栏/锁屏显示后缀
+        title: song.displayName,
         artist: song.artist,
         album: song.album,
         artUri: song.artworkUri != null ? Uri.parse(song.artworkUri!) : null,
@@ -819,15 +870,86 @@ class PlayerProvider extends ChangeNotifier {
     return createAudioSource(
       id: song.id,
       url: playbackUrl ?? '',
-      title: song.title,
+      // 使用 displayName 剥离 .mp3 等扩展名，避免系统通知栏/锁屏显示后缀
+      title: song.displayName,
       artist: song.artist,
       album: song.album,
       artUri: song.artworkUri != null ? Uri.parse(song.artworkUri!) : null,
     );
   }
 
+  /// 监听自身 notifyListeners：检测 currentSong 变化时推送 Lyricon。
+  ///
+  /// PlayerProvider 没有专门的切歌回调（playSong / next / previous / playSongAt
+  /// 等多处都会切歌），用 addListener 监听自身是最小侵入方式。
+  /// 每次 notifyListeners（含 position tick）都会触发本方法，但首行 short-circuit
+  /// 仅做一次字符串比较，开销可忽略。
+  void _handleLyriconSongChange() {
+    if (!LyriconProviderService.instance.enabled) return;
+    final song = _currentSong;
+    // id 相同（含都为 null）则不处理，避免高频 tick 触发重复推送
+    if (song?.id == _lastLyriconSong?.id) return;
+    _lastLyriconSong = song;
+    _pushLyriconSongChange(song);
+  }
+
+  /// 拉取歌词 → 解析 → 推送 Lyricon onSongChanged。
+  ///
+  /// 参考 [DesktopLyricService._onTick] / [_fetchLyricFor] 的模式：
+  /// - 通过 appNavigatorKey.currentContext 拿 KugouProvider
+  /// - 调 kugou.getLyric 拉 LRC（Task 15 双请求会同时拉 KRC）
+  /// - 用 LyricParserChain.parse 自动识别 KRC/LRC/纯文本
+  /// - 推送 LyriconProviderService.instance.onSongChanged
+  ///
+  /// 竞态处理：每次切歌自增 _lyriconFetchToken，异步结果过期则丢弃，
+  /// 避免快速切歌时旧歌词覆盖新歌词。
+  Future<void> _pushLyriconSongChange(Song? song) async {
+    if (!LyriconProviderService.instance.enabled) return;
+    final token = ++_lyriconFetchToken;
+    try {
+      List<LyricLine> lines = const [];
+      if (song != null) {
+        final ctx = appNavigatorKey.currentContext;
+        if (ctx != null) {
+          try {
+            final kugou = ctx.read<KugouProvider>();
+            // fmt='lrc' 触发 KugouApiClient 内部并发双请求（LRC + KRC），
+            // 返回的 KugouLyric 同时携带 decodedContent（LRC）与
+            // decodedKrcContent（KRC），由 displayLyric 优先返回 KRC 明文。
+            // 不复用 kugou.lyric 缓存：KugouProvider 未暴露 lyricSongId getter，
+            // 无法判断缓存是否属于当前歌曲（切歌瞬间缓存可能仍是上一首）。
+            // getLyric 内部有 _lyricSongId 竞态保护，与 apple_lyrics_view
+            // 的并发请求互不干扰（后调覆盖前调，结果一致）。
+            await kugou.getLyric(
+              song.id,
+              songName: song.title,
+              fmt: 'lrc',
+            );
+            if (token != _lyriconFetchToken) return; // 切歌已变化，丢弃旧结果
+            // 复用 LyricParserChain 自动识别 KRC/LRC/纯文本（与
+            // DesktopLyricService 同一解析入口，不重复实现解析逻辑）
+            final text = kugou.lyric?.displayLyric;
+            if (text != null && text.isNotEmpty) {
+              lines = LyricParserChain.parse(text);
+            }
+          } catch (_) {}
+        }
+      }
+      if (token != _lyriconFetchToken) return;
+      // 传入当前播放进度和状态，让 Lyricon 能立即触发歌词渲染
+      // （Lyricon 推荐调用顺序：setSong → setPosition → setPlaybackState）
+      await LyriconProviderService.instance.onSongChanged(
+        song,
+        lines,
+        positionMs: _position.inMilliseconds,
+        isPlaying: _isPlaying,
+      );
+    } catch (_) {}
+  }
+
   @override
   void dispose() {
+    removeListener(_handleLyriconSongChange);
     _positionSubscription?.cancel();
     _durationSubscription?.cancel();
     _playingSubscription?.cancel();

--- a/lib/providers/theme_provider.dart
+++ b/lib/providers/theme_provider.dart
@@ -1,15 +1,49 @@
+import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/material.dart';
+import 'package:material_color_utilities/material_color_utilities.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+import '../core/theme/app_theme.dart';
 
 class ThemeProvider extends ChangeNotifier {
   static const String _key = 'theme_mode';
+  static const String _dynamicKey = 'use_dynamic_color';
+  static const String _amStylePlayerKey = 'use_am_style_player';
+  static const String _manualSeedKey = 'manual_seed_color';
+  static const String _oledBlackKey = 'use_oled_black';
 
   ThemeMode _themeMode = ThemeMode.system;
+  bool _useDynamicColor = false;
+  Color? _systemSeedColor;
+  // Apple Music 风格播放页开关，默认关闭；开启后用 AM 风格 FullPlayer，关闭用原版 MD3
+  bool _useAmStylePlayer = false;
+  // 用户手动选择的种子色；null 表示未选择，使用默认紫色
+  Color? _manualSeedColor;
+  // OLED 纯黑深色模式开关，默认关闭；开启时 darkTheme 的 surface 系列覆盖为纯黑
+  bool _useOledBlack = false;
 
   ThemeMode get themeMode => _themeMode;
+  bool get useDynamicColor => _useDynamicColor;
+  Color? get systemSeedColor => _systemSeedColor;
+  bool get useAmStylePlayer => _useAmStylePlayer;
+  Color? get manualSeedColor => _manualSeedColor;
+  bool get useOledBlack => _useOledBlack;
+
+  /// 当前生效的种子色优先级：
+  /// 1. 启用系统主题色且成功取到 → 系统主色
+  /// 2. 用户手动选择非 null → 手动色
+  /// 3. 默认紫色种子（[AppTheme.defaultSeedColor]）
+  Color get effectiveSeedColor =>
+      _useDynamicColor && _systemSeedColor != null
+          ? _systemSeedColor!
+          : (_manualSeedColor ?? AppTheme.defaultSeedColor);
 
   ThemeProvider() {
     _loadThemeMode();
+    _loadDynamicColor();
+    _loadAmStylePlayer();
+    _loadManualSeedColor();
+    _loadOledBlack();
   }
 
   Future<void> _loadThemeMode() async {
@@ -24,6 +58,134 @@ class ThemeProvider extends ChangeNotifier {
   Future<void> _saveThemeMode(ThemeMode mode) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_key, mode.index);
+  }
+
+  /// 加载「使用系统主题色」开关持久化值，若开启则同步提取系统主色。
+  Future<void> _loadDynamicColor() async {
+    final prefs = await SharedPreferences.getInstance();
+    _useDynamicColor = prefs.getBool(_dynamicKey) ?? false;
+    if (_useDynamicColor) {
+      await _loadSystemColor();
+    }
+    notifyListeners();
+  }
+
+  /// 优化版系统色提取（HCT 多点评分）：
+  /// 1. 取系统 palette.primary 的 5 个 tone（30/35/40/45/50）作为候选
+  /// 2. 用 [Score.score] 在 HCT 色彩空间评分候选，按适合度降序排列
+  ///    （参考 MaterialKolor 的 Score 评分流程）
+  /// 3. 选分最高者作为种子色
+  /// 失败时降级为 [CorePalette.primary.get(40)]（与改造前行为一致）。
+  ///
+  /// 参考：https://github.com/jordond/MaterialKolor
+  /// Flutter 端等价包：material_color_utilities（Google 官方 Dart 端口）
+  ///
+  /// 注意：MaterialKolor 原流程是 QuantizerCelebi + Score，但 QuantizerCelebi
+  /// 内部基于 QuantizerWu（为图片像素设计），对 5 个候选 tone 的少量输入不稳定。
+  /// 这里直接调 Score.score 评分候选 tone，更稳定且符合「HCT 评分选最佳」的核心思想。
+  Future<void> _loadSystemColor() async {
+    try {
+      final palette = await DynamicColorPlugin.getCorePalette();
+      if (palette == null) {
+        _systemSeedColor = null;
+        return;
+      }
+
+      // 候选 tone 列表：覆盖 M3 primary 的典型取值范围（默认 tone=40，向上下扩展）
+      const candidateTones = [30, 35, 40, 45, 50];
+      // 构造 population map：每个候选 tone 等权重出现 1 次
+      // Score.score 内部会根据 HCT 色彩空间评分（chroma / proportion / 过滤），按适合度降序
+      final colorsToPopulation = <int, int>{
+        for (final tone in candidateTones) palette.primary.get(tone): 1,
+      };
+
+      // Score 评分并选最佳（返回按适合度降序排列的 ARGB 列表）
+      // desired 设为候选数，确保返回尽可能多的候选；fallbackColorARGB 用默认紫色
+      final scored = Score.score(
+        colorsToPopulation,
+        desired: candidateTones.length,
+        fallbackColorARGB: AppTheme.defaultSeedColor.value,
+      );
+      if (scored.isEmpty) {
+        // 评分失败降级到原 get(40) 行为
+        _systemSeedColor = Color(palette.primary.get(40));
+        return;
+      }
+      _systemSeedColor = Color(scored.first);
+    } catch (_) {
+      _systemSeedColor = null;
+    }
+  }
+
+  /// 切换「使用系统主题色」开关。
+  Future<void> setUseDynamicColor(bool enabled) async {
+    if (_useDynamicColor == enabled) return;
+    _useDynamicColor = enabled;
+    if (enabled) {
+      await _loadSystemColor();
+    }
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_dynamicKey, enabled);
+  }
+
+  /// 加载「Apple Music 风格播放页」开关持久化值，默认关闭。
+  Future<void> _loadAmStylePlayer() async {
+    final prefs = await SharedPreferences.getInstance();
+    _useAmStylePlayer = prefs.getBool(_amStylePlayerKey) ?? false;
+    notifyListeners();
+  }
+
+  /// 切换「Apple Music 风格播放页」开关。
+  /// - 开启：用 AM 风格 FullPlayer（模糊封面背景 + 弹簧动画 + KRC 逐字歌词）
+  /// - 关闭：用原版 MD3 FullPlayer（标准主题色 + LRC 行级歌词）
+  /// 切换后已打开的 FullPlayer 不会立即换 widget，下次 push 时才走新分支。
+  Future<void> setUseAmStylePlayer(bool enabled) async {
+    if (_useAmStylePlayer == enabled) return;
+    _useAmStylePlayer = enabled;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_amStylePlayerKey, enabled);
+  }
+
+  /// 加载用户手动选择的种子色持久化值。
+  Future<void> _loadManualSeedColor() async {
+    final prefs = await SharedPreferences.getInstance();
+    final value = prefs.getInt(_manualSeedKey);
+    if (value != null) {
+      _manualSeedColor = Color(value);
+      notifyListeners();
+    }
+  }
+
+  /// 设置手动种子色。传 null 清除（回退默认紫色）。
+  Future<void> setManualSeedColor(Color? color) async {
+    if (_manualSeedColor == color) return;
+    _manualSeedColor = color;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    if (color != null) {
+      await prefs.setInt(_manualSeedKey, color.value);
+    } else {
+      await prefs.remove(_manualSeedKey);
+    }
+  }
+
+  /// 加载「OLED 纯黑深色模式」开关持久化值，默认关闭。
+  Future<void> _loadOledBlack() async {
+    final prefs = await SharedPreferences.getInstance();
+    _useOledBlack = prefs.getBool(_oledBlackKey) ?? false;
+    notifyListeners();
+  }
+
+  /// 切换「OLED 纯黑深色模式」开关。
+  /// 开启时 darkTheme 的 surface 系列覆盖为纯黑（仅深色模式生效）。
+  Future<void> setUseOledBlack(bool enabled) async {
+    if (_useOledBlack == enabled) return;
+    _useOledBlack = enabled;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_oledBlackKey, enabled);
   }
 
   void toggleTheme() {

--- a/lib/services/kugou_api/kugou_api_client.dart
+++ b/lib/services/kugou_api/kugou_api_client.dart
@@ -52,44 +52,32 @@ class KugouApiClient {
       await _initCompleter?.future;
     }
 
-    // 登录相关接口直接走云服务器，避免 local→cloud 双重签名
     if (_loginPaths.contains(options.path)) {
       options.baseUrl = 'http://115.29.236.96:5621';
     } else {
       options.baseUrl = KugouEndpoints.baseUrl;
     }
 
-    // 关键修复：每次请求前验证用户身份
     if (_token != null && _userid != null) {
-      // 把 vip_token 一并写入 Authorization，服务端的 cookieToJson
-      // 会按 ; 切成 cookie 对象，song_url_new 等模块可直接读取。
       final authParts = <String>['token=$_token', 'userid=$_userid'];
       if (_vipToken != null && _vipToken!.isNotEmpty) {
         authParts.add('vip_token=$_vipToken');
       }
       options.headers['Authorization'] = authParts.join(';');
-
-      // 调试日志：打印请求的用户身份（生产环境可移除）
       print('🌐 [API Request] User: $_userid, URL: ${options.path}');
-          } else {
-      // 未登录，清除 Authorization 头
+    } else {
       options.headers.remove('Authorization');
       print('⚠️ [API Request] 未登录状态, URL: ${options.path}');
-          }
+    }
 
     if (_dfid != null) {
       options.queryParameters['dfid'] = _dfid;
     }
 
-    // 调用方通过 options.extra['noCache'] = true 标记需要绕过 server_android 的 apicache。
-    // server_android 的 apicache 中间件认 x-apicache-bypass / x-apicache-force-fetch 头
-    // （util/apicache.js L596-597）。这样"我的收藏"新增/取消后下拉刷新能立刻拿到新数据，
-    // 不必等 2 分钟过期。
     final extra = options.extra;
     if (extra['noCache'] == true) {
       options.headers['x-apicache-bypass'] = '1';
       options.headers['Cache-Control'] = 'no-cache';
-      // 同时给查询参数加 t= 戳，避免部分路径在 cache 命中时跳过参数比对
       if (options.queryParameters['t'] == null) {
         options.queryParameters['t'] = DateTime.now().millisecondsSinceEpoch;
       }
@@ -125,13 +113,11 @@ class KugouApiClient {
           return response.data as Map<String, dynamic>;
         }
       }
-      print('[API _get] Non-200 or non-map: status=${response.statusCode} data=${response.data}');
       return null;
     } on DioException catch (e) {
-      print('[API _get] DioException: ${e.type} ${e.message} response=${e.response?.statusCode} ${e.response?.data}');
+      print('[API _get] DioException: ${e.type} ${e.message}');
       return null;
     } catch (e) {
-      print('[API _get] Error: $e');
       return null;
     }
   }
@@ -154,13 +140,10 @@ class KugouApiClient {
           return response.data as Map<String, dynamic>;
         }
       }
-      print('[API _post] Non-200 or non-map: status=${response.statusCode} data=${response.data}');
       return null;
     } on DioException catch (e) {
-      print('[API _post] DioException: ${e.type} ${e.message} response=${e.response?.statusCode} ${e.response?.data}');
       return null;
     } catch (e) {
-      print('[API _post] Error: $e');
       return null;
     }
   }
@@ -169,43 +152,30 @@ class KugouApiClient {
     _initCompleter = Completer<void>();
     try {
       final prefs = await SharedPreferences.getInstance();
-      
-      // 先读取当前登录的用户ID
       final currentUserid = prefs.getString('kugou_current_userid');
-      
       if (currentUserid != null && currentUserid.isNotEmpty) {
-        // 从用户隔离的键名读取
         final userTokenKey = 'kugou_token_$currentUserid';
         final userIdKey = 'kugou_userid_$currentUserid';
         final userVipKey = 'kugou_vip_token_$currentUserid';
-        
         _token = prefs.getString(userTokenKey);
         _userid = prefs.getString(userIdKey);
         _vipToken = prefs.getString(userVipKey);
-        
         if (_token != null && _userid != null) {
           print('✅ [Auth] 从存储恢复用户 $currentUserid 的登录状态');
         } else {
-          print('⚠️ [Auth] 用户 $currentUserid 的凭证不完整，需要重新登录');
           _token = null;
           _userid = null;
           _vipToken = null;
         }
       } else {
-        // 兼容旧版本：尝试读取全局键
         _token = prefs.getString('kugou_token');
         _userid = prefs.getString('kugou_userid');
         _vipToken = prefs.getString('kugou_vip_token');
-        
-        if (_token != null && _userid != null) {
-          print('⚠️ [Auth] 检测到旧版本登录状态，建议重新登录');
-        }
       }
-      
       _dfid = prefs.getString('kugou_dfid');
-          } catch (e) {
+    } catch (e) {
       print('❌ [Auth] 从存储初始化失败: $e');
-          } finally {
+    } finally {
       _isInitialized = true;
       _initCompleter?.complete();
     }
@@ -216,73 +186,53 @@ class KugouApiClient {
     String userid, {
     String? vipToken,
   }) async {
-    // 关键修复：先清除旧的用户数据，再设置新的
     await clearCookies();
-    
     _token = token;
     _userid = userid;
     _vipToken = vipToken;
-    
-    // 使用用户隔离的键名，避免多用户数据混乱
     try {
       final prefs = await SharedPreferences.getInstance();
-      
-      // 清除所有可能的旧键（兼容旧版本）
       await prefs.remove('kugou_token');
       await prefs.remove('kugou_userid');
       await prefs.remove('kugou_vip_token');
       await prefs.remove('kugou_dfid');
-      
-      // 使用带用户ID的键名存储（防止多用户冲突）
       final userTokenKey = 'kugou_token_$userid';
       final userIdKey = 'kugou_userid_$userid';
       final userVipKey = 'kugou_vip_token_$userid';
       final currentUserKey = 'kugou_current_userid';
-      
       await prefs.setString(userTokenKey, token);
       await prefs.setString(userIdKey, userid);
       if (vipToken != null && vipToken.isNotEmpty) {
         await prefs.setString(userVipKey, vipToken);
       }
-      
-      // 记录当前登录的用户ID
       await prefs.setString(currentUserKey, userid);
-      
-      print('✅ [Auth] 登录成功，用户ID: $userid, Token已存储到: $userTokenKey');
-          } catch (e) {
+      print('✅ [Auth] 登录成功，用户ID: $userid');
+    } catch (e) {
       print('❌ [Auth] 保存登录状态失败: $e');
-          }
+    }
   }
 
   Future<void> clearCookies() async {
     final oldUserid = _userid;
-    
     _token = null;
     _userid = null;
     _vipToken = null;
     _dfid = null;
-    
     try {
       final prefs = await SharedPreferences.getInstance();
-      
-      // 清除当前用户的键
       if (oldUserid != null) {
         await prefs.remove('kugou_token_$oldUserid');
         await prefs.remove('kugou_userid_$oldUserid');
         await prefs.remove('kugou_vip_token_$oldUserid');
       }
-      
-      // 清除全局键（兼容旧版本）
       await prefs.remove('kugou_token');
       await prefs.remove('kugou_userid');
       await prefs.remove('kugou_vip_token');
       await prefs.remove('kugou_dfid');
       await prefs.remove('kugou_current_userid');
-      
-      print('✅ [Auth] 已清除用户 $oldUserid 的登录状态');
-          } catch (e) {
+    } catch (e) {
       print('❌ [Auth] 清除登录状态失败: $e');
-          }
+    }
   }
 
   String? get token => _token;
@@ -299,10 +249,9 @@ class KugouApiClient {
         final data = json['data'] as Map<String, dynamic>?;
         if (data != null && data['dfid'] != null) {
           _dfid = data['dfid'].toString();
-                  }
+        }
       }
-    } catch (e) {
-          }
+    } catch (e) {}
   }
 
   bool _hasCandidates(Map<String, dynamic> json) {
@@ -310,80 +259,36 @@ class KugouApiClient {
     return candidates is List && candidates.isNotEmpty;
   }
 
-  // ==================== Search ====================
-
-  Future<KugouSearchResult?> search(
-    String keywords, {
-    int page = 1,
-    int pagesize = 30,
-    String type = 'song',
-  }) async {
-    final json = await _get(
-      KugouEndpoints.search,
-      queryParameters: {
-        'keywords': keywords,
-        'page': page,
-        'pagesize': pagesize,
-        'type': type,
-      },
-    );
+  Future<KugouSearchResult?> search(String keywords, {int page = 1, int pagesize = 30, String type = 'song'}) async {
+    final json = await _get(KugouEndpoints.search, queryParameters: {'keywords': keywords, 'page': page, 'pagesize': pagesize, 'type': type});
     if (json == null) return null;
-    try {
-      return KugouSearchResult.fromJson(json);
-    } catch (e) {
-            return null;
-    }
+    try { return KugouSearchResult.fromJson(json); } catch (e) { return null; }
   }
 
   Future<List<KugouAlbumBrief>?> searchAlbums(String keywords, {int page = 1, int pagesize = 20}) async {
-    final json = await _get(
-      KugouEndpoints.searchAlbum,
-      queryParameters: {'keyword': keywords, 'page': page, 'pagesize': pagesize},
-    );
+    final json = await _get(KugouEndpoints.searchAlbum, queryParameters: {'keyword': keywords, 'page': page, 'pagesize': pagesize});
     if (json == null) return null;
     try {
       final data = json['data'];
       List<dynamic> list = [];
-      if (data is List) {
-        list = data;
-      } else if (data is Map) {
-        list = data['info'] ?? data['list'] ?? [];
-      }
-      return list
-          .map((e) => KugouAlbumBrief.fromJson(e as Map<String, dynamic>))
-          .toList();
-    } catch (e) {
-            return null;
-    }
+      if (data is List) { list = data; } else if (data is Map) { list = data['info'] ?? data['list'] ?? []; }
+      return list.map((e) => KugouAlbumBrief.fromJson(e as Map<String, dynamic>)).toList();
+    } catch (e) { return null; }
   }
 
   Future<List<KugouPlaylistBrief>?> searchPlaylists(String keywords, {int page = 1, int pagesize = 20}) async {
-    final json = await _get(
-      KugouEndpoints.searchSpecial,
-      queryParameters: {'keyword': keywords, 'page': page, 'pagesize': pagesize},
-    );
+    final json = await _get(KugouEndpoints.searchSpecial, queryParameters: {'keyword': keywords, 'page': page, 'pagesize': pagesize});
     if (json == null) return null;
     try {
       final data = json['data'];
       List<dynamic> list = [];
-      if (data is List) {
-        list = data;
-      } else if (data is Map) {
-        list = data['info'] ?? data['list'] ?? [];
-      }
-      return list
-          .map((e) => KugouPlaylistBrief.fromJson(e as Map<String, dynamic>))
-          .toList();
-    } catch (e) {
-            return null;
-    }
+      if (data is List) { list = data; } else if (data is Map) { list = data['info'] ?? data['list'] ?? []; }
+      return list.map((e) => KugouPlaylistBrief.fromJson(e as Map<String, dynamic>)).toList();
+    } catch (e) { return null; }
   }
 
   Future<Map<String, dynamic>?> searchComplex(String keywords) async {
-    return await _get(
-      KugouEndpoints.searchComplex,
-      queryParameters: {'keywords': keywords},
-    );
+    return await _get(KugouEndpoints.searchComplex, queryParameters: {'keywords': keywords});
   }
 
   Future<String?> searchDefault() async {
@@ -392,9 +297,7 @@ class KugouApiClient {
     try {
       final data = json['data'] as Map<String, dynamic>? ?? json;
       return data['keyword']?.toString();
-    } catch (e) {
-      return null;
-    }
+    } catch (e) { return null; }
   }
 
   Future<List<String>?> getHotSearch() async {
@@ -403,33 +306,17 @@ class KugouApiClient {
     try {
       final data = json['data'];
       List<dynamic> list;
-      if (data is List) {
-        list = data;
-      } else if (data is Map) {
-        list = data['list'] ?? data['info'] ?? [];
-      } else {
-        list = [];
-      }
-      return list
-          .map((e) {
-            if (e is String) return e;
-            final m = e as Map<String, dynamic>;
-            return (m['searchword'] ?? m['keyword'] ?? m['name'] ?? '')
-                .toString();
-          })
-          .where((e) => e.isNotEmpty)
-          .cast<String>()
-          .toList();
-    } catch (e) {
-            return null;
-    }
+      if (data is List) { list = data; } else if (data is Map) { list = data['list'] ?? data['info'] ?? []; } else { list = []; }
+      return list.map((e) {
+        if (e is String) return e;
+        final m = e as Map<String, dynamic>;
+        return (m['searchword'] ?? m['keyword'] ?? m['name'] ?? '').toString();
+      }).where((e) => e.isNotEmpty).cast<String>().toList();
+    } catch (e) { return null; }
   }
 
   Future<List<String>?> getSearchSuggest(String keywords) async {
-    final json = await _get(
-      KugouEndpoints.searchSuggest,
-      queryParameters: {'keywords': keywords},
-    );
+    final json = await _get(KugouEndpoints.searchSuggest, queryParameters: {'keywords': keywords});
     if (json == null) return null;
     try {
       final data = json['data'];
@@ -445,11 +332,8 @@ class KugouApiClient {
                   if (hintInfo is String && hintInfo.isNotEmpty) {
                     items.add(hintInfo);
                   } else if (hintInfo is Map<String, dynamic>) {
-                    final word =
-                        hintInfo['HintWords'] ?? hintInfo['keyword'] ?? '';
-                    if (word.toString().isNotEmpty) {
-                      items.add(word.toString());
-                    }
+                    final word = hintInfo['HintWords'] ?? hintInfo['keyword'] ?? '';
+                    if (word.toString().isNotEmpty) { items.add(word.toString()); }
                   }
                 }
               }
@@ -459,23 +343,16 @@ class KugouApiClient {
       } else if (data is Map) {
         final list = data['list'] ?? data['info'] ?? [];
         for (final e in list) {
-          if (e is String) {
-            items.add(e);
-          } else if (e is Map<String, dynamic>) {
+          if (e is String) { items.add(e); }
+          else if (e is Map<String, dynamic>) {
             final word = e['keyword'] ?? e['searchword'] ?? e['name'] ?? '';
-            if (word.toString().isNotEmpty) {
-              items.add(word.toString());
-            }
+            if (word.toString().isNotEmpty) { items.add(word.toString()); }
           }
         }
       }
       return items.cast<String>().toList();
-    } catch (e) {
-            return null;
-    }
+    } catch (e) { return null; }
   }
-
-  // ==================== Song ====================
 
   Map<String, dynamic> _extractData(dynamic rawData) {
     if (rawData is Map<String, dynamic>) return rawData;
@@ -486,179 +363,84 @@ class KugouApiClient {
     return {};
   }
 
-  Future<KugouPlayUrl?> getSongUrl(
-    String hash, {
-    String quality = KugouQuality.standard,
-    String? albumId,
-    String? albumAudioId,
-  }) async {
-    final params = <String, dynamic>{
-      'hash': hash.toLowerCase(),
-      'quality': quality,
-    };
+  Future<KugouPlayUrl?> getSongUrl(String hash, {String quality = KugouQuality.standard, String? albumId, String? albumAudioId}) async {
+    final params = <String, dynamic>{'hash': hash.toLowerCase(), 'quality': quality};
     if (albumId != null) params['album_id'] = albumId;
     if (albumAudioId != null) params['album_audio_id'] = albumAudioId;
-
-    // VIP 用户优先用 /song/url/new（→ /v6/priv_url），它会读取
-    // Authorization 头里的 vip_token，能拿到完整音质。
-    // 注意：如果 _getSongUrlNew 因为 priv_status=0 / fail_process 等
-    // 原因返回 null，说明酷狗没认 VIP。这种情况继续走 /song/url
-    // 也只会拿到 30s 试听片段，必须直接返回 null，让上层提示
-    // 用户 VIP 不生效或登录失效。
     if (hasVipToken) {
-      final vipUrl = await _getSongUrlNew(
-        hash,
-        quality: quality,
-        albumId: albumId,
-        albumAudioId: albumAudioId,
-      );
+      final vipUrl = await _getSongUrlNew(hash, quality: quality, albumId: albumId, albumAudioId: albumAudioId);
       if (vipUrl != null) return vipUrl;
-            return null;
+      return null;
     }
-
     var json = await _get(KugouEndpoints.songUrl, queryParameters: params);
     if (json == null) return null;
-
     var data = _extractData(json['data'] ?? json);
     final errcode = data['errcode'];
-
     if (errcode != null && errcode == 20028) {
-            await registerDevice();
+      await registerDevice();
       if (_dfid == null) return null;
-
       json = await _get(KugouEndpoints.songUrl, queryParameters: params);
       if (json == null) return null;
       data = _extractData(json['data'] ?? json);
     }
-
     final status = data['status'];
     final errorCode = data['error_code'];
-    if (status == 2 &&
-        errorCode == 20018 &&
-        _token != null &&
-        _userid != null) {
-            final refreshed = await _tryRefreshToken();
+    if (status == 2 && errorCode == 20018 && _token != null && _userid != null) {
+      final refreshed = await _tryRefreshToken();
       if (refreshed) {
-        // refresh 后 vip_token 也会更新，重试 /song/url/new 一次
         if (hasVipToken) {
-          final vipUrl = await _getSongUrlNew(
-            hash,
-            quality: quality,
-            albumId: albumId,
-            albumAudioId: albumAudioId,
-          );
+          final vipUrl = await _getSongUrlNew(hash, quality: quality, albumId: albumId, albumAudioId: albumAudioId);
           if (vipUrl != null) return vipUrl;
         }
         json = await _get(KugouEndpoints.songUrl, queryParameters: params);
         if (json == null) return null;
         data = _extractData(json['data'] ?? json);
-        if (data['url'] != null) {
-          return KugouPlayUrl.fromJson(data);
-        }
+        if (data['url'] != null) return KugouPlayUrl.fromJson(data);
       }
     }
-
     try {
-      if (data['url'] != null) {
-        return KugouPlayUrl.fromJson(data);
-      }
-
+      if (data['url'] != null) return KugouPlayUrl.fromJson(data);
       final failProcess = data['fail_process'];
-      if (failProcess is List &&
-          failProcess.contains('buy') &&
-          quality != KugouQuality.standard) {
-                params['quality'] = KugouQuality.standard;
+      if (failProcess is List && failProcess.contains('buy') && quality != KugouQuality.standard) {
+        params['quality'] = KugouQuality.standard;
         json = await _get(KugouEndpoints.songUrl, queryParameters: params);
         if (json != null) {
           final fallbackData = _extractData(json['data'] ?? json);
-          if (fallbackData['url'] != null) {
-            return KugouPlayUrl.fromJson(fallbackData);
-          }
+          if (fallbackData['url'] != null) return KugouPlayUrl.fromJson(fallbackData);
         }
       }
-
-      // VIP 用户不要再走 free_part=1 主动拉 30 秒试听。
-      // 试听只对未登录 / 没有 VIP 凭证的人兜底。
-      if (hasVipToken) {
-                return null;
-      }
-
-            final freeParams = Map<String, dynamic>.from(params);
+      if (hasVipToken) return null;
+      final freeParams = Map<String, dynamic>.from(params);
       freeParams['free_part'] = 1;
-      final freeJson = await _get(
-        KugouEndpoints.songUrl,
-        queryParameters: freeParams,
-      );
+      final freeJson = await _get(KugouEndpoints.songUrl, queryParameters: freeParams);
       if (freeJson != null) {
         final freeData = _extractData(freeJson['data'] ?? freeJson);
-        if (freeData['url'] != null) {
-          return KugouPlayUrl.fromJson(freeData);
-        }
+        if (freeData['url'] != null) return KugouPlayUrl.fromJson(freeData);
       }
-
-          } catch (e) {
-          }
+    } catch (e) {}
     return null;
   }
 
-  /// /song/url/new 走的是 /v6/priv_url，服务端会读 cookie 里的 vip_token
-  /// 并作为 tracker_param.viptoken 上传给酷狗。返回结构通常为：
-  ///   { data: { url: [...], bitRate, priv_status, fail_process, ... } }
-  ///
-  /// 关键：必须检查 `priv_status`，0 表示酷狗没认 VIP，返回的是 30s/1min
-  /// 试听片段；`fail_process` 含 `buy` 时也是同样情况。这两种情况下
-  /// 即便 url 字段非空也不能直接拿来用，否则会播放到片段末尾就跳结束。
-  Future<KugouPlayUrl?> _getSongUrlNew(
-    String hash, {
-    String quality = KugouQuality.standard,
-    String? albumId,
-    String? albumAudioId,
-  }) async {
-    final query = <String, dynamic>{
-      'hash': hash.toLowerCase(),
-      'quality': quality,
-    };
+  Future<KugouPlayUrl?> _getSongUrlNew(String hash, {String quality = KugouQuality.standard, String? albumId, String? albumAudioId}) async {
+    final query = <String, dynamic>{'hash': hash.toLowerCase(), 'quality': quality};
     if (albumId != null) query['album_id'] = albumId;
     if (albumAudioId != null) query['album_audio_id'] = albumAudioId;
     try {
-      final json = await _get(
-        KugouEndpoints.songUrlNew,
-        queryParameters: query,
-      );
-      if (json == null) {
-                return null;
-      }
+      final json = await _get(KugouEndpoints.songUrlNew, queryParameters: query);
+      if (json == null) return null;
       final data = _extractData(json['data'] ?? json);
       final rawUrl = data['url'];
-      final hasUrl = rawUrl is List
-          ? rawUrl.isNotEmpty
-          : (rawUrl is String && rawUrl.isNotEmpty);
-
+      final hasUrl = rawUrl is List ? rawUrl.isNotEmpty : (rawUrl is String && rawUrl.isNotEmpty);
       if (hasUrl) {
-        // 1) priv_status 显式标记 VIP 是否生效。
-        //    酷狗约定：1 = VIP 验证通过给完整音源，0 = 走试听/包月/购买。
         final privStatus = _parseInt(data['priv_status']);
-        if (privStatus == 0) {
-                    return null;
-        }
-
-        // 2) fail_process 含 buy/pkg 时也是试听兜底，丢弃。
+        if (privStatus == 0) return null;
         final failProcess = data['fail_process'];
-        if (failProcess is List && failProcess.isNotEmpty) {
-                    return null;
-        }
-
-        // 3) 用 fileSize 兜底识别：3~5 分钟的普通歌曲通常 > 2MB，
-        //    如果不到 200KB 几乎一定是 30s 试听片段。
+        if (failProcess is List && failProcess.isNotEmpty) return null;
         final fileSize = _parseInt(data['fileSize'] ?? data['file_size']);
-        if (fileSize > 0 && fileSize < 200 * 1024) {
-                    return null;
-        }
-
-                return KugouPlayUrl.fromJson({...data, 'quality': quality});
+        if (fileSize > 0 && fileSize < 200 * 1024) return null;
+        return KugouPlayUrl.fromJson({...data, 'quality': quality});
       }
-          } catch (e) {
-          }
+    } catch (e) {}
     return null;
   }
 
@@ -674,114 +456,55 @@ class KugouApiClient {
     if (json == null) return null;
     try {
       final data = json['data'] as Map<String, dynamic>? ?? json;
-      final list =
-          data['song_list'] ??
-          data['songs'] ??
-          data['list'] ??
-          data['info'] ??
-          [];
-      return (list as List<dynamic>)
-          .map((e) => KugouSongDetail.fromJson(e as Map<String, dynamic>))
-          .toList();
-    } catch (e) {
-      return null;
-    }
+      final list = data['song_list'] ?? data['songs'] ?? data['list'] ?? data['info'] ?? [];
+      return (list as List<dynamic>).map((e) => KugouSongDetail.fromJson(e as Map<String, dynamic>)).toList();
+    } catch (e) { return null; }
   }
 
   Future<KugouSongDetail?> getSongDetail(String hash) async {
-    final json = await _get(
-      KugouEndpoints.songDetail,
-      queryParameters: {'hash': hash},
-    );
+    final json = await _get(KugouEndpoints.songDetail, queryParameters: {'hash': hash});
     if (json == null) return null;
     try {
       final rawData = json['data'] ?? json;
       Map<String, dynamic> data;
-      if (rawData is List && rawData.isNotEmpty) {
-        data = rawData.first as Map<String, dynamic>;
-      } else if (rawData is Map<String, dynamic>) {
-        data = rawData;
-      } else {
-        return null;
-      }
+      if (rawData is List && rawData.isNotEmpty) { data = rawData.first as Map<String, dynamic>; }
+      else if (rawData is Map<String, dynamic>) { data = rawData; }
+      else { return null; }
       return KugouSongDetail.fromJson(data);
-    } catch (e) {
-            return null;
-    }
+    } catch (e) { return null; }
   }
 
-  Future<KugouSongClimax?> getSongClimax(
-    String hash, {
-    String? albumAudioId,
-  }) async {
+  Future<KugouSongClimax?> getSongClimax(String hash, {String? albumAudioId}) async {
     final params = <String, dynamic>{'hash': hash};
     if (albumAudioId != null) params['album_audio_id'] = albumAudioId;
     final json = await _get(KugouEndpoints.songClimax, queryParameters: params);
     if (json == null) return null;
-    try {
-      return KugouSongClimax.fromJson(json);
-    } catch (e) {
-      return null;
-    }
+    try { return KugouSongClimax.fromJson(json); } catch (e) { return null; }
   }
 
   Future<KugouSongRanking?> getSongRanking(String hash) async {
-    final json = await _get(
-      KugouEndpoints.songRanking,
-      queryParameters: {'hash': hash},
-    );
+    final json = await _get(KugouEndpoints.songRanking, queryParameters: {'hash': hash});
     if (json == null) return null;
-    try {
-      return KugouSongRanking.fromJson(json);
-    } catch (e) {
-      return null;
-    }
+    try { return KugouSongRanking.fromJson(json); } catch (e) { return null; }
   }
 
   Future<List<KugouSongDetail>?> getAudioRelated(String hash) async {
-    final json = await _get(
-      KugouEndpoints.audioRelated,
-      queryParameters: {'hash': hash},
-    );
+    final json = await _get(KugouEndpoints.audioRelated, queryParameters: {'hash': hash});
     if (json == null) return null;
     try {
       final data = json['data'] as Map<String, dynamic>? ?? json;
       final list = data['list'] ?? data['songs'] ?? data['info'] ?? [];
-      return (list as List<dynamic>)
-          .map((e) => KugouSongDetail.fromJson(e as Map<String, dynamic>))
-          .toList();
-    } catch (e) {
-      return null;
-    }
+      return (list as List<dynamic>).map((e) => KugouSongDetail.fromJson(e as Map<String, dynamic>)).toList();
+    } catch (e) { return null; }
   }
 
-  // ==================== Lyric ====================
-
-  Future<KugouLyric?> getLyric(
-    String hash, {
-    String? accesskey,
-    String? songName,
-    String fmt = 'lrc',
-    bool decode = true,
-  }) async {
+  Future<KugouLyric?> getLyric(String hash, {String? accesskey, String? songName, String fmt = 'lrc', bool decode = true}) async {
     String? lyricId;
     String? lyricAccesskey;
-
-    Map<String, dynamic>? searchResult = await _get(
-      KugouEndpoints.searchLyric,
-      queryParameters: {'hash': hash.toLowerCase()},
-    );
-
-    if (searchResult != null &&
-        !_hasCandidates(searchResult) &&
-        songName != null &&
-        songName.isNotEmpty) {
-            searchResult = await _get(
-        KugouEndpoints.searchLyric,
-        queryParameters: {'keywords': songName, 'hash': hash.toLowerCase()},
-      );
+    Map<String, dynamic>? searchResult = await _get(KugouEndpoints.searchLyric, queryParameters: {'hash': hash.toLowerCase()});
+    if (searchResult != null && !_hasCandidates(searchResult) && songName != null && songName.isNotEmpty) {
+      searchResult = await _get(KugouEndpoints.searchLyric, queryParameters: {'keywords': songName, 'hash': hash.toLowerCase()});
     }
-
     if (searchResult != null) {
       try {
         final candidates = searchResult['candidates'];
@@ -790,167 +513,98 @@ class KugouApiClient {
           lyricId = first['id']?.toString();
           lyricAccesskey = first['accesskey']?.toString();
         }
-      } catch (e) {
-              }
+      } catch (e) {}
     }
-
-    if (lyricId == null) {
-            return null;
+    if (lyricId == null) return null;
+    final bool dualRequest = (fmt == 'lrc');
+    if (dualRequest) {
+      final results = await Future.wait([
+        _fetchLyricContent(lyricId, lyricAccesskey, 'lrc', decode),
+        _fetchLyricContent(lyricId, lyricAccesskey, 'krc', decode),
+      ]);
+      return mergeLyricResponses(results[0], results[1]);
     }
-
-    final params = <String, dynamic>{
-      'id': lyricId,
-      'fmt': fmt,
-      'decode': decode.toString(),
-    };
-    if (lyricAccesskey != null) params['accesskey'] = lyricAccesskey;
-
-    final json = await _get(KugouEndpoints.lyric, queryParameters: params);
+    final json = await _fetchLyricContent(lyricId, lyricAccesskey, fmt, decode);
     if (json == null) return null;
-    try {
-      final data = json['data'] as Map<String, dynamic>? ?? json;
-      return KugouLyric.fromJson(data);
-    } catch (e) {
-            return null;
-    }
+    try { return KugouLyric.fromJson(json); } catch (e) { return null; }
   }
 
-  // ==================== Comment ====================
+  Future<Map<String, dynamic>?> _fetchLyricContent(String lyricId, String? lyricAccesskey, String fmt, bool decode) async {
+    try {
+      final params = <String, dynamic>{'id': lyricId, 'fmt': fmt, 'decode': decode.toString()};
+      if (lyricAccesskey != null) params['accesskey'] = lyricAccesskey;
+      final json = await _get(KugouEndpoints.lyric, queryParameters: params);
+      if (json == null) return null;
+      return json['data'] as Map<String, dynamic>? ?? json;
+    } catch (e) { return null; }
+  }
 
-  Future<KugouCommentList?> getComments(
-    String hash, {
-    String? albumAudioId,
-    int page = 1,
-    int pagesize = 20,
-  }) async {
-    final params = <String, dynamic>{
-      'hash': hash,
-      'page': page,
-      'pagesize': pagesize,
-    };
+  static KugouLyric? mergeLyricResponses(Map<String, dynamic>? lrcJson, Map<String, dynamic>? krcJson) {
+    if (lrcJson == null && krcJson == null) return null;
+    final lrcLyric = lrcJson != null ? KugouLyric.fromJson(lrcJson) : null;
+    final krcLyric = krcJson != null ? KugouLyric.fromJson(krcJson) : null;
+    String? krcContent;
+    if (krcJson != null) {
+      final explicitKrc = krcJson['decodeKrcContent'] ?? krcJson['decoded_krc_content'] ?? krcJson['krcContent'];
+      if (explicitKrc != null) { krcContent = explicitKrc.toString(); }
+      else if (krcJson['decodeContent'] != null) { krcContent = krcJson['decodeContent'].toString(); }
+    }
+    return KugouLyric(
+      content: lrcLyric?.content ?? krcLyric?.content ?? '',
+      decodedContent: lrcLyric?.decodedContent,
+      decodedKrcContent: krcContent,
+      translatedContent: lrcLyric?.translatedContent ?? krcLyric?.translatedContent,
+    );
+  }
+
+  Future<KugouCommentList?> getComments(String hash, {String? albumAudioId, int page = 1, int pagesize = 20}) async {
+    final params = <String, dynamic>{'hash': hash, 'page': page, 'pagesize': pagesize};
     if (albumAudioId != null) params['album_audio_id'] = albumAudioId;
-    final json = await _get(
-      KugouEndpoints.commentMusic,
-      queryParameters: params,
-    );
+    final json = await _get(KugouEndpoints.commentMusic, queryParameters: params);
     if (json == null) return null;
-    try {
-      return KugouCommentList.fromJson(json);
-    } catch (e) {
-            return null;
-    }
+    try { return KugouCommentList.fromJson(json); } catch (e) { return null; }
   }
 
-  Future<KugouCommentList?> getCommentsByClassify(
-    String hash, {
-    String? classify,
-    int page = 1,
-    int pagesize = 20,
-  }) async {
-    final params = <String, dynamic>{
-      'hash': hash,
-      'page': page,
-      'pagesize': pagesize,
-    };
+  Future<KugouCommentList?> getCommentsByClassify(String hash, {String? classify, int page = 1, int pagesize = 20}) async {
+    final params = <String, dynamic>{'hash': hash, 'page': page, 'pagesize': pagesize};
     if (classify != null) params['classify'] = classify;
-    final json = await _get(
-      KugouEndpoints.commentMusicClassify,
-      queryParameters: params,
-    );
+    final json = await _get(KugouEndpoints.commentMusicClassify, queryParameters: params);
     if (json == null) return null;
-    try {
-      return KugouCommentList.fromJson(json);
-    } catch (e) {
-      return null;
-    }
+    try { return KugouCommentList.fromJson(json); } catch (e) { return null; }
   }
 
-  Future<KugouCommentList?> getCommentsByHotword(
-    String hash, {
-    String? hotword,
-    int page = 1,
-  }) async {
+  Future<KugouCommentList?> getCommentsByHotword(String hash, {String? hotword, int page = 1}) async {
     final params = <String, dynamic>{'hash': hash, 'page': page};
     if (hotword != null) params['hotword'] = hotword;
-    final json = await _get(
-      KugouEndpoints.commentMusicHotword,
-      queryParameters: params,
-    );
+    final json = await _get(KugouEndpoints.commentMusicHotword, queryParameters: params);
     if (json == null) return null;
-    try {
-      return KugouCommentList.fromJson(json);
-    } catch (e) {
-      return null;
-    }
+    try { return KugouCommentList.fromJson(json); } catch (e) { return null; }
   }
 
-  Future<KugouCommentList?> getFloorComments(
-    String commentId, {
-    int page = 1,
-  }) async {
-    final json = await _get(
-      KugouEndpoints.commentFloor,
-      queryParameters: {'commentid': commentId, 'page': page},
-    );
+  Future<KugouCommentList?> getFloorComments(String commentId, {int page = 1}) async {
+    final json = await _get(KugouEndpoints.commentFloor, queryParameters: {'commentid': commentId, 'page': page});
     if (json == null) return null;
-    try {
-      return KugouCommentList.fromJson(json);
-    } catch (e) {
-      return null;
-    }
+    try { return KugouCommentList.fromJson(json); } catch (e) { return null; }
   }
 
-  Future<KugouCommentList?> getPlaylistComments(
-    String specialId, {
-    int page = 1,
-  }) async {
-    final json = await _get(
-      KugouEndpoints.commentPlaylist,
-      queryParameters: {'specialid': specialId, 'page': page},
-    );
+  Future<KugouCommentList?> getPlaylistComments(String specialId, {int page = 1}) async {
+    final json = await _get(KugouEndpoints.commentPlaylist, queryParameters: {'specialid': specialId, 'page': page});
     if (json == null) return null;
-    try {
-      return KugouCommentList.fromJson(json);
-    } catch (e) {
-      return null;
-    }
+    try { return KugouCommentList.fromJson(json); } catch (e) { return null; }
   }
 
-  Future<KugouCommentList?> getAlbumComments(
-    String albumId, {
-    int page = 1,
-  }) async {
-    final json = await _get(
-      KugouEndpoints.commentAlbum,
-      queryParameters: {'album_id': albumId, 'page': page},
-    );
+  Future<KugouCommentList?> getAlbumComments(String albumId, {int page = 1}) async {
+    final json = await _get(KugouEndpoints.commentAlbum, queryParameters: {'album_id': albumId, 'page': page});
     if (json == null) return null;
-    try {
-      return KugouCommentList.fromJson(json);
-    } catch (e) {
-      return null;
-    }
+    try { return KugouCommentList.fromJson(json); } catch (e) { return null; }
   }
 
-  // ==================== Playlist ====================
-
-  Future<KugouPlaylistCategory?> getPlaylist({
-    String? categoryId,
-    int page = 1,
-  }) async {
+  Future<KugouPlaylistCategory?> getPlaylist({String? categoryId, int page = 1}) async {
     final params = <String, dynamic>{'page': page};
     if (categoryId != null) params['category_id'] = categoryId;
-
-    final json = await _get(
-      KugouEndpoints.topPlaylist,
-      queryParameters: params,
-    );
+    final json = await _get(KugouEndpoints.topPlaylist, queryParameters: params);
     if (json == null) return null;
-    try {
-      return KugouPlaylistCategory.fromJson(json);
-    } catch (e) {
-            return null;
-    }
+    try { return KugouPlaylistCategory.fromJson(json); } catch (e) { return null; }
   }
 
   Future<List<KugouPlaylistBrief>?> getPlaylistDetail(String ids) async {
@@ -958,578 +612,194 @@ class KugouApiClient {
     if (json == null) return null;
     try {
       final data = json['data'];
-      if (data is List) {
-        return data
-            .map((e) => KugouPlaylistBrief.fromJson(e as Map<String, dynamic>))
-            .toList();
-      }
+      if (data is List) { return data.map((e) => KugouPlaylistBrief.fromJson(e as Map<String, dynamic>)).toList(); }
       return [];
-    } catch (e) {
-            return null;
-    }
+    } catch (e) { return null; }
   }
 
-  Future<KugouPlaylistSongs?> getPlaylistSongs(
-    String globalCollectionId, {
-    int page = 1,
-    int pagesize = 30,
-    bool noCache = false,
-  }) async {
-    final params = <String, dynamic>{
-      'global_collection_id': globalCollectionId,
-      'page': page,
-      'pagesize': pagesize,
-    };
-    final json = await _get(
-      KugouEndpoints.playlistTrackAll,
-      queryParameters: params,
-      noCache: noCache,
-    );
+  Future<KugouPlaylistSongs?> getPlaylistSongs(String globalCollectionId, {int page = 1, int pagesize = 30, bool noCache = false}) async {
+    final params = <String, dynamic>{'global_collection_id': globalCollectionId, 'page': page, 'pagesize': pagesize};
+    final json = await _get(KugouEndpoints.playlistTrackAll, queryParameters: params, noCache: noCache);
     if (json == null) return null;
-    try {
-      return KugouPlaylistSongs.fromJson(json);
-    } catch (e) {
-            return null;
-    }
+    try { return KugouPlaylistSongs.fromJson(json); } catch (e) { return null; }
   }
 
-  Future<KugouPlaylistSongs?> getPlaylistSongsByListid({
-    required String listid,
-    int page = 1,
-    int pagesize = 30,
-    bool noCache = false,
-  }) async {
-    final params = <String, dynamic>{
-      'listid': listid,
-      'page': page,
-      'pagesize': pagesize,
-    };
-    final json = await _get(
-      KugouEndpoints.playlistTrackAllNew,
-      queryParameters: params,
-      noCache: noCache,
-    );
+  Future<KugouPlaylistSongs?> getPlaylistSongsByListid({required String listid, int page = 1, int pagesize = 30, bool noCache = false}) async {
+    final params = <String, dynamic>{'listid': listid, 'page': page, 'pagesize': pagesize};
+    final json = await _get(KugouEndpoints.playlistTrackAllNew, queryParameters: params, noCache: noCache);
     if (json == null) return null;
-    try {
-      return KugouPlaylistSongs.fromJson(json);
-    } catch (e) {
-            return null;
-    }
+    try { return KugouPlaylistSongs.fromJson(json); } catch (e) { return null; }
   }
 
   Future<Map<String, dynamic>?> getPlaylistSimilar(String id) async {
-    return await _get(
-      KugouEndpoints.playlistSimilar,
-      queryParameters: {'id': id},
-    );
+    return await _get(KugouEndpoints.playlistSimilar, queryParameters: {'id': id});
   }
 
-  Future<Map<String, dynamic>?> getPlaylistEffect() async {
-    return await _get(KugouEndpoints.playlistEffect);
-  }
-
-  Future<Map<String, dynamic>?> getPlaylistTags() async {
-    return await _get(KugouEndpoints.playlistTags);
-  }
-
-  // ==================== Sheet ====================
-
-  Future<Map<String, dynamic>?> getSheetExplore({int page = 1}) async {
-    return await _get(
-      KugouEndpoints.sheetExplore,
-      queryParameters: {'page': page},
-    );
-  }
-
-  Future<Map<String, dynamic>?> getSheetDetail(String id) async {
-    return await _get(KugouEndpoints.sheetDetail, queryParameters: {'id': id});
-  }
-
-  Future<Map<String, dynamic>?> getSheetSong(String id) async {
-    return await _get(KugouEndpoints.sheetSong, queryParameters: {'id': id});
-  }
-
-  Future<Map<String, dynamic>?> getSheetTags() async {
-    return await _get(KugouEndpoints.sheetTags);
-  }
-
-  // ==================== Theme ====================
-
-  Future<Map<String, dynamic>?> getThemeMusic() async {
-    return await _get(KugouEndpoints.themeMusic);
-  }
-
-  Future<Map<String, dynamic>?> getThemeMusicDetail(String id) async {
-    return await _get(
-      KugouEndpoints.themeMusicDetail,
-      queryParameters: {'id': id},
-    );
-  }
-
-  Future<Map<String, dynamic>?> getThemePlaylist() async {
-    return await _get(KugouEndpoints.themePlaylist);
-  }
-
-  Future<Map<String, dynamic>?> getThemePlaylistTrack(String id) async {
-    return await _get(
-      KugouEndpoints.themePlaylistTrack,
-      queryParameters: {'id': id},
-    );
-  }
-
-  // ==================== Rank ====================
+  Future<Map<String, dynamic>?> getPlaylistEffect() async { return await _get(KugouEndpoints.playlistEffect); }
+  Future<Map<String, dynamic>?> getPlaylistTags() async { return await _get(KugouEndpoints.playlistTags); }
+  Future<Map<String, dynamic>?> getSheetExplore({int page = 1}) async { return await _get(KugouEndpoints.sheetExplore, queryParameters: {'page': page}); }
+  Future<Map<String, dynamic>?> getSheetDetail(String id) async { return await _get(KugouEndpoints.sheetDetail, queryParameters: {'id': id}); }
+  Future<Map<String, dynamic>?> getSheetSong(String id) async { return await _get(KugouEndpoints.sheetSong, queryParameters: {'id': id}); }
+  Future<Map<String, dynamic>?> getSheetTags() async { return await _get(KugouEndpoints.sheetTags); }
+  Future<Map<String, dynamic>?> getThemeMusic() async { return await _get(KugouEndpoints.themeMusic); }
+  Future<Map<String, dynamic>?> getThemeMusicDetail(String id) async { return await _get(KugouEndpoints.themeMusicDetail, queryParameters: {'id': id}); }
+  Future<Map<String, dynamic>?> getThemePlaylist() async { return await _get(KugouEndpoints.themePlaylist); }
+  Future<Map<String, dynamic>?> getThemePlaylistTrack(String id) async { return await _get(KugouEndpoints.themePlaylistTrack, queryParameters: {'id': id}); }
 
   Future<KugouRankList?> getRankList({int withsong = 1}) async {
-    final json = await _get(
-      KugouEndpoints.rankList,
-      queryParameters: {'withsong': withsong},
-    );
+    final json = await _get(KugouEndpoints.rankList, queryParameters: {'withsong': withsong});
     if (json == null) return null;
-    try {
-      return KugouRankList.fromJson(json);
-    } catch (e) {
-            return null;
-    }
+    try { return KugouRankList.fromJson(json); } catch (e) { return null; }
   }
 
-  Future<Map<String, dynamic>?> getRankTop() async {
-    return await _get(KugouEndpoints.rankTop);
-  }
+  Future<Map<String, dynamic>?> getRankTop() async { return await _get(KugouEndpoints.rankTop); }
+  Future<Map<String, dynamic>?> getRankVol(String rankId) async { return await _get(KugouEndpoints.rankVol, queryParameters: {'rankid': rankId}); }
+  Future<Map<String, dynamic>?> getRankInfo(String rankId) async { return await _get(KugouEndpoints.rankInfo, queryParameters: {'rankid': rankId}); }
 
-  Future<Map<String, dynamic>?> getRankVol(String rankId) async {
-    return await _get(
-      KugouEndpoints.rankVol,
-      queryParameters: {'rankid': rankId},
-    );
-  }
-
-  Future<Map<String, dynamic>?> getRankInfo(String rankId) async {
-    return await _get(
-      KugouEndpoints.rankInfo,
-      queryParameters: {'rankid': rankId},
-    );
-  }
-
-  Future<List<KugouSongDetail>?> getRankAudio({
-    required String rankId,
-    int rankCid = 0,
-    int page = 1,
-    int pagesize = 30,
-  }) async {
-    final json = await _get(
-      KugouEndpoints.rankAudio,
-      queryParameters: {
-        'rankid': rankId,
-        'rank_cid': rankCid,
-        'page': page,
-        'pagesize': pagesize,
-      },
-    );
+  Future<List<KugouSongDetail>?> getRankAudio({required String rankId, int rankCid = 0, int page = 1, int pagesize = 30}) async {
+    final json = await _get(KugouEndpoints.rankAudio, queryParameters: {'rankid': rankId, 'rank_cid': rankCid, 'page': page, 'pagesize': pagesize});
     if (json == null) return null;
     try {
       final data = json['data'] as Map<String, dynamic>? ?? json;
-      final list =
-          data['songlist'] ??
-          data['list'] ??
-          data['songs'] ??
-          data['info'] ??
-          [];
-      return (list as List<dynamic>)
-          .map((e) => KugouSongDetail.fromJson(e as Map<String, dynamic>))
-          .toList();
-    } catch (e) {
-            return null;
-    }
+      final list = data['songlist'] ?? data['list'] ?? data['songs'] ?? data['info'] ?? [];
+      return (list as List<dynamic>).map((e) => KugouSongDetail.fromJson(e as Map<String, dynamic>)).toList();
+    } catch (e) { return null; }
   }
-
-  // ==================== Everyday ====================
 
   Future<List<KugouSongDetail>?> getRecommendDaily() async {
     final json = await _get(KugouEndpoints.everydayRecommend);
     if (json == null) return null;
     try {
       final data = json['data'] as Map<String, dynamic>? ?? json;
-      final list =
-          data['song_list'] ??
-          data['songs'] ??
-          data['list'] ??
-          data['info'] ??
-          [];
-      return (list as List<dynamic>)
-          .map((e) => KugouSongDetail.fromJson(e as Map<String, dynamic>))
-          .toList();
-    } catch (e) {
-            return null;
-    }
+      final list = data['song_list'] ?? data['songs'] ?? data['list'] ?? data['info'] ?? [];
+      return (list as List<dynamic>).map((e) => KugouSongDetail.fromJson(e as Map<String, dynamic>)).toList();
+    } catch (e) { return null; }
   }
 
-  Future<Map<String, dynamic>?> getEverydayHistory() async {
-    return await _get(KugouEndpoints.everydayHistory);
-  }
+  Future<Map<String, dynamic>?> getEverydayHistory() async { return await _get(KugouEndpoints.everydayHistory); }
+  Future<Map<String, dynamic>?> getEverydayStyleRecommend() async { return await _get(KugouEndpoints.everydayStyleRecommend); }
+  Future<Map<String, dynamic>?> getTopAlbum({int page = 1}) async { return await _get(KugouEndpoints.topAlbum, queryParameters: {'page': page}); }
+  Future<Map<String, dynamic>?> getTopSong({int page = 1}) async { return await _get(KugouEndpoints.topSong, queryParameters: {'page': page}); }
+  Future<Map<String, dynamic>?> getYueku() async { return await _get(KugouEndpoints.yueku); }
+  Future<Map<String, dynamic>?> getYuekuBanner() async { return await _get(KugouEndpoints.yuekuBanner); }
+  Future<Map<String, dynamic>?> getYuekuFm() async { return await _get(KugouEndpoints.yuekuFm); }
+  Future<Map<String, dynamic>?> getIpHome() async { return await _get(KugouEndpoints.ipHome); }
+  Future<Map<String, dynamic>?> getIpDateil() async { return await _get(KugouEndpoints.ipDateil); }
+  Future<Map<String, dynamic>?> getIpPlaylist() async { return await _get(KugouEndpoints.ipPlaylist); }
+  Future<Map<String, dynamic>?> getIpZone() async { return await _get(KugouEndpoints.ipZone); }
+  Future<Map<String, dynamic>?> getIpZoneHome(String zoneId) async { return await _get(KugouEndpoints.ipZoneHome, queryParameters: {'zone_id': zoneId}); }
+  Future<Map<String, dynamic>?> getFmRecommend() async { return await _get(KugouEndpoints.fmRecommend); }
+  Future<Map<String, dynamic>?> getFmClass() async { return await _get(KugouEndpoints.fmClass); }
+  Future<Map<String, dynamic>?> getFmImage() async { return await _get(KugouEndpoints.fmImage); }
+  Future<Map<String, dynamic>?> getFmSongs(String fmId) async { return await _get(KugouEndpoints.fmSongs, queryParameters: {'id': fmId}); }
 
-  Future<Map<String, dynamic>?> getEverydayStyleRecommend() async {
-    return await _get(KugouEndpoints.everydayStyleRecommend);
-  }
-
-  // ==================== Top ====================
-
-  Future<Map<String, dynamic>?> getTopAlbum({int page = 1}) async {
-    return await _get(KugouEndpoints.topAlbum, queryParameters: {'page': page});
-  }
-
-  Future<Map<String, dynamic>?> getTopSong({int page = 1}) async {
-    return await _get(KugouEndpoints.topSong, queryParameters: {'page': page});
-  }
-
-  // ==================== Yueku ====================
-
-  Future<Map<String, dynamic>?> getYueku() async {
-    return await _get(KugouEndpoints.yueku);
-  }
-
-  Future<Map<String, dynamic>?> getYuekuBanner() async {
-    return await _get(KugouEndpoints.yuekuBanner);
-  }
-
-  Future<Map<String, dynamic>?> getYuekuFm() async {
-    return await _get(KugouEndpoints.yuekuFm);
-  }
-
-  // ==================== IP (Edit Picks) ====================
-
-  Future<Map<String, dynamic>?> getIpHome() async {
-    return await _get(KugouEndpoints.ipHome);
-  }
-
-  Future<Map<String, dynamic>?> getIpDateil() async {
-    return await _get(KugouEndpoints.ipDateil);
-  }
-
-  Future<Map<String, dynamic>?> getIpPlaylist() async {
-    return await _get(KugouEndpoints.ipPlaylist);
-  }
-
-  Future<Map<String, dynamic>?> getIpZone() async {
-    return await _get(KugouEndpoints.ipZone);
-  }
-
-  Future<Map<String, dynamic>?> getIpZoneHome(String zoneId) async {
-    return await _get(
-      KugouEndpoints.ipZoneHome,
-      queryParameters: {'zone_id': zoneId},
-    );
-  }
-
-  // ==================== FM (Radio) ====================
-
-  Future<Map<String, dynamic>?> getFmRecommend() async {
-    return await _get(KugouEndpoints.fmRecommend);
-  }
-
-  Future<Map<String, dynamic>?> getFmClass() async {
-    return await _get(KugouEndpoints.fmClass);
-  }
-
-  Future<Map<String, dynamic>?> getFmImage() async {
-    return await _get(KugouEndpoints.fmImage);
-  }
-
-  Future<Map<String, dynamic>?> getFmSongs(String fmId) async {
-    return await _get(KugouEndpoints.fmSongs, queryParameters: {'id': fmId});
-  }
-
-  // ==================== Personal FM ====================
-
-  Future<List<KugouSongDetail>?> getPersonalFm({
-    String? mode,
-    int? songPoolId,
-    String? hash,
-    String? songId,
-    String? action,
-  }) async {
+  Future<List<KugouSongDetail>?> getPersonalFm({String? mode, int? songPoolId, String? hash, String? songId, String? action}) async {
     final params = <String, dynamic>{};
     if (mode != null) params['mode'] = mode;
     if (songPoolId != null) params['song_pool_id'] = songPoolId.toString();
     if (hash != null) params['hash'] = hash;
     if (songId != null) params['songid'] = songId;
     if (action != null) params['action'] = action;
-
     final json = await _get(KugouEndpoints.personalFm, queryParameters: params);
     if (json == null) return null;
     try {
       final data = json['data'] as Map<String, dynamic>? ?? json;
-      final list =
-          data['song_list'] ??
-          data['songs'] ??
-          data['list'] ??
-          data['info'] ??
-          [];
-      return (list as List<dynamic>)
-          .map((e) => KugouSongDetail.fromJson(e as Map<String, dynamic>))
-          .toList();
-    } catch (e) {
-            return null;
-    }
+      final list = data['song_list'] ?? data['songs'] ?? data['list'] ?? data['info'] ?? [];
+      return (list as List<dynamic>).map((e) => KugouSongDetail.fromJson(e as Map<String, dynamic>)).toList();
+    } catch (e) { return null; }
   }
 
-  // ==================== Scene ====================
-
-  Future<Map<String, dynamic>?> getSceneLists() async {
-    return await _get(KugouEndpoints.sceneLists);
-  }
-
-  Future<Map<String, dynamic>?> getSceneMusic() async {
-    return await _get(KugouEndpoints.sceneMusic);
-  }
-
-  Future<Map<String, dynamic>?> getSceneModule(String moduleId) async {
-    return await _get(
-      KugouEndpoints.sceneModule,
-      queryParameters: {'id': moduleId},
-    );
-  }
-
-  Future<Map<String, dynamic>?> getSceneModuleInfo(String moduleId) async {
-    return await _get(
-      KugouEndpoints.sceneModuleInfo,
-      queryParameters: {'id': moduleId},
-    );
-  }
-
-  Future<Map<String, dynamic>?> getSceneCollectionList(String moduleId) async {
-    return await _get(
-      KugouEndpoints.sceneCollectionList,
-      queryParameters: {'id': moduleId},
-    );
-  }
-
-  Future<Map<String, dynamic>?> getSceneVideoList(String moduleId) async {
-    return await _get(
-      KugouEndpoints.sceneVideoList,
-      queryParameters: {'id': moduleId},
-    );
-  }
-
-  Future<Map<String, dynamic>?> getSceneAudioList(
-    String moduleId, {
-    String? collectionId,
-  }) async {
+  Future<Map<String, dynamic>?> getSceneLists() async { return await _get(KugouEndpoints.sceneLists); }
+  Future<Map<String, dynamic>?> getSceneMusic() async { return await _get(KugouEndpoints.sceneMusic); }
+  Future<Map<String, dynamic>?> getSceneModule(String moduleId) async { return await _get(KugouEndpoints.sceneModule, queryParameters: {'id': moduleId}); }
+  Future<Map<String, dynamic>?> getSceneModuleInfo(String moduleId) async { return await _get(KugouEndpoints.sceneModuleInfo, queryParameters: {'id': moduleId}); }
+  Future<Map<String, dynamic>?> getSceneCollectionList(String moduleId) async { return await _get(KugouEndpoints.sceneCollectionList, queryParameters: {'id': moduleId}); }
+  Future<Map<String, dynamic>?> getSceneVideoList(String moduleId) async { return await _get(KugouEndpoints.sceneVideoList, queryParameters: {'id': moduleId}); }
+  Future<Map<String, dynamic>?> getSceneAudioList(String moduleId, {String? collectionId}) async {
     final params = <String, dynamic>{'id': moduleId};
     if (collectionId != null) params['collection_id'] = collectionId;
     return await _get(KugouEndpoints.sceneAudioList, queryParameters: params);
   }
 
-  // ==================== Artist ====================
-
-  Future<Map<String, dynamic>?> getSingerList({int page = 1}) async {
-    return await _get(
-      KugouEndpoints.singerList,
-      queryParameters: {'page': page},
-    );
-  }
+  Future<Map<String, dynamic>?> getSingerList({int page = 1}) async { return await _get(KugouEndpoints.singerList, queryParameters: {'page': page}); }
 
   Future<KugouArtistDetail?> getArtistDetail(String artistId) async {
-    final json = await _get(
-      KugouEndpoints.artistDetail,
-      queryParameters: {'singerid': artistId},
-    );
+    final json = await _get(KugouEndpoints.artistDetail, queryParameters: {'singerid': artistId});
     if (json == null) return null;
     try {
       final data = json['data'] as Map<String, dynamic>? ?? json;
       return KugouArtistDetail.fromJson(data);
-    } catch (e) {
-            return null;
-    }
+    } catch (e) { return null; }
   }
 
-  Future<KugouArtistAlbums?> getArtistAlbums(
-    String artistId, {
-    int page = 1,
-    int pagesize = 30,
-  }) async {
-    final json = await _get(
-      KugouEndpoints.artistAlbums,
-      queryParameters: {
-        'singerid': artistId,
-        'page': page,
-        'pagesize': pagesize,
-      },
-    );
+  Future<KugouArtistAlbums?> getArtistAlbums(String artistId, {int page = 1, int pagesize = 30}) async {
+    final json = await _get(KugouEndpoints.artistAlbums, queryParameters: {'singerid': artistId, 'page': page, 'pagesize': pagesize});
     if (json == null) return null;
-    try {
-      return KugouArtistAlbums.fromJson(json);
-    } catch (e) {
-            return null;
-    }
+    try { return KugouArtistAlbums.fromJson(json); } catch (e) { return null; }
   }
 
-  Future<KugouArtistAudios?> getArtistAudios(
-    String artistId, {
-    int page = 1,
-    int pagesize = 30,
-  }) async {
-    final json = await _get(
-      KugouEndpoints.artistAudios,
-      queryParameters: {
-        'singerid': artistId,
-        'page': page,
-        'pagesize': pagesize,
-      },
-    );
+  Future<KugouArtistAudios?> getArtistAudios(String artistId, {int page = 1, int pagesize = 30}) async {
+    final json = await _get(KugouEndpoints.artistAudios, queryParameters: {'singerid': artistId, 'page': page, 'pagesize': pagesize});
     if (json == null) return null;
-    try {
-      return KugouArtistAudios.fromJson(json);
-    } catch (e) {
-            return null;
-    }
+    try { return KugouArtistAudios.fromJson(json); } catch (e) { return null; }
   }
 
-  Future<Map<String, dynamic>?> getArtistVideos(String artistId) async {
-    return await _get(
-      KugouEndpoints.artistVideos,
-      queryParameters: {'singerid': artistId},
-    );
-  }
+  Future<Map<String, dynamic>?> getArtistVideos(String artistId) async { return await _get(KugouEndpoints.artistVideos, queryParameters: {'singerid': artistId}); }
+  Future<Map<String, dynamic>?> followArtist(String artistId) async { return await _post(KugouEndpoints.artistFollow, data: {'singerid': artistId}); }
+  Future<Map<String, dynamic>?> unfollowArtist(String artistId) async { return await _post(KugouEndpoints.artistUnfollow, data: {'singerid': artistId}); }
+  Future<Map<String, dynamic>?> getFollowNewsongs() async { return await _get(KugouEndpoints.artistFollowNewsongs); }
 
-  Future<Map<String, dynamic>?> followArtist(String artistId) async {
-    return await _post(
-      KugouEndpoints.artistFollow,
-      data: {'singerid': artistId},
-    );
-  }
-
-  Future<Map<String, dynamic>?> unfollowArtist(String artistId) async {
-    return await _post(
-      KugouEndpoints.artistUnfollow,
-      data: {'singerid': artistId},
-    );
-  }
-
-  Future<Map<String, dynamic>?> getFollowNewsongs() async {
-    return await _get(KugouEndpoints.artistFollowNewsongs);
-  }
-
-  // ==================== Login ====================
-
-  Future<Map<String, dynamic>?> loginByCellphone(
-    String mobile,
-    String code, {
-    String? userid,
-  }) async {
+  Future<Map<String, dynamic>?> loginByCellphone(String mobile, String code, {String? userid}) async {
     final params = <String, dynamic>{'mobile': mobile, 'code': code};
     if (userid != null) params['userid'] = userid;
     return await _get(KugouEndpoints.loginCellphone, queryParameters: params);
   }
 
-  Future<Map<String, dynamic>?> loginByUsername(
-    String username,
-    String password,
-  ) async {
-    return await _get(
-      KugouEndpoints.login,
-      queryParameters: {'username': username, 'password': password},
-    );
+  Future<Map<String, dynamic>?> loginByUsername(String username, String password) async {
+    return await _get(KugouEndpoints.login, queryParameters: {'username': username, 'password': password});
   }
 
   Future<KugouQrKey?> getLoginQrKey() async {
-    final json = await _get(
-      KugouEndpoints.loginQrKey,
-      queryParameters: {
-        'timestamp': DateTime.now().millisecondsSinceEpoch.toString(),
-      },
-    );
+    final json = await _get(KugouEndpoints.loginQrKey, queryParameters: {'timestamp': DateTime.now().millisecondsSinceEpoch.toString()});
     if (json == null) return null;
     try {
       final data = json['data'] as Map<String, dynamic>? ?? json;
       return KugouQrKey.fromJson(data);
-    } catch (e) {
-            return null;
-    }
+    } catch (e) { return null; }
   }
 
   Future<KugouQrCreate?> createLoginQr(String key) async {
-    final json = await _get(
-      KugouEndpoints.loginQrCreate,
-      queryParameters: {
-        'key': key,
-        'qrimg': 'true',
-        'timestamp': DateTime.now().millisecondsSinceEpoch.toString(),
-      },
-    );
+    final json = await _get(KugouEndpoints.loginQrCreate, queryParameters: {'key': key, 'qrimg': 'true', 'timestamp': DateTime.now().millisecondsSinceEpoch.toString()});
     if (json == null) return null;
     try {
       final data = json['data'] as Map<String, dynamic>? ?? json;
       return KugouQrCreate.fromJson(data);
-    } catch (e) {
-            return null;
-    }
+    } catch (e) { return null; }
   }
 
   Future<KugouQrCheck?> checkLoginQr(String key) async {
-    final json = await _get(
-      KugouEndpoints.loginQrCheck,
-      queryParameters: {
-        'key': key,
-        'timestamp': DateTime.now().millisecondsSinceEpoch.toString(),
-      },
-    );
+    final json = await _get(KugouEndpoints.loginQrCheck, queryParameters: {'key': key, 'timestamp': DateTime.now().millisecondsSinceEpoch.toString()});
     if (json == null) return null;
-    try {
-            return KugouQrCheck.fromJson(json);
-    } catch (e) {
-            return null;
-    }
+    try { return KugouQrCheck.fromJson(json); } catch (e) { return null; }
   }
 
-  Future<Map<String, dynamic>?> refreshLogin({
-    String? token,
-    String? userid,
-  }) async {
+  Future<Map<String, dynamic>?> refreshLogin({String? token, String? userid}) async {
     final params = <String, dynamic>{};
     if (token != null) params['token'] = token;
     if (userid != null) params['userid'] = userid;
     return await _get(KugouEndpoints.loginToken, queryParameters: params);
   }
 
-  // 发送手机验证码
-  Future<Map<String, dynamic>?> sendLoginCaptcha(String mobile) async {
-    return await _get(
-      KugouEndpoints.captchaSent,
-      queryParameters: {'mobile': mobile},
-    );
-  }
-
-  // 开放平台登录 (微信 code 换取酷狗 token)
-  Future<Map<String, dynamic>?> loginByOpenplat(String code) async {
-    return await _get(
-      KugouEndpoints.loginOpenplat,
-      queryParameters: {'code': code},
-    );
-  }
-
-  // 微信扫码 - 生成 uuid + 二维码
-  Future<Map<String, dynamic>?> createLoginWx() async {
-    return await _get(KugouEndpoints.loginWxCreate);
-  }
-
-  // 微信扫码 - 轮询状态
-  Future<Map<String, dynamic>?> checkLoginWx(String uuid) async {
-    return await _get(
-      KugouEndpoints.loginWxCheck,
-      queryParameters: {
-        'uuid': uuid,
-        'timestamp': DateTime.now().millisecondsSinceEpoch,
-      },
-    );
-  }
+  Future<Map<String, dynamic>?> sendLoginCaptcha(String mobile) async { return await _get(KugouEndpoints.captchaSent, queryParameters: {'mobile': mobile}); }
+  Future<Map<String, dynamic>?> loginByOpenplat(String code) async { return await _get(KugouEndpoints.loginOpenplat, queryParameters: {'code': code}); }
+  Future<Map<String, dynamic>?> createLoginWx() async { return await _get(KugouEndpoints.loginWxCreate); }
+  Future<Map<String, dynamic>?> checkLoginWx(String uuid) async { return await _get(KugouEndpoints.loginWxCheck, queryParameters: {'uuid': uuid, 'timestamp': DateTime.now().millisecondsSinceEpoch}); }
 
   Future<bool> _tryRefreshToken() async {
     if (_token == null || _userid == null) return false;
     try {
-            final result = await refreshLogin(token: _token, userid: _userid);
-      if (result == null) {
-                return false;
-      }
+      final result = await refreshLogin(token: _token, userid: _userid);
+      if (result == null) return false;
       final status = result['status'];
       final data = result['data'] as Map<String, dynamic>?;
       if (status == 1 && data != null) {
@@ -1538,402 +808,122 @@ class KugouApiClient {
         final newVipToken = data['vip_token']?.toString();
         if (newToken != null && newUserid != null) {
           await setLoginCookies(newToken, newUserid, vipToken: newVipToken);
-                    return true;
+          return true;
         }
       }
-            return false;
-    } catch (e) {
-            return false;
-    }
+      return false;
+    } catch (e) { return false; }
   }
 
-  Future<Map<String, dynamic>?> sendCaptcha(String mobile) async {
-    return await _get(
-      KugouEndpoints.captchaSent,
-      queryParameters: {'mobile': mobile},
-    );
-  }
-
-  // ==================== User ====================
+  Future<Map<String, dynamic>?> sendCaptcha(String mobile) async { return await _get(KugouEndpoints.captchaSent, queryParameters: {'mobile': mobile}); }
 
   Future<KugouUserDetail?> getUserDetail() async {
     final json = await _get(KugouEndpoints.userDetail);
     if (json == null) return null;
-    try {
-      return KugouUserDetail.fromJson(json);
-    } catch (e) {
-            return null;
-    }
+    try { return KugouUserDetail.fromJson(json); } catch (e) { return null; }
   }
 
   Future<KugouUserVipDetail?> getUserVipDetail() async {
     final json = await _get(KugouEndpoints.userVipDetail);
     if (json == null) return null;
-    try {
-      return KugouUserVipDetail.fromJson(json);
-    } catch (e) {
-      return null;
-    }
+    try { return KugouUserVipDetail.fromJson(json); } catch (e) { return null; }
   }
 
-  Future<Map<String, dynamic>?> getUserPlaylist({
-    int page = 1,
-    int pagesize = 30,
-    int? type, // 0=歌单, 1=专辑
-    bool noCache = false,
-  }) async {
-    final params = <String, dynamic>{
-      'page': page,
-      'pagesize': pagesize,
-      if (isLoggedIn && userid != null) 'userid': userid!,
-    };
+  Future<Map<String, dynamic>?> getUserPlaylist({int page = 1, int pagesize = 30, int? type, bool noCache = false}) async {
+    final params = <String, dynamic>{'page': page, 'pagesize': pagesize, if (isLoggedIn && userid != null) 'userid': userid!};
     if (type != null) params['type'] = type;
-    return await _get(
-      KugouEndpoints.userPlaylist,
-      queryParameters: params,
-      noCache: noCache,
-    );
+    return await _get(KugouEndpoints.userPlaylist, queryParameters: params, noCache: noCache);
   }
 
-  Future<Map<String, dynamic>?> getUserFollow() async {
-    return await _get(KugouEndpoints.userFollow);
-  }
-
-  Future<Map<String, dynamic>?> getUserFollowMessage(
-    String userId, {
-    int pagesize = 30,
-  }) async {
-    return await _get(
-      KugouEndpoints.userFollowMessage,
-      queryParameters: {'id': userId, 'pagesize': pagesize},
-    );
-  }
-
-  Future<Map<String, dynamic>?> getUserCloudUrl(
-    String hash, {
-    String? albumId,
-    String? name,
-    String? albumAudioId,
-  }) async {
+  Future<Map<String, dynamic>?> getUserFollow() async { return await _get(KugouEndpoints.userFollow); }
+  Future<Map<String, dynamic>?> getUserFollowMessage(String userId, {int pagesize = 30}) async { return await _get(KugouEndpoints.userFollowMessage, queryParameters: {'id': userId, 'pagesize': pagesize}); }
+  Future<Map<String, dynamic>?> getUserCloudUrl(String hash, {String? albumId, String? name, String? albumAudioId}) async {
     final params = <String, dynamic>{'hash': hash};
     if (albumId != null) params['album_id'] = albumId;
     if (name != null) params['name'] = name;
     if (albumAudioId != null) params['album_audio_id'] = albumAudioId;
     return await _get(KugouEndpoints.userCloudUrl, queryParameters: params);
   }
-
-  Future<Map<String, dynamic>?> getUserVideoCollect({
-    int page = 1,
-    int pagesize = 30,
-  }) async {
-    return await _get(
-      KugouEndpoints.userVideoCollect,
-      queryParameters: {'page': page, 'pagesize': pagesize},
-    );
+  Future<Map<String, dynamic>?> getUserVideoCollect({int page = 1, int pagesize = 30}) async { return await _get(KugouEndpoints.userVideoCollect, queryParameters: {'page': page, 'pagesize': pagesize}); }
+  Future<Map<String, dynamic>?> getUserVideoLove({int pagesize = 30}) async { return await _get(KugouEndpoints.userVideoLove, queryParameters: {'pagesize': pagesize}); }
+  Future<Map<String, dynamic>?> getUserListen({int type = 0}) async { return await _get(KugouEndpoints.userListen, queryParameters: {'type': type}); }
+  Future<Map<String, dynamic>?> getUserHistory() async { return await _get(KugouEndpoints.userHistory); }
+  Future<Map<String, dynamic>?> uploadPlayHistory(String hash, String songName, {String? albumAudioId}) async {
+    final params = <String, dynamic>{'hash': hash, 'songname': songName};
+    if (albumAudioId != null) params['album_audio_id'] = albumAudioId;
+    return await _get(KugouEndpoints.playhistoryUpload, queryParameters: params);
   }
 
-  Future<Map<String, dynamic>?> getUserVideoLove({int pagesize = 30}) async {
-    return await _get(
-      KugouEndpoints.userVideoLove,
-      queryParameters: {'pagesize': pagesize},
-    );
-  }
-
-  Future<Map<String, dynamic>?> getUserListen({int type = 0}) async {
-    return await _get(
-      KugouEndpoints.userListen,
-      queryParameters: {'type': type},
-    );
-  }
-
-  Future<Map<String, dynamic>?> getUserHistory() async {
-    return await _get(KugouEndpoints.userHistory);
-  }
-
-  Future<Map<String, dynamic>?> uploadPlayHistory(
-    String hash,
-    String songName, {
-    String? albumAudioId,
-  }) async {
-    return await _get(
-      KugouEndpoints.playhistoryUpload,
-      queryParameters: {
-        'hash': hash,
-        'songname': songName,
-        'album_audio_id': ?albumAudioId,
-      },
-    );
-  }
-
-  // ==================== Playlist Management ====================
-
-  Future<Map<String, dynamic>?> createPlaylist(
-    String name, {
-    int type = 0,
-    int isPri = 0,
-    String? listCreateUserid,
-    String? listCreateListid,
-    String? globalCollectionId,
-  }) async {
+  Future<Map<String, dynamic>?> createPlaylist(String name, {int type = 0, int isPri = 0, String? listCreateUserid, String? listCreateListid, String? globalCollectionId}) async {
     String userid = listCreateUserid ?? _userid ?? '0';
     String listid = listCreateListid ?? '0';
-
     if (globalCollectionId != null && globalCollectionId.isNotEmpty) {
       final parts = globalCollectionId.split('_');
-      if (parts.length >= 4) {
-        userid = parts[2];
-        listid = parts[3];
-      }
+      if (parts.length >= 4) { userid = parts[2]; listid = parts[3]; }
     }
-
-    final params = <String, dynamic>{
-      'name': name,
-      'type': type,
-      'is_pri': isPri,
-      'list_create_userid': userid,
-      'list_create_listid': listid,
-    };
+    final params = <String, dynamic>{'name': name, 'type': type, 'is_pri': isPri, 'list_create_userid': userid, 'list_create_listid': listid};
     return await _get(KugouEndpoints.playlistAdd, queryParameters: params);
   }
 
-  Future<Map<String, dynamic>?> deletePlaylist(String listid, {int type = 1}) async {
-    return await _get(
-      KugouEndpoints.playlistDel,
-      queryParameters: {'listid': listid, 'type': type},
-    );
-  }
-
-  Future<Map<String, dynamic>?> addPlaylistTracks(
-    String listid,
-    String data,
-  ) async {
-    return await _get(
-      KugouEndpoints.playlistTracksAdd,
-      queryParameters: {'listid': listid, 'data': data},
-    );
-  }
-
-  Future<Map<String, dynamic>?> deletePlaylistTracks(
-    String listid,
-    String fileids,
-  ) async {
-    return await _get(
-      KugouEndpoints.playlistTracksDel,
-      queryParameters: {'listid': listid, 'fileids': fileids},
-    );
-  }
-
-  Future<Map<String, dynamic>?> collectSheet(String specialId) async {
-    return await _post(
-      KugouEndpoints.sheetCollection,
-      data: {'specialid': specialId},
-    );
-  }
-
-  // ==================== Video ====================
-
-  Future<Map<String, dynamic>?> getVideoUrl(String hash) async {
-    return await _get(KugouEndpoints.videoUrl, queryParameters: {'hash': hash});
-  }
-
-  Future<Map<String, dynamic>?> getVideoDetail(String hash) async {
-    return await _get(
-      KugouEndpoints.videoDetail,
-      queryParameters: {'hash': hash},
-    );
-  }
-
-  Future<Map<String, dynamic>?> getVideoPrivilege(String hash) async {
-    return await _get(
-      KugouEndpoints.videoPrivilege,
-      queryParameters: {'hash': hash},
-    );
-  }
-
-  // ==================== Youth Channel ====================
-
-  Future<Map<String, dynamic>?> getYouthChannels() async {
-    return await _get(KugouEndpoints.youthChannelAll);
-  }
-
-  Future<Map<String, dynamic>?> getYouthChannelDetail(String channelId) async {
-    return await _get(
-      KugouEndpoints.youthChannelDetail,
-      queryParameters: {'id': channelId},
-    );
-  }
-
-  Future<Map<String, dynamic>?> getYouthChannelAmway() async {
-    return await _get(KugouEndpoints.youthChannelAmway);
-  }
-
-  Future<Map<String, dynamic>?> getYouthChannelSimilar(String channelId) async {
-    return await _get(
-      KugouEndpoints.youthChannelSimilar,
-      queryParameters: {'channelid': channelId},
-    );
-  }
-
-  Future<Map<String, dynamic>?> subscribeYouthChannel(String channelId) async {
-    return await _get(
-      KugouEndpoints.youthChannelSub,
-      queryParameters: {'channelid': channelId},
-    );
-  }
-
-  Future<Map<String, dynamic>?> getYouthChannelSong(String channelId) async {
-    return await _get(
-      KugouEndpoints.youthChannelSong,
-      queryParameters: {'channelid': channelId},
-    );
-  }
-
-  Future<Map<String, dynamic>?> getYouthChannelSongDetail(
-    String channelId,
-  ) async {
-    return await _get(
-      KugouEndpoints.youthChannelSongDetail,
-      queryParameters: {'id': channelId},
-    );
-  }
-
-  // ==================== Long Audio ====================
-
-  Future<Map<String, dynamic>?> getLongaudioDaily() async {
-    return await _get(KugouEndpoints.longaudioDailyRecommend);
-  }
-
-  Future<Map<String, dynamic>?> getLongaudioRank() async {
-    return await _get(KugouEndpoints.longaudioRankRecommend);
-  }
-
-  Future<Map<String, dynamic>?> getLongaudioVip() async {
-    return await _get(KugouEndpoints.longaudioVipRecommend);
-  }
-
-  Future<Map<String, dynamic>?> getLongaudioWeek() async {
-    return await _get(KugouEndpoints.longaudioWeekRecommend);
-  }
-
-  Future<Map<String, dynamic>?> getLongaudioAlbumDetail(String albumId) async {
-    return await _get(
-      KugouEndpoints.longaudioAlbumDetail,
-      queryParameters: {'album_id': albumId},
-    );
-  }
-
-  Future<Map<String, dynamic>?> getLongaudioAlbumAudios(String albumId) async {
-    return await _get(
-      KugouEndpoints.longaudioAlbumAudios,
-      queryParameters: {'album_id': albumId},
-    );
-  }
-
-  // ==================== Other ====================
-
-  Future<Map<String, dynamic>?> getBrush() async {
-    return await _get(KugouEndpoints.brush);
-  }
-
-  Future<Map<String, dynamic>?> getAiRecommend() async {
-    return await _get(KugouEndpoints.aiRecommend);
-  }
-
-  Future<Map<String, dynamic>?> getServerNow() async {
-    return await _get(KugouEndpoints.serverNow);
-  }
-
-  Future<Map<String, dynamic>?> getAlbumInfo(String albumId) async {
-    return await _get(
-      KugouEndpoints.albumInfo,
-      queryParameters: {'album_id': albumId},
-    );
-  }
+  Future<Map<String, dynamic>?> deletePlaylist(String listid, {int type = 1}) async { return await _get(KugouEndpoints.playlistDel, queryParameters: {'listid': listid, 'type': type}); }
+  Future<Map<String, dynamic>?> addPlaylistTracks(String listid, String data) async { return await _get(KugouEndpoints.playlistTracksAdd, queryParameters: {'listid': listid, 'data': data}); }
+  Future<Map<String, dynamic>?> deletePlaylistTracks(String listid, String fileids) async { return await _get(KugouEndpoints.playlistTracksDel, queryParameters: {'listid': listid, 'fileids': fileids}); }
+  Future<Map<String, dynamic>?> collectSheet(String specialId) async { return await _post(KugouEndpoints.sheetCollection, data: {'specialid': specialId}); }
+  Future<Map<String, dynamic>?> getVideoUrl(String hash) async { return await _get(KugouEndpoints.videoUrl, queryParameters: {'hash': hash}); }
+  Future<Map<String, dynamic>?> getVideoDetail(String hash) async { return await _get(KugouEndpoints.videoDetail, queryParameters: {'hash': hash}); }
+  Future<Map<String, dynamic>?> getVideoPrivilege(String hash) async { return await _get(KugouEndpoints.videoPrivilege, queryParameters: {'hash': hash}); }
+  Future<Map<String, dynamic>?> getYouthChannels() async { return await _get(KugouEndpoints.youthChannelAll); }
+  Future<Map<String, dynamic>?> getYouthChannelDetail(String channelId) async { return await _get(KugouEndpoints.youthChannelDetail, queryParameters: {'id': channelId}); }
+  Future<Map<String, dynamic>?> getYouthChannelAmway() async { return await _get(KugouEndpoints.youthChannelAmway); }
+  Future<Map<String, dynamic>?> getYouthChannelSimilar(String channelId) async { return await _get(KugouEndpoints.youthChannelSimilar, queryParameters: {'channelid': channelId}); }
+  Future<Map<String, dynamic>?> subscribeYouthChannel(String channelId) async { return await _get(KugouEndpoints.youthChannelSub, queryParameters: {'channelid': channelId}); }
+  Future<Map<String, dynamic>?> getYouthChannelSong(String channelId) async { return await _get(KugouEndpoints.youthChannelSong, queryParameters: {'channelid': channelId}); }
+  Future<Map<String, dynamic>?> getYouthChannelSongDetail(String channelId) async { return await _get(KugouEndpoints.youthChannelSongDetail, queryParameters: {'id': channelId}); }
+  Future<Map<String, dynamic>?> getLongaudioDaily() async { return await _get(KugouEndpoints.longaudioDailyRecommend); }
+  Future<Map<String, dynamic>?> getLongaudioRank() async { return await _get(KugouEndpoints.longaudioRankRecommend); }
+  Future<Map<String, dynamic>?> getLongaudioVip() async { return await _get(KugouEndpoints.longaudioVipRecommend); }
+  Future<Map<String, dynamic>?> getLongaudioWeek() async { return await _get(KugouEndpoints.longaudioWeekRecommend); }
+  Future<Map<String, dynamic>?> getLongaudioAlbumDetail(String albumId) async { return await _get(KugouEndpoints.longaudioAlbumDetail, queryParameters: {'album_id': albumId}); }
+  Future<Map<String, dynamic>?> getLongaudioAlbumAudios(String albumId) async { return await _get(KugouEndpoints.longaudioAlbumAudios, queryParameters: {'album_id': albumId}); }
+  Future<Map<String, dynamic>?> getBrush() async { return await _get(KugouEndpoints.brush); }
+  Future<Map<String, dynamic>?> getAiRecommend() async { return await _get(KugouEndpoints.aiRecommend); }
+  Future<Map<String, dynamic>?> getServerNow() async { return await _get(KugouEndpoints.serverNow); }
+  Future<Map<String, dynamic>?> getAlbumInfo(String albumId) async { return await _get(KugouEndpoints.albumInfo, queryParameters: {'album_id': albumId}); }
 
   Future<KugouAlbumDetail?> getAlbumDetail(String albumId) async {
-    final json = await _get(
-      KugouEndpoints.albumDetail,
-      queryParameters: {'album_id': albumId},
-    );
+    final json = await _get(KugouEndpoints.albumDetail, queryParameters: {'album_id': albumId});
     if (json == null) return null;
     try {
       final data = json['data'] as Map<String, dynamic>? ?? json;
       return KugouAlbumDetail.fromJson(data);
-    } catch (e) {
-            return null;
-    }
+    } catch (e) { return null; }
   }
 
-  Future<KugouAlbumSongs?> getAlbumSongs(
-    String albumId, {
-    int page = 1,
-    int pagesize = 30,
-  }) async {
-    final json = await _get(
-      KugouEndpoints.albumSongs,
-      queryParameters: {
-        'album_id': albumId,
-        'page': page,
-        'pagesize': pagesize,
-      },
-    );
+  Future<KugouAlbumSongs?> getAlbumSongs(String albumId, {int page = 1, int pagesize = 30}) async {
+    final json = await _get(KugouEndpoints.albumSongs, queryParameters: {'album_id': albumId, 'page': page, 'pagesize': pagesize});
     if (json == null) return null;
-    try {
-      return KugouAlbumSongs.fromJson(json);
-    } catch (e) {
-            return null;
-    }
+    try { return KugouAlbumSongs.fromJson(json); } catch (e) { return null; }
   }
 
-  Future<List<KugouSongDetail>?> getPlaylistTrackAll({
-    required String id,
-    int page = 1,
-    int pagesize = 30,
-  }) async {
-    final params = <String, dynamic>{
-      'global_collection_id': id,
-      'page': page,
-      'pagesize': pagesize,
-    };
-    final json = await _get(
-      KugouEndpoints.playlistTrackAll,
-      queryParameters: params,
-    );
+  Future<List<KugouSongDetail>?> getPlaylistTrackAll({required String id, int page = 1, int pagesize = 30}) async {
+    final params = <String, dynamic>{'global_collection_id': id, 'page': page, 'pagesize': pagesize};
+    final json = await _get(KugouEndpoints.playlistTrackAll, queryParameters: params);
     if (json == null) return null;
     try {
       final data = json['data'] as Map<String, dynamic>? ?? json;
       final list = data['list'] ?? data['songs'] ?? data['info'] ?? [];
-      return (list as List<dynamic>)
-          .map((e) => KugouSongDetail.fromJson(e as Map<String, dynamic>))
-          .toList();
-    } catch (e) {
-            return null;
-    }
+      return (list as List<dynamic>).map((e) => KugouSongDetail.fromJson(e as Map<String, dynamic>)).toList();
+    } catch (e) { return null; }
   }
 
-  Future<List<KugouSongDetail>?> getPlaylistTrackAllNew({
-    required String listid,
-    int page = 1,
-    int pagesize = 30,
-  }) async {
-    final json = await _get(
-      KugouEndpoints.playlistTrackAllNew,
-      queryParameters: {
-        'listid': listid,
-        'page': page,
-        'pagesize': pagesize,
-      },
-    );
+  Future<List<KugouSongDetail>?> getPlaylistTrackAllNew({required String listid, int page = 1, int pagesize = 30}) async {
+    final json = await _get(KugouEndpoints.playlistTrackAllNew, queryParameters: {'listid': listid, 'page': page, 'pagesize': pagesize});
     if (json == null) return null;
     try {
       final data = json['data'] as Map<String, dynamic>? ?? json;
       final list = data['list'] ?? data['songs'] ?? data['info'] ?? [];
-      return (list as List<dynamic>)
-          .map((e) => KugouSongDetail.fromJson(e as Map<String, dynamic>))
-          .toList();
-    } catch (e) {
-            return null;
-    }
+      return (list as List<dynamic>).map((e) => KugouSongDetail.fromJson(e as Map<String, dynamic>)).toList();
+    } catch (e) { return null; }
   }
 
   Future<List<KugouSongDetail>?> getLastestSongsListen() async {
@@ -1942,141 +932,45 @@ class KugouApiClient {
     try {
       final data = json['data'] as Map<String, dynamic>? ?? json;
       final list = data['list'] ?? data['songs'] ?? data['info'] ?? [];
-      return (list as List<dynamic>)
-          .map((e) => KugouSongDetail.fromJson(e as Map<String, dynamic>))
-          .toList();
-    } catch (e) {
-      return null;
-    }
+      return (list as List<dynamic>).map((e) => KugouSongDetail.fromJson(e as Map<String, dynamic>)).toList();
+    } catch (e) { return null; }
   }
 
-  Future<Map<String, dynamic>?> getYouthListenSong() async {
-    return await _get(KugouEndpoints.youthListenSong);
-  }
-
-  Future<Map<String, dynamic>?> getYouthUserSong(String userId) async {
-    return await _get(
-      KugouEndpoints.youthUserSong,
-      queryParameters: {'userid': userId},
-    );
-  }
-
-  Future<Map<String, dynamic>?> getYouthDynamic() async {
-    return await _get(KugouEndpoints.youthDynamic);
-  }
-
-  Future<Map<String, dynamic>?> getYouthDynamicRecent() async {
-    return await _get(KugouEndpoints.youthDynamicRecent);
-  }
-
-  Future<Map<String, dynamic>?> getPrivilegeLite(String hash) async {
-    return await _get(
-      KugouEndpoints.privilegeLite,
-      queryParameters: {'hash': hash},
-    );
-  }
-
-  Future<Map<String, dynamic>?> getAlbumShop(String albumId) async {
-    return await _get(
-      KugouEndpoints.albumShop,
-      queryParameters: {'album_id': albumId},
-    );
-  }
-
-  Future<Map<String, dynamic>?> getArtistLists(String artistId) async {
-    return await _get(
-      KugouEndpoints.artistLists,
-      queryParameters: {'singerid': artistId},
-    );
-  }
-
-  Future<Map<String, dynamic>?> getArtistHonour(String artistId) async {
-    return await _get(
-      KugouEndpoints.artistHonour,
-      queryParameters: {'singerid': artistId},
-    );
-  }
-
-  Future<Map<String, dynamic>?> getPcDiantai() async {
-    return await _get(KugouEndpoints.pcDiantai);
-  }
-
-  Future<Map<String, dynamic>?> getImages(String hash) async {
-    return await _get(KugouEndpoints.images, queryParameters: {'hash': hash});
-  }
-
-  Future<Map<String, dynamic>?> getImagesAudio(String hash) async {
-    return await _get(
-      KugouEndpoints.imagesAudio,
-      queryParameters: {'hash': hash},
-    );
-  }
-
-  Future<Map<String, dynamic>?> getKrmAudio(String hash) async {
-    return await _get(KugouEndpoints.krmAudio, queryParameters: {'hash': hash});
-  }
-
-  Future<Map<String, dynamic>?> getKmrAudioMv(String hash) async {
-    return await _get(
-      KugouEndpoints.kmrAudioMv,
-      queryParameters: {'hash': hash},
-    );
-  }
-
-  Future<Map<String, dynamic>?> getAudioAccompany(String hash) async {
-    return await _get(
-      KugouEndpoints.audioAccompany,
-      queryParameters: {'hash': hash},
-    );
-  }
-
-  Future<Map<String, dynamic>?> getAudioKtvTotal(String hash) async {
-    return await _get(
-      KugouEndpoints.audioKtvTotal,
-      queryParameters: {'hash': hash},
-    );
-  }
-
-  Future<Map<String, dynamic>?> getYouthVip() async {
-    return await _get(KugouEndpoints.youthVip);
-  }
-
-  Future<Map<String, dynamic>?> getYouthUnionVip() async {
-    return await _get(KugouEndpoints.youthUnionVip);
-  }
+  Future<Map<String, dynamic>?> getYouthListenSong() async { return await _get(KugouEndpoints.youthListenSong); }
+  Future<Map<String, dynamic>?> getYouthUserSong(String userId) async { return await _get(KugouEndpoints.youthUserSong, queryParameters: {'userid': userId}); }
+  Future<Map<String, dynamic>?> getYouthDynamic() async { return await _get(KugouEndpoints.youthDynamic); }
+  Future<Map<String, dynamic>?> getYouthDynamicRecent() async { return await _get(KugouEndpoints.youthDynamicRecent); }
+  Future<Map<String, dynamic>?> getPrivilegeLite(String hash) async { return await _get(KugouEndpoints.privilegeLite, queryParameters: {'hash': hash}); }
+  Future<Map<String, dynamic>?> getAlbumShop(String albumId) async { return await _get(KugouEndpoints.albumShop, queryParameters: {'album_id': albumId}); }
+  Future<Map<String, dynamic>?> getArtistLists(String artistId) async { return await _get(KugouEndpoints.artistLists, queryParameters: {'singerid': artistId}); }
+  Future<Map<String, dynamic>?> getArtistHonour(String artistId) async { return await _get(KugouEndpoints.artistHonour, queryParameters: {'singerid': artistId}); }
+  Future<Map<String, dynamic>?> getPcDiantai() async { return await _get(KugouEndpoints.pcDiantai); }
+  Future<Map<String, dynamic>?> getImages(String hash) async { return await _get(KugouEndpoints.images, queryParameters: {'hash': hash}); }
+  Future<Map<String, dynamic>?> getImagesAudio(String hash) async { return await _get(KugouEndpoints.imagesAudio, queryParameters: {'hash': hash}); }
+  Future<Map<String, dynamic>?> getKrmAudio(String hash) async { return await _get(KugouEndpoints.krmAudio, queryParameters: {'hash': hash}); }
+  Future<Map<String, dynamic>?> getKmrAudioMv(String hash) async { return await _get(KugouEndpoints.kmrAudioMv, queryParameters: {'hash': hash}); }
+  Future<Map<String, dynamic>?> getAudioAccompany(String hash) async { return await _get(KugouEndpoints.audioAccompany, queryParameters: {'hash': hash}); }
+  Future<Map<String, dynamic>?> getAudioKtvTotal(String hash) async { return await _get(KugouEndpoints.audioKtvTotal, queryParameters: {'hash': hash}); }
+  Future<Map<String, dynamic>?> getYouthVip() async { return await _get(KugouEndpoints.youthVip); }
+  Future<Map<String, dynamic>?> getYouthUnionVip() async { return await _get(KugouEndpoints.youthUnionVip); }
 
   Future<Map<String, dynamic>?> claimDayVip(String receiveDay) async {
-    // 还原到最初项目的签到架构：优先调用 /youth/day/vip（需传 receive_day）。
-    // 若该接口已被酷狗停用（error_code 20028 等拒领码）或请求失败，
-    // 自动回退到可用的 /youth/vip，保证手动/自动签到仍能完成。
-    final primary = await _post(
-      KugouEndpoints.youthDayVip,
-      data: {'receive_day': receiveDay},
-    );
+    final primary = await _post(KugouEndpoints.youthDayVip, data: {'receive_day': receiveDay});
     final errCode = primary?['error_code'] as int?;
     final isRefusedOrFailed = primary == null || errCode == 20028;
-    if (!isRefusedOrFailed) {
-      return primary; // 成功 / 今日已签到 等正常响应，直接返回
-    }
+    if (!isRefusedOrFailed) return primary;
     try {
       final fallback = await _post(KugouEndpoints.youthVip, data: {});
       if (fallback != null) return fallback;
     } catch (_) {}
-    return primary; // 回退也失败，返回原始响应供上层提示
+    return primary;
   }
 
-  Future<Map<String, dynamic>?> upgradeDayVip() async {
-        return await _post(KugouEndpoints.youthDayVipUpgrade);
-  }
+  Future<Map<String, dynamic>?> upgradeDayVip() async { return await _post(KugouEndpoints.youthDayVipUpgrade); }
 
   Future<Map<String, dynamic>?> getYouthMonthVipRecord({String? month}) async {
     final query = <String, dynamic>{};
-    if (month != null && month.isNotEmpty) {
-      query['month'] = month;
-    }
-    return await _get(
-      KugouEndpoints.youthMonthVipRecord,
-      queryParameters: query.isNotEmpty ? query : null,
-    );
+    if (month != null && month.isNotEmpty) query['month'] = month;
+    return await _get(KugouEndpoints.youthMonthVipRecord, queryParameters: query.isNotEmpty ? query : null);
   }
 }

--- a/lib/services/kugou_api/kugou_models.dart
+++ b/lib/services/kugou_api/kugou_models.dart
@@ -670,11 +670,13 @@ class KugouComment {
 class KugouLyric {
   final String content;
   final String? decodedContent;
+  final String? decodedKrcContent;
   final String? translatedContent;
 
   const KugouLyric({
     required this.content,
     this.decodedContent,
+    this.decodedKrcContent,
     this.translatedContent,
   });
 
@@ -686,13 +688,26 @@ class KugouLyric {
       decodedContent: _strNull(
         json['decodeContent'] ?? json['decoded_content'] ?? json['lrcContent'],
       ),
+      // KRC 明文（Node 侧解码后），多字段名降级以兼容不同上游
+      decodedKrcContent: _strNull(
+        json['decodeKrcContent'] ??
+            json['decoded_krc_content'] ??
+            json['krcContent'],
+      ),
       translatedContent: _strNull(
         json['translated_content'] ?? json['trans'] ?? json['lrcContentChi'],
       ),
     );
   }
 
-  String get displayLyric => decodedContent ?? content;
+  /// 优先返回 KRC 明文（逐字），降级 LRC 明文，最后降级原始 content
+  String get displayLyric => decodedKrcContent ?? decodedContent ?? content;
+
+  /// 仅返回 KRC 明文（可空）
+  String? get displayKrcLyric => decodedKrcContent;
+
+  /// 仅返回 LRC 明文（可空）
+  String? get displayLrcLyric => decodedContent;
 }
 
 class KugouArtistDetail {

--- a/lib/widgets/apple_lyrics/animation/spring.dart
+++ b/lib/widgets/apple_lyrics/animation/spring.dart
@@ -1,0 +1,231 @@
+import 'dart:math';
+
+/// 弹簧物理动画引擎
+///
+/// 参照 AMLL 项目 packages/core/src/utils/spring.ts 实现，
+/// 提供临界阻尼、欠阻尼、过阻尼三种模式的解析求解器。
+///
+/// 物理方程: m * x'' + c * x' + k * (x - target) = 0
+/// 其中 m=mass, c=damping, k=stiffness。
+class Spring {
+  /// 弹簧质量
+  double _mass;
+
+  /// 阻尼系数
+  double _damping;
+
+  /// 刚度
+  double _stiffness;
+
+  /// 当前位移
+  double _position;
+
+  /// 当前速度（一阶导数）
+  double _velocity;
+
+  /// 目标位移
+  double _target;
+
+  /// 求解器起点位移（上次 setTarget/setParams 时的位置）
+  double _fromPosition;
+
+  /// 求解器起点速度
+  double _fromVelocity;
+
+  /// 自上次 setTarget/setParams 起累积的时间（秒）
+  double _elapsedTime;
+
+  /// 内部稳定标志：为 true 时 tick 直接跳过计算
+  bool _settled;
+
+  /// 稳定阈值：位移、速度、加速度均小于此值时认为已稳定
+  static const double _settleThreshold = 0.01;
+
+  /// 子步长上限（秒），dt 过大时按此步长子步进
+  static const double _maxStepTime = 0.016;
+
+  Spring({
+    double mass = 1,
+    double damping = 20,
+    double stiffness = 100,
+    double initialPosition = 0,
+  })  : _mass = mass,
+        _damping = damping,
+        _stiffness = stiffness,
+        _position = initialPosition,
+        _target = initialPosition,
+        _velocity = 0,
+        _fromPosition = initialPosition,
+        _fromVelocity = 0,
+        _elapsedTime = 0,
+        _settled = true;
+
+  /// 当前位移
+  double get position => _position;
+
+  /// 当前速度
+  double get velocity => _velocity;
+
+  /// 当前目标位移
+  double get target => _target;
+
+  /// 当前加速度（二阶导数），由弹簧方程直接给出: a = (-k*x - c*v) / m
+  double get acceleration {
+    final double displacement = _position - _target;
+    return (-_stiffness * displacement - _damping * _velocity) / _mass;
+  }
+
+  /// 是否已稳定：位移、速度、加速度均 < 0.01
+  bool get isSettled {
+    if (!_settled) return false;
+    return (_position - _target).abs() < _settleThreshold &&
+        _velocity.abs() < _settleThreshold &&
+        acceleration.abs() < _settleThreshold;
+  }
+
+  /// 设置当前位移与速度（瞬移到指定状态，目标=当前位置）
+  void setPosition(double position, double velocity) {
+    _position = position;
+    _velocity = velocity;
+    _target = position;
+    _fromPosition = position;
+    _fromVelocity = velocity;
+    _elapsedTime = 0;
+    // 若有初速度，弹簧需运动以耗散速度；否则视为已稳定
+    _settled = velocity.abs() < 1e-9;
+  }
+
+  /// 设置目标位移，从当前状态继续弹簧运动
+  void setTarget(double target) {
+    // 目标未变且已稳定，无需重新求解
+    if ((target - _target).abs() < 1e-9 && _settled) return;
+    _target = target;
+    _resetSolver();
+  }
+
+  /// 动态调整弹簧参数，从当前状态重新求解
+  void setParams({double? mass, double? damping, double? stiffness}) {
+    if (mass != null) _mass = mass;
+    if (damping != null) _damping = damping;
+    if (stiffness != null) _stiffness = stiffness;
+    // 运动中改变参数需要重新初始化求解器
+    if (!_settled) {
+      _resetSolver();
+    }
+  }
+
+  /// 重置到 0 位移、0 速度、0 目标
+  void reset() {
+    _position = 0;
+    _velocity = 0;
+    _target = 0;
+    _fromPosition = 0;
+    _fromVelocity = 0;
+    _elapsedTime = 0;
+    _settled = true;
+  }
+
+  /// 推进 dt 秒，更新位置与速度
+  void tick(double dt) {
+    if (_settled) return;
+    if (dt <= 0) return;
+
+    // 子步进：dt 过大时按固定步长分步求解，避免数值发散
+    // 并在每步后检查稳定条件，提前停止
+    double remaining = dt;
+    while (remaining > 0 && !_settled) {
+      final double step = remaining > _maxStepTime ? _maxStepTime : remaining;
+      _elapsedTime += step;
+      _solveAt(_elapsedTime);
+      remaining -= step;
+
+      // 到达阈值：位移、速度、加速度均 < 0.01 时认为已稳定，吸附到目标
+      if ((_position - _target).abs() < _settleThreshold &&
+          _velocity.abs() < _settleThreshold &&
+          acceleration.abs() < _settleThreshold) {
+        _position = _target;
+        _velocity = 0;
+        _settled = true;
+      }
+    }
+  }
+
+  /// 重置求解器：以当前状态作为新的起点
+  void _resetSolver() {
+    _fromPosition = _position;
+    _fromVelocity = _velocity;
+    _elapsedTime = 0;
+    _settled = false;
+  }
+
+  /// 在累积时间 t 处解析求解位置与速度
+  void _solveAt(double t) {
+    final double from = _fromPosition;
+    final double vel = _fromVelocity;
+    final double to = _target;
+    final double m = _mass;
+    final double c = _damping;
+    final double k = _stiffness;
+
+    final double delta = to - from;
+    // 判别式: 4*m*k - c²
+    final double discriminant = 4 * m * k - c * c;
+
+    // 已在目标位置且无初速度，直接吸附
+    if (delta.abs() < 1e-12 && vel.abs() < 1e-12) {
+      _position = to;
+      _velocity = 0;
+      return;
+    }
+
+    if (discriminant.abs() < 1e-9) {
+      // 临界阻尼：damping == 2*sqrt(stiffness*mass)
+      // x(t) = to - (delta + t*leftover) * e^(t*angular_frequency)
+      // angular_frequency = -sqrt(k/m), leftover = -af*delta - vel
+      final double af = sqrt(k / m);
+      final double dm = -af; // 即 angular_frequency
+      final double leftover = -dm * delta - vel;
+      final double e = exp(dm * t);
+      _position = to - (delta + t * leftover) * e;
+      // 速度解析求导: x'(t) = -e * (leftover + (delta + t*leftover) * dm)
+      _velocity = -e * (leftover + (delta + t * leftover) * dm);
+    } else if (discriminant > 0) {
+      // 欠阻尼：damping < 2*sqrt(stiffness*mass)
+      // x(t) = to - e^(dm*t) * (delta*cos(dfm*t) + leftover*sin(dfm*t))
+      // damping_frequency = sqrt(4*m*k - c²)
+      // dfm = 0.5 * damping_frequency / mass （阻尼自然角频率）
+      // dm = -0.5 * damping / mass （衰减率）
+      // leftover = (c*delta - 2*m*vel) / damping_frequency
+      final double dampingFrequency = sqrt(discriminant);
+      final double dfm = 0.5 * dampingFrequency / m;
+      final double dm = -0.5 * c / m;
+      final double leftover = (c * delta - 2 * m * vel) / dampingFrequency;
+      final double e = exp(dm * t);
+      final double cosT = cos(dfm * t);
+      final double sinT = sin(dfm * t);
+      _position = to - e * (delta * cosT + leftover * sinT);
+      // 速度解析求导
+      _velocity = -e *
+          (dm * (delta * cosT + leftover * sinT) +
+              dfm * (-delta * sinT + leftover * cosT));
+    } else {
+      // 过阻尼：damping > 2*sqrt(stiffness*mass)
+      // 使用指数形式避免 cosh/sinh 在大 t 下溢出
+      // 两根: r1 = dm + dfm, r2 = dm - dfm（均小于 0）
+      // 通解: u(t) = A*e^(r1*t) + B*e^(r2*t)，其中 u = x - to
+      // 初始条件: A + B = -delta, r1*A + r2*B = vel
+      final double dampingFrequency = sqrt(-discriminant); // sqrt(c² - 4*m*k)
+      final double dfm = 0.5 * dampingFrequency / m;
+      final double dm = -0.5 * c / m;
+      final double r1 = dm + dfm; // 较小的负根（绝对值小，衰减慢）
+      final double r2 = dm - dfm; // 较大的负根（绝对值大，衰减快）
+      // 由初始条件解线性方程组
+      final double a = (vel + r2 * delta) / (2 * dfm);
+      final double b = -delta - a;
+      final double er1 = exp(r1 * t);
+      final double er2 = exp(r2 * t);
+      _position = to + a * er1 + b * er2;
+      _velocity = a * r1 * er1 + b * r2 * er2;
+    }
+  }
+}

--- a/lib/widgets/apple_lyrics/apple_lyrics_view.dart
+++ b/lib/widgets/apple_lyrics/apple_lyrics_view.dart
@@ -1,0 +1,789 @@
+/// Apple Music 风格歌词主组件
+///
+/// 参照 spec.md "Requirement: 点击跳转" 与 tasks.md Task 17 实现。
+/// 接收已解析的 [LyricLine] 列表与播放状态，集成所有渲染器与控制器，
+/// 通过 [CustomPainter] 绘制 Apple Music 风格的逐字 / 整行歌词。
+///
+/// 设计要点：
+/// - 解析由调用方完成（[LyricParserChain.parse]），本组件只接收 [lines]
+/// - 用 [Ticker] + [SingleTickerProviderStateMixin] 每帧推进
+///   所有控制器与渲染器，触发 [setState] 重绘
+/// - 每行独立的 renderer 实例（按行索引缓存），避免多行共用导致状态混乱
+/// - [LineScaleController] 仅管理当前行 scale 弹簧，非当前行直接用 inactiveScale
+library;
+
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
+
+import 'controllers/line_scale_controller.dart';
+import 'controllers/lyric_scroll_controller.dart';
+import 'layout/lyric_layout.dart';
+import 'layout/lyric_preferences.dart';
+import 'models/lyric_line.dart';
+import 'renderers/emphasize_effect.dart';
+import 'renderers/interlude_dots.dart';
+import 'renderers/line_renderer.dart';
+import 'renderers/word_renderer.dart';
+
+/// Apple Music 风格歌词主组件。
+///
+/// 调用方负责通过 [LyricParserChain.parse] 解析得到 [lines]，本组件不再解析。
+/// 内部用 [Ticker] + [SingleTickerProviderStateMixin] 驱动每帧
+/// [tick] 推进所有控制器与渲染器，调用 [setState] 触发重绘。
+class AppleLyricsView extends StatefulWidget {
+  /// 已解析的歌词行列表（由调用方通过 LyricParserChain.parse 得到）
+  final List<LyricLine> lines;
+
+  /// 当前播放时间（毫秒）
+  final int currentTimeMs;
+
+  /// 是否正在播放
+  final bool isPlaying;
+
+  /// 用户点击某行后回调（调用方应调用 just_audio.seek）
+  final void Function(int timeMs)? onSeek;
+
+  /// 是否启用缩放（默认 true）
+  final bool enableScale;
+
+  const AppleLyricsView({
+    super.key,
+    required this.lines,
+    required this.currentTimeMs,
+    this.isPlaying = false,
+    this.onSeek,
+    this.enableScale = true,
+  });
+
+  /// 找到当前应高亮的行索引：最后一个 `startTime <= currentTimeMs` 的行。
+  ///
+  /// 抽象为静态方法便于单元测试。空列表返回 -1；时间早于第一行返回 0。
+  @visibleForTesting
+  static int findCurrentLineIndex(List<LyricLine> lines, int currentTimeMs) {
+    if (lines.isEmpty) return -1;
+    for (int i = lines.length - 1; i >= 0; i--) {
+      if (lines[i].startTime <= currentTimeMs) return i;
+    }
+    return 0;
+  }
+
+  @override
+  State<AppleLyricsView> createState() => _AppleLyricsViewState();
+}
+
+class _AppleLyricsViewState extends State<AppleLyricsView>
+    with SingleTickerProviderStateMixin {
+  // ============== 动画驱动 ==============
+  //
+  // 使用 Ticker（而非 AnimationController.addListener + DateTime.now()）驱动每帧，
+  // 因为 Ticker 的回调参数 [Duration elapsed] 基于调度器时钟（测试中为模拟时间），
+  // 保证单元测试中 pump(Duration) 能正确推进弹簧动画。
+  // AnimationController.addListener + DateTime.now() 在测试中会用真实墙钟时间，
+  // 导致弹簧几乎不推进，测试无法验证动画行为。
+
+  late final Ticker _ticker;
+  Duration _lastElapsed = Duration.zero;
+
+  // ============== 控制器与效果 ==============
+
+  final LyricScrollController _scrollController = LyricScrollController();
+  final LineScaleController _scaleController = LineScaleController();
+  final InterludeDots _interludeDots = InterludeDots();
+  final EmphasizeEffect _emphasizeEffect = EmphasizeEffect();
+
+  /// 每行独立的 [WordRenderer] 缓存（按行索引）。
+  ///
+  /// WordRenderer 内部检测 line 切换并维护 alpha map，多行共用会导致状态混乱，
+  /// 故每行独占一个实例。首次访问时懒创建。
+  final Map<int, WordRenderer> _wordRenderers = <int, WordRenderer>{};
+
+  /// 每行独立的 [LineRenderer] 缓存（按行索引）。
+  final Map<int, LineRenderer> _lineRenderers = <int, LineRenderer>{};
+
+  // ============== 当前状态 ==============
+
+  int _currentLineIndex = -1;
+  Offset? _tapDownPosition;
+
+  /// 预计算每行实际高度（含自动换行）。
+  ///
+  /// **性能优化**：只在 lines/fontSize/viewportWidth 变化时重算，
+  /// 不再每帧重算（之前每帧 build 都跑 N 次 TextPainter.layout 是 CPU 杀手）。
+  /// [_recomputeLineHeightsIfNeeded] 负责缓存命中判断。
+  List<double> _lineHeights = const <double>[];
+  List<double> _lineTops = const <double>[];
+
+  /// 哪些行索引后面有间奏（gap >= thresholdMs）。
+  ///
+  /// 用于检测当前是否进入间奏时段（_activeInterludeAfterIndex）。
+  /// 注意：只有激活间奏才占位高度（动态展开/收起），非激活间奏占位 = 0。
+  List<int> _interludeAfterIndices = const <int>[];
+
+  /// 当前激活的间奏在 _interludeAfterIndices 中的索引（-1 表示无激活）。
+  ///
+  /// 严格 AMLL 逻辑：只有 currentTime 真正进入间奏时段
+  /// （gapStart < now < gapEnd）才激活占位。
+  /// 一激活就开始 spring 展开 0 → totalHeight，
+  /// 间奏结束（now >= gapEnd）就 spring 收起 totalHeight → 0。
+  int _activeInterludeIdx = -1;
+
+  /// 最后激活的间奏 anchor 行索引（-1 表示从未激活过）。
+  ///
+  /// 用于间奏结束后 progress 收起期间继续计算占位偏移，
+  /// 避免 `_interludeOffsetBefore` 在间奏一结束就立即返回 0 导致 targetY 突变。
+  /// 当 `_interludeExpandProgress` 收起到 0 后重置为 -1。
+  int _lastActiveAnchorIdx = -1;
+
+  /// 间奏占位 spring 进度（0 = 完全收起，1 = 完全展开）。
+  ///
+  /// 用指数衰减逼近目标值，目标由 _activeInterludeIdx 决定：
+  /// - 激活：target = 1.0
+  /// - 未激活：target = 0.0
+  /// 每帧 _onTick 中推进：progress += (target - progress) * (1 - exp(-speed * dt))
+  /// speed = 18（300ms 内基本到位）
+  double _interludeExpandProgress = 0;
+
+  /// 间奏占位完全展开后的总高度（含上下 0.4em 边距，跟随 fontSize 缩放）。
+  double _interludePlaceholderHeight = 0;
+
+  // 缓存命中判断字段
+  double _cachedFontSize = -1;
+  double _cachedViewportWidth = -1;
+  int _cachedLinesLength = -1;
+  Object? _cachedLinesRef;
+
+  /// 返回指定行索引上方所有激活间奏占位的累计高度。
+  ///
+  /// **progress 驱动**：只要 `_interludeExpandProgress > 0` 就返回占位高度，
+  /// 不依赖 `_activeInterludeIdx`。这样间奏结束后 progress 缓慢收起到 0 期间，
+  /// 占位偏移也跟随平滑收起，posY target 不会突变。
+  ///
+  /// 使用 `_lastActiveAnchorIdx` 记录最后激活的间奏 anchor，
+  /// 避免影响其他未激活间奏的占位。
+  ///
+  /// 高度 = _interludePlaceholderHeight × _interludeExpandProgress
+  double _interludeOffsetBefore(int lineIndex) {
+    if (_interludeExpandProgress <= 0) return 0;
+    final int anchorIdx = _lastActiveAnchorIdx;
+    if (anchorIdx < 0 || anchorIdx >= lineIndex) return 0;
+    return _interludePlaceholderHeight * _interludeExpandProgress;
+  }
+
+  /// 根据 fontSize/viewportWidth/lines 变化判断是否需要重算 lineHeights/lineTops。
+  ///
+  /// 命中缓存时直接 return，避免每帧 N 次 TextPainter.layout（N=歌词行数）。
+  /// 50 行歌词 × 60fps = 每秒 3000 次 layout → 缓存后降为 0 次/帧。
+  ///
+  /// 同时检测相邻行间隔 >= [LyricLayout.interludeThresholdMs] 的位置，
+  /// 记录到 [_interludeAfterIndices]。占位高度动态展开/收起（不在这里固定）。
+  void _recomputeLineHeightsIfNeeded(double fontSize, double viewportWidth) {
+    final identitySame = identical(widget.lines, _cachedLinesRef);
+    if (fontSize == _cachedFontSize &&
+        viewportWidth == _cachedViewportWidth &&
+        widget.lines.length == _cachedLinesLength &&
+        identitySame &&
+        _lineHeights.length == widget.lines.length) {
+      return; // 缓存命中
+    }
+    _cachedFontSize = fontSize;
+    _cachedViewportWidth = viewportWidth;
+    _cachedLinesLength = widget.lines.length;
+    _cachedLinesRef = widget.lines;
+
+    final maxLineWidth = LyricLayout.maxLineWidth(viewportWidth, fontSize);
+    final mainLineHeight = fontSize * LyricLayout.lineHeight;
+    // 间奏占位总高度 = 点高度 + 上下 0.4em 边距
+    // 点高度约 2 * dotRadius = 2 * fontSize * 0.08 = 0.16em
+    // 边距 = 0.8em
+    // 总高度约 0.96em，约等于 1 倍主行高
+    _interludePlaceholderHeight = mainLineHeight * 1.0;
+    final List<double> heights = <double>[];
+    final List<double> tops = <double>[];
+    final List<int> interludeIndices = <int>[];
+    double acc = 0;
+    for (int i = 0; i < widget.lines.length; i++) {
+      final line = widget.lines[i];
+      heights.add(LyricLayout.measureLineHeight(
+        line,
+        fontSize,
+        mainLineHeight,
+        maxLineWidth,
+      ));
+      tops.add(acc);
+      acc += heights.last;
+      // 检测当前行与下一行之间是否有间奏（最后一行后面无间奏）
+      if (i < widget.lines.length - 1) {
+        final next = widget.lines[i + 1];
+        final gap = next.startTime - line.endTime;
+        if (gap >= LyricLayout.interludeThresholdMs) {
+          interludeIndices.add(i);
+        }
+      }
+    }
+    _lineHeights = heights;
+    _lineTops = tops;
+    _interludeAfterIndices = interludeIndices;
+    // 重置激活间奏（lines 变化时）
+    _activeInterludeIdx = -1;
+    _lastActiveAnchorIdx = -1;
+    _interludeExpandProgress = 0;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    // createTicker 由 SingleTickerProviderStateMixin 提供，
+    // 在 widget 不可见时自动暂停（muted），节省 CPU。
+    _ticker = createTicker(_onTick);
+    _ticker.start();
+    _lastElapsed = Duration.zero;
+    // 监听字号/行间距偏好变化，实时刷新（设置页滑块、长按菜单调节后立即生效）
+    LyricPreferences.instance.addListener(_onPreferencesChanged);
+  }
+
+  /// 偏好变化时触发重绘（不需要 setState，因为 _onTick 每帧 setState），
+  /// 但偏好变化时若 ticker 未启动（暂停状态），需要手动 setState 触发一次。
+  void _onPreferencesChanged() {
+    if (!_ticker.isActive) {
+      setState(() {});
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant AppleLyricsView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // lines 列表缩短时，清理不再存在的行索引对应的 renderer 缓存，避免内存泄漏
+    _wordRenderers.removeWhere((key, _) => key >= widget.lines.length);
+    _lineRenderers.removeWhere((key, _) => key >= widget.lines.length);
+  }
+
+  @override
+  void dispose() {
+    _ticker.dispose();
+    _scrollController.dispose();
+    LyricPreferences.instance.removeListener(_onPreferencesChanged);
+    super.dispose();
+  }
+
+  // ============== 工具方法 ==============
+
+  /// 获取或创建指定行的 [WordRenderer]。
+  WordRenderer _wordRendererFor(int index) =>
+      _wordRenderers.putIfAbsent(index, () => WordRenderer());
+
+  /// 获取或创建指定行的 [LineRenderer]。
+  LineRenderer _lineRendererFor(int index) =>
+      _lineRenderers.putIfAbsent(index, () => LineRenderer());
+
+  /// 计算指定行的播放进度（0~1），用于 [WordRenderer.tick] 的 progress 参数。
+  double _lineProgress(int lineIndex, int currentTimeMs) {
+    if (lineIndex < 0 || lineIndex >= widget.lines.length) return 0.0;
+    final line = widget.lines[lineIndex];
+    if (line.duration <= 0) return 0.0;
+    final p = (currentTimeMs - line.startTime) / line.duration;
+    return p.clamp(0.0, 1.0).toDouble();
+  }
+
+  // ============== 动画推进 ==============
+
+  void _onTick(Duration elapsed) {
+    // 使用 Ticker 的调度器时钟（测试中为模拟时间）计算 dt，
+    // 避免 DateTime.now() 在测试中返回真实墙钟时间导致弹簧不推进。
+    final dt = (elapsed - _lastElapsed).inMicroseconds / 1000000.0;
+    _lastElapsed = elapsed;
+
+    // 1. 找当前行
+    _currentLineIndex =
+        AppleLyricsView.findCurrentLineIndex(widget.lines, widget.currentTimeMs);
+
+    // 2. 推进滚动控制器（需要 lineHeight 与 intervalMs 计算目标 posY）
+    if (_currentLineIndex >= 0) {
+      final fontSize = LyricLayout.fontSize(context);
+      final mainLineHeight = fontSize * LyricLayout.lineHeight;
+      // 当前行实际高度（含换行）：用预计算 _lineHeights，无则降级 mainLineHeight
+      final currentLineHeight = (_currentLineIndex < _lineHeights.length
+              ? _lineHeights[_currentLineIndex]
+              : mainLineHeight);
+      // 当前行顶部 y（前面所有行高度的累加 + 间奏占位偏移）
+      final currentLineRawTop = (_currentLineIndex < _lineTops.length
+              ? _lineTops[_currentLineIndex]
+              : _currentLineIndex * mainLineHeight);
+      final currentLineTop =
+          currentLineRawTop + _interludeOffsetBefore(_currentLineIndex);
+      // intervalMs = 下一行 startTime - 当前行 endTime，用于动态 stiffness
+      int intervalMs = 0;
+      if (_currentLineIndex < widget.lines.length - 1) {
+        final current = widget.lines[_currentLineIndex];
+        final next = widget.lines[_currentLineIndex + 1];
+        intervalMs = next.startTime - current.endTime;
+      }
+      _scrollController.setCurrentLine(
+        _currentLineIndex,
+        // 暂停时视为 seeking 模式（固定弹簧参数），播放时用动态参数
+        isSeeking: !widget.isPlaying,
+        lineHeight: currentLineHeight,
+        intervalMs: intervalMs,
+        lineTop: currentLineTop,
+        // 间奏激活或占位还在收起时都用柔和 spring（stiffness=40, damping=10），
+        // 让歌词跟随占位收起时有阻尼感而非瞬移
+        isInterludeActive: _interludeExpandProgress > 0.01,
+      );
+    }
+    _scrollController.tick(dt);
+
+    // 3. 推进当前行缩放控制器（仅管理当前行的 scale 弹簧 0.97→1.0）
+    _scaleController.setLineState(
+      isActive: true,
+      enableScale: widget.enableScale,
+    );
+    _scaleController.tick(dt);
+
+    // 4. 推进每行的 renderer
+    // 性能优化：非当前行用 LineRenderer（整行单一 alpha，1 次 layout/帧），
+    // 当前行用 WordRenderer（逐字 alpha + 上浮，N 次 layout/帧）。
+    // 视口内约 10 行，从 10×N 次 layout 降为 9+N 次，主线程 CPU 显著下降。
+    final progress = _lineProgress(_currentLineIndex, widget.currentTimeMs);
+    for (int i = 0; i < widget.lines.length; i++) {
+      final line = widget.lines[i];
+      final isActive = i == _currentLineIndex;
+      // 当前行使用 LineScaleController 的弹簧 scale；非当前行直接 inactive
+      final scale = isActive
+          ? (widget.enableScale
+              ? _scaleController.currentScale
+              : LyricLayout.activeScale)
+          : (widget.enableScale
+              ? LyricLayout.inactiveScale
+              : LyricLayout.activeScale);
+      // 当前行 + 有 word 时间戳 → WordRenderer（逐字模式）
+      // 否则 → LineRenderer（整行模式，含非当前行的 KRC 行）
+      final bool useWordRenderer = isActive && line.hasWordTiming;
+      if (useWordRenderer) {
+        final renderer = _wordRendererFor(i);
+        renderer.setLineState(isActive: true, scale: scale);
+        renderer.tick(dt, progress);
+      } else {
+        final renderer = _lineRendererFor(i);
+        renderer.setLineState(isActive: isActive, scale: scale);
+        renderer.tick(dt);
+      }
+    }
+
+    // 5. 间奏检测与推进
+    _updateInterlude();
+
+    // 6. 推进间奏点动画时钟（基于帧 dt，60fps 流畅，不受 positionStream 5fps 限制）
+    _interludeDots.tick(dt);
+
+    // 7. 推进间奏占位 spring（_interludeExpandProgress）
+    // 严格 AMLL：进入间奏时段 spring 展开 0 → 1，离开则 spring 收起 1 → 0
+    // 用指数衰减逼近目标值：progress += (target - progress) * (1 - exp(-speed * dt))
+    // speed = 18 对应 ~300ms 内基本到位（AMLL 视觉过渡感）
+    final double interludeTarget = _activeInterludeIdx >= 0 ? 1.0 : 0.0;
+    const double interludeSpeed = 18.0;
+    _interludeExpandProgress += (interludeTarget - _interludeExpandProgress) *
+        (1 - math.exp(-interludeSpeed * dt));
+    // 收起到接近 0 时直接归零，避免无限逼近占着微小高度
+    if (_activeInterludeIdx < 0 && _interludeExpandProgress < 0.001) {
+      _interludeExpandProgress = 0;
+    }
+
+    // 8. 触发重绘
+    setState(() {});
+  }
+
+  /// 检测当前时间是否处于某个间奏时段，更新 [_activeInterludeIdx] 和 [_interludeDots]。
+  ///
+  /// 严格 AMLL 逻辑：遍历所有 [_interludeAfterIndices]，
+  /// 找到第一个满足 `gapStart <= currentTime < gapEnd` 的间奏，
+  /// 设置为激活间奏（占位动态展开 0 → totalHeight）。
+  /// 若无激活，则清除间奏点并收起占位（totalHeight → 0）。
+  ///
+  /// 间奏时段：[line.endTime, next.startTime - interludeEarlyEndMs]，
+  /// 250ms 提前结束以准备下一行渲染（与 AMLL 一致）。
+  ///
+  /// **间奏点同步收起**：间奏结束后不立即 `clear()` 间奏点，
+  /// 让 `_animationTimeMs` 继续推进到 `interludeDuration`，
+  /// 间奏点会自然完成消失动画（最后 750ms easeInBack 缩小）。
+  /// 占位收起与点消失同步进行（都是 ~300-750ms）。
+  /// 只有当 `_interludeExpandProgress` 收起到 0 后才 `clear()` 间奏点状态。
+  void _updateInterlude() {
+    int foundIdx = -1;
+    int? gapStart;
+    int? gapEnd;
+    for (int i = 0; i < _interludeAfterIndices.length; i++) {
+      final int lineIdx = _interludeAfterIndices[i];
+      if (lineIdx < 0 || lineIdx >= widget.lines.length - 1) continue;
+      final current = widget.lines[lineIdx];
+      final next = widget.lines[lineIdx + 1];
+      final start = current.endTime;
+      final end = next.startTime - LyricLayout.interludeEarlyEndMs;
+      if (widget.currentTimeMs >= start && widget.currentTimeMs < end) {
+        foundIdx = i;
+        gapStart = start;
+        gapEnd = end;
+        break;
+      }
+    }
+
+    _activeInterludeIdx = foundIdx;
+
+    if (foundIdx >= 0 && gapStart != null && gapEnd != null) {
+      _interludeDots.setInterlude(gapStart, gapEnd);
+      // 记录最后激活的 anchor 行索引（用于间奏结束后继续计算占位偏移）
+      if (foundIdx < _interludeAfterIndices.length) {
+        _lastActiveAnchorIdx = _interludeAfterIndices[foundIdx];
+      }
+    } else {
+      // 间奏结束：不立即 clear() 间奏点
+      // 让 _animationTimeMs 继续推进到 interludeDuration，
+      // 间奏点会自然完成消失动画（最后 750ms easeInBack）
+      // 只有当 _interludeExpandProgress 收起到 0 后才 clear()
+      if (_interludeExpandProgress <= 0.001) {
+        _interludeDots.clear();
+        _lastActiveAnchorIdx = -1;
+      }
+    }
+    // 注意：间奏点动画时间由 _onTick 中的 _interludeDots.tick(dt) 推进，
+    // 不依赖 currentTimeMs（positionStream 5fps 太卡）
+  }
+
+  // ============== 点击跳转与手动滚动 ==============
+
+  void _onTapDown(TapDownDetails details) {
+    _tapDownPosition = details.localPosition;
+  }
+
+  void _onTapUp(TapUpDetails details) {
+    final downPos = _tapDownPosition;
+    if (downPos == null) return;
+    _tapDownPosition = null;
+    // 移动距离 < clickThresholdPx(10px) 视为点击，否则视为滚动
+    final delta = (details.localPosition - downPos).distance;
+    if (delta >= LyricLayout.clickThresholdPx) return;
+
+    // 计算点击 y 对应的行索引：用预计算的 lineTops（支持非均匀行高）
+    // 每行的实际 top = lineTops[i] + _interludeOffsetBefore(i)，
+    // 找第一个 (lineTops[i+1] + interludeOffset) + posY > clickY 的 i（即 clickY 落在第 i 行内）
+    final posY = _scrollController.posY;
+    final relativeY = details.localPosition.dy - posY;
+    if (_lineTops.isEmpty) return;
+    int index = -1;
+    for (int i = 0; i < _lineTops.length; i++) {
+      final top = _lineTops[i] + _interludeOffsetBefore(i);
+      final height = _lineHeights.length > i ? _lineHeights[i] : 0;
+      if (relativeY >= top && relativeY < top + height) {
+        index = i;
+        break;
+      }
+    }
+    if (index < 0 && _lineTops.isNotEmpty) {
+      // 兜底：找最接近的行
+      index = (_lineTops.length - 1).clamp(0, widget.lines.length - 1);
+    }
+    if (index >= 0 && index < widget.lines.length) {
+      widget.onSeek?.call(widget.lines[index].startTime);
+    }
+  }
+
+  /// 用户垂直拖动歌词：调用 scrollController.onUserScroll 偏移 posY 并重置 5s 回弹倒计时。
+  ///
+  /// 之前只挂了 onTapDown/onTapUp，导致用户无法上下滑动歌词（spec 要求
+  /// 用户滚动后 5s 自动回弹到当前行）。这里补上 onVerticalDragUpdate/End。
+  void _onVerticalDragUpdate(DragUpdateDetails details) {
+    _scrollController.onUserScroll(details.primaryDelta ?? 0);
+  }
+
+  void _onVerticalDragEnd(DragEndDetails details) {
+    // 传递松手时的垂直速度给 scrollController，用于惯性滚动
+    // velocity.pixelsPerSecond.dy 单位 px/s，向下为正
+    _scrollController.onUserScrollEnd(
+        velocity: details.velocity.pixelsPerSecond.dy);
+  }
+
+  // ============== 构建 ==============
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        // 设置视口大小，供 scrollController 计算 targetY
+        _scrollController.setViewportSize(
+          Size(constraints.maxWidth, constraints.maxHeight),
+        );
+
+        final fontSize = LyricLayout.fontSize(context);
+        final mainLineHeight = fontSize * LyricLayout.lineHeight;
+        // 可用最大文字宽度（视口宽 - 左右 1em 边距），用于自动换行
+        final maxLineWidth =
+            LyricLayout.maxLineWidth(constraints.maxWidth, fontSize);
+
+        // 性能优化：缓存命中检查，只在数据/字号/视口变化时重算 lineHeights/lineTops
+        // 之前每帧都跑 N 次 TextPainter.layout 是 CPU 瓶颈（UI 线程 70%+）
+        _recomputeLineHeightsIfNeeded(fontSize, constraints.maxWidth);
+
+        return GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTapDown: _onTapDown,
+          onTapUp: _onTapUp,
+          // 挂载垂直拖动手势：用户可上下滑动歌词，5s 后自动回弹到当前行。
+          onVerticalDragUpdate: _onVerticalDragUpdate,
+          onVerticalDragEnd: _onVerticalDragEnd,
+          // AMLL 上下渐变 mask：顶部底部各 15% 视口高度 alpha 渐变（黑→透明→黑）
+          // 用户确认（grill-me Q6）：按 AMLL 规范来。
+          // 用 ShaderMask + LinearGradient 实现，blendMode: dstIn
+          // 让歌词在两端淡出，营造无限滚动感。
+          child: ShaderMask(
+            shaderCallback: (Rect bounds) {
+              return LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: const <Color>[
+                  Color(0x00000000),
+                  Color(0xFF000000),
+                  Color(0xFF000000),
+                  Color(0x00000000),
+                ],
+                stops: const <double>[0.0, 0.15, 0.85, 1.0],
+              ).createShader(bounds);
+            },
+            blendMode: BlendMode.dstIn,
+            child: ClipRect(
+              child: CustomPaint(
+                painter: _LyricsPainter(
+                  lines: widget.lines,
+                  currentLineIndex: _currentLineIndex,
+                  posY: _scrollController.posY,
+                  fontSize: fontSize,
+                  mainLineHeight: mainLineHeight,
+                  lineHeights: _lineHeights,
+                  lineTops: _lineTops,
+                  viewportHeight: constraints.maxHeight,
+                  viewportWidth: constraints.maxWidth,
+                  maxLineWidth: maxLineWidth,
+                  currentTimeMs: widget.currentTimeMs,
+                  enableScale: widget.enableScale,
+                  wordRenderers: _wordRenderers,
+                  lineRenderers: _lineRenderers,
+                  scaleController: _scaleController,
+                  emphasizeEffect: _emphasizeEffect,
+                  interludeDots: _interludeDots,
+                  interludeAfterIndices: _interludeAfterIndices,
+                  interludePlaceholderHeight: _interludePlaceholderHeight,
+                  activeInterludeIdx: _activeInterludeIdx,
+                  lastActiveAnchorIdx: _lastActiveAnchorIdx,
+                  interludeExpandProgress: _interludeExpandProgress,
+                ),
+                size: Size.infinite,
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// 歌词绘制器。
+///
+/// 遍历所有 lines，跳过视口外（含 overscan=300px 上下缓冲）的行，
+/// 按行调用对应 renderer 的 [WordRenderer.paintLine] / [LineRenderer.paintLine]。
+///
+/// 当前行通过 [LineScaleController.currentScale] 提供 scale（弹簧动画），
+/// 非当前行直接使用 [LyricLayout.inactiveScale]=0.97。
+///
+/// 间奏时段在视口中央绘制 [InterludeDots]。
+///
+/// **自动换行**：每行实际高度由 [lineHeights] 提供（非均匀），
+/// 行顶部 y = lineTops[i] + posY（累加偏移）。renderer 的 paintLine 接收
+/// [maxLineWidth] 参数实现 word 级换行。
+class _LyricsPainter extends CustomPainter {
+  final List<LyricLine> lines;
+  final int currentLineIndex;
+  final double posY;
+  final double fontSize;
+  final double mainLineHeight;
+  final List<double> lineHeights;
+  final List<double> lineTops;
+  final double viewportHeight;
+  final double viewportWidth;
+  final double maxLineWidth;
+  final int currentTimeMs;
+  final bool enableScale;
+  final Map<int, WordRenderer> wordRenderers;
+  final Map<int, LineRenderer> lineRenderers;
+  final LineScaleController scaleController;
+  final EmphasizeEffect emphasizeEffect;
+  final InterludeDots interludeDots;
+  final List<int> interludeAfterIndices;
+  final double interludePlaceholderHeight;
+
+  /// 当前激活间奏在 interludeAfterIndices 中的索引（-1 = 无激活）。
+  /// 只有激活间奏才占位（动态展开/收起），其它间奏占位 = 0。
+  final int activeInterludeIdx;
+
+  /// 最后激活的间奏 anchor 行索引（-1 = 从未激活过）。
+  ///
+  /// 用于间奏结束后 progress 收起期间继续计算占位偏移。
+  final int lastActiveAnchorIdx;
+
+  /// 间奏占位 spring 进度（0 = 完全收起，1 = 完全展开）。
+  /// 占位高度 = interludePlaceholderHeight * interludeExpandProgress
+  final double interludeExpandProgress;
+
+  _LyricsPainter({
+    required this.lines,
+    required this.currentLineIndex,
+    required this.posY,
+    required this.fontSize,
+    required this.mainLineHeight,
+    required this.lineHeights,
+    required this.lineTops,
+    required this.viewportHeight,
+    required this.viewportWidth,
+    required this.maxLineWidth,
+    required this.currentTimeMs,
+    required this.enableScale,
+    required this.wordRenderers,
+    required this.lineRenderers,
+    required this.scaleController,
+    required this.emphasizeEffect,
+    required this.interludeDots,
+    required this.interludeAfterIndices,
+    required this.interludePlaceholderHeight,
+    required this.activeInterludeIdx,
+    required this.lastActiveAnchorIdx,
+    required this.interludeExpandProgress,
+  });
+
+  /// 获取指定行 i 的实际高度（含换行），降级到 mainLineHeight。
+  double _heightOf(int i) =>
+      i < lineHeights.length ? lineHeights[i] : mainLineHeight;
+
+  /// 获取指定行 i 的顶部 y（累加偏移），降级到 i * mainLineHeight。
+  /// 不包含间奏占位偏移。
+  double _topOf(int i) =>
+      i < lineTops.length ? lineTops[i] : i * mainLineHeight;
+
+  /// 计算指定行索引上方激活间奏的占位高度。
+  ///
+  /// **progress 驱动**：只要 `interludeExpandProgress > 0` 就返回占位高度，
+  /// 不依赖 `activeInterludeIdx`。这样间奏结束后 progress 缓慢收起到 0 期间，
+  /// 占位偏移也跟随平滑收起，posY target 不会突变。
+  ///
+  /// 使用 `lastActiveAnchorIdx` 记录最后激活的间奏 anchor，
+  /// 避免影响其他未激活间奏的占位。
+  ///
+  /// 高度 = interludePlaceholderHeight * interludeExpandProgress
+  double _interludeOffsetBefore(int lineIndex) {
+    if (interludeExpandProgress <= 0) return 0;
+    final int anchorIdx = lastActiveAnchorIdx;
+    if (anchorIdx < 0 || anchorIdx >= lineIndex) return 0;
+    return interludePlaceholderHeight * interludeExpandProgress;
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    // 行水平起始位置：左留 1em 边距（对应 LyricLayout.linePadding 的 horizontal）
+    final double startX = fontSize * 1.0;
+
+    for (int i = 0; i < lines.length; i++) {
+      final line = lines[i];
+      final double lineHeight = _heightOf(i);
+      // 行顶部 y 坐标 = lineTops[i] + 该行上方间奏占位偏移 + posY
+      final double y = _topOf(i) + _interludeOffsetBefore(i) + posY;
+
+      // 跳过视口外（含 overscan=300px 上下缓冲）的行，避免不必要的绘制
+      if (y + lineHeight < -LyricLayout.overscanPx) continue;
+      if (y > viewportHeight + LyricLayout.overscanPx) break;
+
+      final bool isActive = i == currentLineIndex;
+      // 当前行用 LineScaleController 的弹簧 scale，非当前行用 inactiveScale
+      final double scale = isActive
+          ? (enableScale
+              ? scaleController.currentScale
+              : LyricLayout.activeScale)
+          : (enableScale
+              ? LyricLayout.inactiveScale
+              : LyricLayout.activeScale);
+
+      // 保存画布状态，应用 scale 变换（transform-origin: left）
+      canvas.save();
+      final double pivotX = startX;
+      final double pivotY = y + lineHeight / 2;
+      canvas.translate(pivotX, pivotY);
+      canvas.scale(scale, scale);
+      canvas.translate(-pivotX, -pivotY);
+
+      // 当前行 + 有 word 时间戳 → WordRenderer（逐字模式：N 次 layout/帧）
+      // 否则 → LineRenderer（整行模式：1 次 layout/帧，含非当前行的 KRC 行）
+      // 性能优化：非当前行不需要逐字渐变，用 LineRenderer 大幅减少 layout 次数
+      final bool useWordRenderer = isActive && line.hasWordTiming;
+      if (useWordRenderer) {
+        // 逐字模式：当前行的 KRC 行
+        final renderer = wordRenderers[i] ?? WordRenderer();
+        renderer.setLineState(isActive: true, scale: scale);
+        renderer.paintLine(
+          canvas,
+          Offset(startX, y),
+          line,
+          fontSize,
+          maxWidth: maxLineWidth,
+        );
+      } else {
+        // 整行模式：LRC/纯文本行 + 非当前行的 KRC 行
+        final renderer = lineRenderers[i] ?? LineRenderer();
+        renderer.setLineState(isActive: isActive, scale: scale);
+        renderer.paintLine(
+          canvas,
+          Offset(startX, y),
+          line,
+          fontSize,
+          maxWidth: maxLineWidth,
+        );
+      }
+
+      canvas.restore();
+    }
+
+    // 绘制间奏点（若处于间奏时段或间奏结束后收起期间）。
+    // 间奏点作为占位行嵌在歌词流里，位于激活间奏的 anchor 行之后。
+    // 占位高度 = interludePlaceholderHeight * interludeExpandProgress（动态展开/收起）
+    // centerY 居中在占位区域内（动态高度的一半）。
+    // 点大小/间距跟随 fontSize 缩放：radius≈fontSize*0.18，spacing≈fontSize*0.9。
+    //
+    // **同步收起**：间奏结束后 progress 收起期间也绘制间奏点，
+    // 让点消失动画与占位收起同步（都是 ~300-750ms）。
+    if (interludeDots.shouldRender &&
+        lastActiveAnchorIdx >= 0 &&
+        lastActiveAnchorIdx < lines.length) {
+      final int anchorIdx = lastActiveAnchorIdx;
+      final double anchorHeight = _heightOf(anchorIdx);
+      final double anchorTop = _topOf(anchorIdx);
+      // anchor 行底部 y（含 anchor 行上方的间奏偏移）
+      final double anchorBottomY =
+          anchorTop + anchorHeight + _interludeOffsetBefore(anchorIdx) + posY;
+      // 占位高度动态展开：0 → interludePlaceholderHeight
+      final double placeholderH =
+          interludePlaceholderHeight * interludeExpandProgress;
+      // 间奏点 centerY 居中在占位区域内
+      final double centerY = anchorBottomY + placeholderH / 2;
+      // 点半径与间距跟随 fontSize 缩放（AMLL 风格：直径约 6-8px @ fontSize=24）
+      final double dotRadius = fontSize * 0.18;
+      final double dotSpacing = fontSize * 0.9;
+      // 间奏点单独右移：startX * 1.5（比歌词左对齐右移 0.5em）
+      // 让点整体居中偏右，视觉更平衡
+      final double dotsStartX = fontSize * 1.5;
+      interludeDots.paintAtLineY(canvas, dotsStartX, centerY,
+          dotRadius: dotRadius, spacing: dotSpacing);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _LyricsPainter oldDelegate) {
+    // 每帧重绘（动画驱动，setState 每帧调用）
+    return true;
+  }
+}

--- a/lib/widgets/apple_lyrics/controllers/line_scale_controller.dart
+++ b/lib/widgets/apple_lyrics/controllers/line_scale_controller.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/widgets.dart';
+import 'package:md3music/widgets/apple_lyrics/animation/spring.dart';
+import 'package:md3music/widgets/apple_lyrics/layout/lyric_layout.dart';
+
+/// 行缩放动画管理器
+///
+/// 参照 spec.md "Requirement: 行缩放动画" 与 AMLL 项目 `group.ts:86-106` 实现。
+/// 用 [Spring] 驱动单行的 `scale` 值，使当前行与非当前行之间通过弹簧平滑过渡。
+///
+/// 设计要点：
+/// - 当前行 `scale = 1.0`，非当前行 `scale = 0.97`（`enableScale=true` 时）。
+/// - 背景行（人声）：当前 `bgScale = 1.0`，非当前 `bgScale = 0.75`。
+/// - 主行与背景行使用不同的弹簧参数，背景行更轻更快。
+/// - 缩放基准点默认 `left`，对唱行为 `right`（影响视觉缩放方向）。
+/// - `enableScale=false` 时所有行 scale 强制为 1.0。
+class LineScaleController {
+  LineScaleController() {
+    _scaleSpring = Spring(
+      mass: LyricLayout.scaleSpringMass,
+      damping: LyricLayout.scaleSpringDamping,
+      stiffness: LyricLayout.scaleSpringStiffness,
+      // 初始即为当前行 scale，避免首帧从 0 弹起
+      initialPosition: LyricLayout.activeScale,
+    );
+  }
+
+  /// 行缩放弹簧
+  late final Spring _scaleSpring;
+
+  /// 是否为对唱行（影响 transform-origin）
+  bool _isDuet = false;
+
+  /// 设置某行是否为当前行
+  ///
+  /// [isActive] 是否当前行
+  /// [isBackground] 是否背景行（人声）
+  /// [isDuet] 是否对唱行（影响 transform-origin）
+  /// [enableScale] 是否启用缩放（false 时所有行 scale=1.0）
+  void setLineState({
+    required bool isActive,
+    bool isBackground = false,
+    bool isDuet = false,
+    bool enableScale = true,
+  }) {
+    // 未启用缩放：所有行保持 1.0
+    if (!enableScale) {
+      _scaleSpring.setTarget(LyricLayout.activeScale);
+      _isDuet = isDuet;
+      return;
+    }
+
+    if (isBackground) {
+      // 背景行弹簧：更轻更快
+      _scaleSpring.setParams(
+        mass: LyricLayout.bgScaleSpringMass,
+        damping: LyricLayout.bgScaleSpringDamping,
+        stiffness: LyricLayout.bgScaleSpringStiffness,
+      );
+      _scaleSpring.setTarget(
+        isActive
+            ? LyricLayout.backgroundActiveScale
+            : LyricLayout.backgroundInactiveScale,
+      );
+    } else {
+      // 主行弹簧
+      _scaleSpring.setParams(
+        mass: LyricLayout.scaleSpringMass,
+        damping: LyricLayout.scaleSpringDamping,
+        stiffness: LyricLayout.scaleSpringStiffness,
+      );
+      _scaleSpring.setTarget(
+        isActive ? LyricLayout.activeScale : LyricLayout.inactiveScale,
+      );
+    }
+
+    _isDuet = isDuet;
+  }
+
+  /// 推进动画
+  ///
+  /// 返回是否需要重绘（即是否仍在运动中）
+  bool tick(double dt) {
+    _scaleSpring.tick(dt);
+    return !_scaleSpring.isSettled;
+  }
+
+  /// 当前行缩放
+  double get currentScale => _scaleSpring.position;
+
+  /// 缩放基准点（对唱行为 right，其他为 left）
+  Alignment get scaleOrigin =>
+      _isDuet ? LyricLayout.scaleOriginDuet : LyricLayout.scaleOrigin;
+
+  /// 是否在动画中
+  bool get isAnimating => !_scaleSpring.isSettled;
+
+  /// 重置：弹簧回到 1.0
+  void reset() {
+    _scaleSpring.setPosition(LyricLayout.activeScale, 0);
+  }
+}

--- a/lib/widgets/apple_lyrics/controllers/lyric_scroll_controller.dart
+++ b/lib/widgets/apple_lyrics/controllers/lyric_scroll_controller.dart
@@ -1,0 +1,269 @@
+import 'package:flutter/widgets.dart';
+import 'package:md3music/widgets/apple_lyrics/animation/spring.dart';
+import 'package:md3music/widgets/apple_lyrics/layout/lyric_layout.dart';
+
+/// 歌词滚动控制器
+///
+/// 参照 spec.md "Requirement: 弹簧物理动画引擎" 与 tasks.md Task 11 实现。
+/// 用 [Spring] 驱动 `posY`（垂直滚动偏移），使当前行的中心始终位于
+/// 视口高度 [LyricLayout.alignPosition]=0.35 处（不是 0.5）。
+///
+/// 设计要点：
+/// - `tick(dt)` 由外部驱动（外部 Widget 用 `AnimationController` + `addListener`
+///   调用 `tick`），因此构造函数不需要 `vsync` 参数。
+/// - 普通播放模式下，弹簧参数由相邻行间隔动态决定（间隔越短，弹簧越灵敏）。
+/// - seeking/间奏模式下使用固定参数（stiffness=90, damping=15），更稳定。
+/// - 用户手动滚动后 5000ms 自动回弹到当前行。
+class LyricScrollController {
+  LyricScrollController() {
+    _posYSpring = Spring(
+      mass: 1,
+      stiffness: LyricLayout.posYSeekingStiffness,
+      damping: LyricLayout.posYSeekingDamping,
+      initialPosition: 0,
+    );
+  }
+
+  /// posY 弹簧
+  late final Spring _posYSpring;
+
+  /// 视口高度（像素）
+  double _viewportHeight = 0;
+
+  /// 当前行索引，-1 表示未设置
+  int _currentLineIndex = -1;
+
+  /// 当前行高度（用于自动回弹时计算 targetY）
+  double _currentLineHeight = 0;
+
+  /// 当前行顶部 y（累加偏移，支持非均匀行高）
+  ///
+  /// 之前 `targetYForLine` 用 `lineTop = lineIndex * lineHeight` 线性假设，
+  /// 启用自动换行后每行高度不同，需传入实际累加 lineTop。
+  double _currentLineTop = 0;
+
+  /// 用户是否正在拖动
+  bool _isUserScrolling = false;
+
+  /// 自动回弹剩余倒计时（毫秒），<=0 且 _autoReturned=false 时表示等待回弹
+  double _autoReturnRemainingMs = 0;
+
+  /// 是否已自动回弹（避免在倒计时结束后重复 setTarget）
+  bool _autoReturned = true;
+
+  /// 当前弹簧 stiffness（用于测试与外部诊断）
+  double _currentStiffness = LyricLayout.posYSeekingStiffness;
+
+  /// 当前弹簧 damping（用于测试与外部诊断）
+  double _currentDamping = LyricLayout.posYSeekingDamping;
+
+  /// 视口高度
+  double get viewportHeight => _viewportHeight;
+
+  /// 当前行索引
+  int get currentLineIndex => _currentLineIndex;
+
+  /// 当前 posY（用于绘制时偏移）
+  double get posY => _posYSpring.position;
+
+  /// 当前弹簧目标（用于测试与外部诊断）
+  double get currentTarget => _posYSpring.target;
+
+  /// 当前弹簧 stiffness（用于测试）
+  double get currentStiffness => _currentStiffness;
+
+  /// 当前弹簧 damping（用于测试）
+  double get currentDamping => _currentDamping;
+
+  /// 设置视口尺寸
+  void setViewportSize(Size size) {
+    _viewportHeight = size.height;
+  }
+
+  /// 设置当前行
+  ///
+  /// [isSeeking] 为 true 时使用固定弹簧参数（stiffness=90, damping=15）；
+  /// 为 false 时使用动态参数（基于 [intervalMs]）。
+  ///
+  /// [isInterludeActive] 为 true 时使用更柔和的弹簧参数（stiffness=40, damping=10），
+  /// 让间奏结束时歌词跟随占位收起更柔软（约 500ms 到位而非瞬移）。
+  /// 优先级：isSeeking > isInterludeActive > 普通模式。
+  ///
+  /// [intervalMs] 为下一行 startTime - 当前行 endTime，仅 [isSeeking]=false
+  /// 时用于计算动态 stiffness。会被 clamp 到 [100, 800]。
+  ///
+  /// [lineHeight] 为当前行的总高度（含 padding 与自动换行高度），
+  /// 用于计算 targetY。
+  ///
+  /// [lineTop] 为当前行顶部 y（前面所有行高度的累加），用于自动换行场景。
+  /// 默认 -1 表示用线性假设 `lineTop = lineIndex * lineHeight`。
+  ///
+  /// **重要**：用户正在拖动歌词时（[onUserScroll] 后到 5000ms 回弹前），
+  /// 不调用 `setTarget`，避免覆盖用户手动滚动位置导致瞬间回弹。
+  /// 仅更新 `_currentLineIndex` 和 `_currentLineHeight`，等用户松手 5s 后
+  /// 由 [_returnToCurrentLine] 自动对齐到最新行。
+  void setCurrentLine(
+    int index, {
+    required bool isSeeking,
+    required double lineHeight,
+    int intervalMs = 0,
+    double lineTop = -1,
+    bool isInterludeActive = false,
+  }) {
+    _currentLineIndex = index;
+    _currentLineHeight = lineHeight;
+    _currentLineTop = lineTop >= 0 ? lineTop : index * lineHeight;
+    _applySpringParams(isSeeking, intervalMs, isInterludeActive);
+    // 用户滚动期间不强制 setTarget，等 5s 倒计时结束后自动回弹到最新行
+    if (!_isUserScrolling && _autoReturned) {
+      final double targetY = targetYForLine(index, lineHeight, lineTop: lineTop);
+      _posYSpring.setTarget(targetY);
+    }
+  }
+
+  /// 应用弹簧参数
+  ///
+  /// 优先级：seeking > 间奏 > 普通。
+  /// - seeking 模式：固定 stiffness=90, damping=15
+  /// - 间奏模式：固定 stiffness=40, damping=10（更柔和，跟随占位收起）
+  /// - 普通模式：stiffness = LyricLayout.posYNormalStiffness(intervalMs)，
+  ///   damping = LyricLayout.posYNormalDamping(stiffness)
+  void _applySpringParams(bool isSeeking, int intervalMs,
+      [bool isInterludeActive = false]) {
+    if (isSeeking) {
+      _currentStiffness = LyricLayout.posYSeekingStiffness;
+      _currentDamping = LyricLayout.posYSeekingDamping;
+    } else if (isInterludeActive) {
+      // 间奏模式：更柔和的弹簧，让歌词跟随占位收起时有阻尼感
+      _currentStiffness = 40;
+      _currentDamping = 10;
+    } else {
+      _currentStiffness = LyricLayout.posYNormalStiffness(intervalMs);
+      _currentDamping = LyricLayout.posYNormalDamping(_currentStiffness);
+    }
+    _posYSpring.setParams(
+      mass: 1,
+      stiffness: _currentStiffness,
+      damping: _currentDamping,
+    );
+  }
+
+  /// 计算某行的目标 posY
+  ///
+  /// 公式：`targetY = -(lineTop + lineHeight/2 - viewportHeight * alignPosition)`
+  ///
+  /// 负号因为滚动是反向偏移（posY 越负，内容越往上）。
+  ///
+  /// [lineTop] 默认 -1 表示用线性假设 `lineTop = lineIndex * lineHeight`；
+  /// 自动换行场景下需传入实际累加 lineTop（前面所有行高度之和）。
+  ///
+  /// 例：viewport=600, lineHeight=40, lineIndex=0, alignPosition=0.35
+  ///   → targetY = -(0 + 20 - 210) = 190
+  double targetYForLine(int lineIndex, double lineHeight, {double lineTop = -1}) {
+    final double top = lineTop >= 0 ? lineTop : lineIndex * lineHeight;
+    return -(top + lineHeight / 2 - _viewportHeight * LyricLayout.alignPosition);
+  }
+
+  /// 用户手动滚动（拖动）
+  ///
+  /// 直接修改 spring 的 position（不通过 setTarget），并重置 5000ms 倒计时。
+  /// 在倒计时结束前若用户停止滚动，将自动回弹到当前行的 targetY。
+  void onUserScroll(double delta) {
+    // setPosition 会把 target 同步设为当前 position，弹簧暂时不会回弹；
+    // 等 5000ms 倒计时结束后再 setTarget 触发回弹。
+    _posYSpring.setPosition(_posYSpring.position + delta, 0);
+    _isUserScrolling = true;
+    _autoReturnRemainingMs = LyricLayout.autoReturnMs.toDouble();
+    _autoReturned = false;
+  }
+
+  /// 用户滚动结束
+  ///
+  /// 从此时起开始 5000ms 倒计时，到时自动回弹到当前行。
+  ///
+  /// **惯性滚动（AMLL 标准）**：松手时根据 [velocity] 计算惯性距离，
+  /// 让歌词继续滑动一段再停下，营造自然物理感。
+  /// - velocity 单位：px/s（来自 DragEndDetails.velocity.pixelsPerSecond.dy）
+  /// - 惯性距离 = velocity * 0.3s，clamp 到 [-300, 300] px
+  /// - 用 spring 的 velocity 注入 + target 偏移实现衰减
+  void onUserScrollEnd({double velocity = 0}) {
+    _isUserScrolling = false;
+
+    // 注入惯性：松手时根据速度让歌词继续滑动一段距离
+    // 距离 = velocity * 0.3s，clamp 到 ±300px（AMLL 标准 200-400px）
+    final double inertiaDistance =
+        (velocity * 0.3).clamp(-300.0, 300.0);
+    if (inertiaDistance.abs() > 5) {
+      // 用当前位置 + 惯性距离作为新 target，并注入速度
+      // setPosition 会把 target 设为 position，所以先 setPosition 注入速度，
+      // 再 setTarget 偏移 target（setTarget 会保留当前 velocity）
+      final double currentPos = _posYSpring.position;
+      _posYSpring.setPosition(currentPos, velocity);
+      _posYSpring.setTarget(currentPos + inertiaDistance);
+    }
+
+    // 仅在尚未回弹时重置倒计时
+    if (!_autoReturned) {
+      _autoReturnRemainingMs = LyricLayout.autoReturnMs.toDouble();
+    }
+  }
+
+  /// 推进动画，返回是否需要重绘
+  ///
+  /// 返回 true 表示 spring 仍在运动或即将开始运动，需要重绘；false 表示已稳定。
+  /// 同时负责推进自动回弹倒计时（用户停止滚动后 5000ms）。
+  bool tick(double dt) {
+    // 推进自动回弹倒计时（仅在用户停止滚动且尚未回弹时）
+    if (!_isUserScrolling && !_autoReturned && _autoReturnRemainingMs > 0) {
+      _autoReturnRemainingMs -= dt * 1000;
+      if (_autoReturnRemainingMs <= 0) {
+        _autoReturnRemainingMs = 0;
+        _returnToCurrentLine();
+      }
+    }
+
+    _posYSpring.tick(dt);
+    return !_posYSpring.isSettled;
+  }
+
+  /// 自动回弹到当前行的 targetY
+  void _returnToCurrentLine() {
+    _autoReturned = true;
+    if (_currentLineIndex < 0 || _currentLineHeight <= 0) return;
+    final double targetY = targetYForLine(
+      _currentLineIndex,
+      _currentLineHeight,
+      lineTop: _currentLineTop,
+    );
+    _posYSpring.setTarget(targetY);
+  }
+
+  /// 判断手势是否为点击
+  ///
+  /// 移动总距离 < [LyricLayout.clickThresholdPx]=10px 视为点击。
+  bool isClickGesture(double totalDelta) {
+    return totalDelta.abs() < LyricLayout.clickThresholdPx;
+  }
+
+  /// 设置普通/seeking 模式
+  ///
+  /// 切换模式时会立即应用对应的弹簧参数。
+  /// [isSeeking]=true 使用固定参数（90, 15）；
+  /// false 使用普通模式默认参数（intervalMs=0 → clamp 到 100，stiffness=220）。
+  void setSeekingMode(bool isSeeking) {
+    _applySpringParams(isSeeking, 0, false);
+  }
+
+  /// 释放资源
+  ///
+  /// Spring 是纯 Dart 对象，无需显式释放，但保留 dispose 以便未来扩展
+  /// （如内部添加 Ticker/AnimationController 时在此释放）。
+  void dispose() {
+    _currentLineIndex = -1;
+    _viewportHeight = 0;
+    _currentLineHeight = 0;
+    _currentLineTop = 0;
+    _autoReturned = true;
+    _autoReturnRemainingMs = 0;
+  }
+}

--- a/lib/widgets/apple_lyrics/layout/lyric_layout.dart
+++ b/lib/widgets/apple_lyrics/layout/lyric_layout.dart
@@ -1,0 +1,286 @@
+import 'dart:math' as math;
+
+import 'package:flutter/widgets.dart';
+
+import '../models/lyric_line.dart';
+import 'lyric_preferences.dart';
+
+/// Apple Music 风格歌词布局常量
+///
+/// 参照 spec.md "Requirement: 字号与行距" 与 "行为参数" / "alpha 参数" 章节，
+/// 集中定义所有字号、行距、缩放、弹簧、滚动等布局常量与计算函数。
+///
+/// 字号与行距支持用户偏好调节（[LyricPreferences]），不再使用固定值。
+/// 默认字号 15px，默认行间距系数 1.5（可通过设置页滑块或长按菜单调整）。
+class LyricLayout {
+  LyricLayout._();
+
+  // ============== 字号与行高（主行） ==============
+
+  /// 字号：返回用户偏好的字号（[LyricPreferences.fontSize]）。
+  ///
+  /// 之前是 `max(8vw, 12px)` 固定公式，导致字号过大且不可调。
+  /// 现在改为从 [LyricPreferences] 读取，默认 15px，范围 12~30px。
+  /// 调用方仍传 [BuildContext]，保留以便未来根据屏幕尺寸自适应缩放。
+  static double fontSize(BuildContext context) {
+    return LyricPreferences.instance.fontSize;
+  }
+
+  /// 行高系数：返回用户偏好行高系数（基于 [LyricPreferences.lineSpacing]）。
+  ///
+  /// 公式：`lineHeight = (fontSize / defaultFontSize) * lineSpacing`
+  /// 例如 fontSize=15, lineSpacing=1.5 → 1.5；
+  /// fontSize=20, lineSpacing=1.0 → (20/15)*1.0 ≈ 1.33。
+  ///
+  /// 之前是固定 1.2，现在支持跟随字号缩放 + 用户调节。
+  static double get lineHeight => LyricPreferences.instance.lineHeightMultiplier;
+
+  // ============== 行 wrapper 间距 ==============
+
+  /// 行 wrapper padding（垂直 0.4em，水平 1em）
+  ///
+  /// em 基于当前字号，需在调用处传入 [fontSize] 计算结果。
+  static EdgeInsets linePadding(double fontSize) {
+    return EdgeInsets.symmetric(
+      vertical: fontSize * 0.4,
+      horizontal: fontSize * 1.0,
+    );
+  }
+
+  /// 行 wrapper 内 gap：0.3em
+  static double lineGap(double fontSize) => fontSize * 0.3;
+
+  // ============== 自动换行 ==============
+
+  /// 换行行高系数：换行的内部行高 = 主行高 × 0.8。
+  ///
+  /// 用户确认（grill-me Q4）：换行行高 0.8x 正常行高，左边距与主行一致。
+  /// 即一行歌词若换为 N 个视觉行（N≥1），总高度为：
+  /// `mainLineHeight + (N - 1) * mainLineHeight * wrapLineHeightFactor`
+  static const double wrapLineHeightFactor = 0.8;
+
+  /// 计算视口内单行歌词可用的最大文字宽度（像素）。
+  ///
+  /// 左右边距各 1em（与 [linePadding] horizontal 一致，左对齐到 startX）。
+  /// 超出此宽度即触发自动换行。
+  static double maxLineWidth(double viewportWidth, double fontSize) {
+    final sidePadding = fontSize * 1.0;
+    final w = viewportWidth - sidePadding * 2;
+    return w > 0 ? w : 0;
+  }
+
+  /// 测量指定行在视口宽度内实际占用的总高度（含自动换行）。
+  ///
+  /// - 无 word 时间戳：用 [TextPainter] 对整行 text 自动换行测量。
+  /// - 有 word 时间戳：按 word 累加 dx 超过 [maxWidth] 即换行。
+  ///
+  /// 返回值即该行在垂直方向占用的像素高度。
+  static double measureLineHeight(
+    LyricLine line,
+    double fontSize,
+    double mainLineHeight,
+    double maxWidth,
+  ) {
+    if (maxWidth <= 0 || line.text.isEmpty) return mainLineHeight;
+
+    if (line.words.isEmpty) {
+      // 纯文本行：用 TextPainter 自动换行
+      final painter = TextPainter(
+        text: TextSpan(
+          text: line.text,
+          style: TextStyle(fontSize: fontSize, height: lineHeight),
+        ),
+        textDirection: TextDirection.ltr,
+      )..layout(maxWidth: maxWidth);
+      final lineCount = painter.computeLineMetrics().length;
+      return lineCount <= 1
+          ? mainLineHeight
+          : mainLineHeight +
+              (lineCount - 1) * mainLineHeight * wrapLineHeightFactor;
+    }
+
+    // 逐字行：按 word 累加，超宽即换行
+    double dx = 0;
+    int rowCount = 1;
+    for (final word in line.words) {
+      final painter = TextPainter(
+        text: TextSpan(
+          text: word.text,
+          style: TextStyle(fontSize: fontSize, height: lineHeight),
+        ),
+        textDirection: TextDirection.ltr,
+      )..layout();
+      if (dx + painter.width > maxWidth && dx > 0) {
+        dx = 0;
+        rowCount++;
+      }
+      dx += painter.width;
+    }
+    return rowCount <= 1
+        ? mainLineHeight
+        : mainLineHeight +
+            (rowCount - 1) * mainLineHeight * wrapLineHeightFactor;
+  }
+
+  // ============== 副行（翻译） ==============
+
+  /// 副行（翻译）字号：`max(0.5em, 10px)`
+  ///
+  /// 0.5em 为主行字号的一半，再与 10px 取下限保护。
+  static double translationFontSize(double fontSize) {
+    final half = fontSize * 0.5;
+    return half > 10 ? half : 10;
+  }
+
+  /// 副行行高：1.5em
+  static const double translationLineHeight = 1.5;
+
+  /// 副行透明度
+  static const double translationOpacity = 0.3;
+
+  // ============== 背景行（人声） ==============
+
+  /// 背景行（人声）透明度
+  static const double backgroundLineOpacity = 0.4;
+
+  /// 背景行字号缩放
+  static const double backgroundLineFontScale = 0.7;
+
+  // ============== 行缩放 ==============
+
+  /// 当前行缩放
+  static const double activeScale = 1.0;
+
+  /// 非当前行缩放（enableScale=true 时）
+  static const double inactiveScale = 0.97;
+
+  /// 背景行：当前行缩放
+  static const double backgroundActiveScale = 1.0;
+
+  /// 背景行：非当前行缩放
+  static const double backgroundInactiveScale = 0.75;
+
+  /// 缩放基准点：默认 left（对唱行 right）
+  static const Alignment scaleOrigin = Alignment.centerLeft;
+
+  /// 对唱行缩放基准点
+  static const Alignment scaleOriginDuet = Alignment.centerRight;
+
+  // ============== 颜色 ==============
+
+  /// 文字颜色（固定白色 #FFFFFF）
+  static const int textColorValue = 0xFFFFFFFF;
+
+  /// 背景颜色（半透明黑 rgba(0,0,0,0.35)）
+  ///
+  /// 0.35 * 255 ≈ 89 = 0x59，故 ARGB 为 0x59000000。
+  static const int backgroundColorValue = 0x59000000;
+
+  // ============== alpha 参数 ==============
+
+  /// 当前字已播亮态 alpha（满 scale 时 1.0）
+  static const double currentBrightAlpha = 1.0;
+
+  /// 当前字未播暗态 alpha（满 scale 时 0.2）
+  static const double currentDarkAlpha = 0.2;
+
+  /// ATTACK 速度：当前字变亮指数渐变系数
+  static const double attackSpeed = 50.0;
+
+  /// RELEASE 速度：当前字变暗指数渐变系数
+  static const double releaseSpeed = 7.0;
+
+  /// alpha 渐变阈值：低于此值认为已收敛
+  static const double alphaEpsilon = 0.001;
+
+  // ============== 滚动与对齐 ==============
+
+  /// 对齐位置：行中心位于视口高度 35% 处（不是 0.5）
+  static const double alignPosition = 0.35;
+
+  /// overscan：视口上下额外预渲染像素
+  static const double overscanPx = 300;
+
+  /// 间奏阈值：相邻行间隔 >= 此值时渲染间奏点
+  static const int interludeThresholdMs = 4000;
+
+  /// 间奏提前结束：间奏动画提前此毫秒数结束以准备下一行
+  static const int interludeEarlyEndMs = 250;
+
+  /// 点击判定阈值：< 此像素值视为点击，否则视为滚动
+  static const double clickThresholdPx = 10;
+
+  /// 用户滚动后自动回弹到当前行的超时时间
+  static const int autoReturnMs = 5000;
+
+  // ============== 弹簧参数：行缩放 ==============
+
+  /// 主行缩放弹簧：mass
+  static const double scaleSpringMass = 2;
+
+  /// 主行缩放弹簧：damping
+  static const double scaleSpringDamping = 25;
+
+  /// 主行缩放弹簧：stiffness
+  static const double scaleSpringStiffness = 100;
+
+  // ============== 弹簧参数：背景行缩放 ==============
+
+  /// 背景行缩放弹簧：mass
+  static const double bgScaleSpringMass = 1;
+
+  /// 背景行缩放弹簧：damping
+  static const double bgScaleSpringDamping = 20;
+
+  /// 背景行缩放弹簧：stiffness
+  static const double bgScaleSpringStiffness = 50;
+
+  // ============== 弹簧参数：posY seeking/间奏模式 ==============
+
+  /// posY seeking/间奏模式：stiffness
+  static const double posYSeekingStiffness = 90;
+
+  /// posY seeking/间奏模式：damping
+  static const double posYSeekingDamping = 15;
+
+  // ============== 弹簧参数：posY 普通播放动态范围 ==============
+
+  /// posY 普通播放 stiffness 下限
+  static const double posYNormalStiffnessMin = 170;
+
+  /// posY 普通播放 stiffness 上限
+  static const double posYNormalStiffnessMax = 220;
+
+  /// posY 普通播放 interval 下限（ms）
+  static const int posYNormalIntervalMinMs = 100;
+
+  /// posY 普通播放 interval 上限（ms）
+  static const int posYNormalIntervalMaxMs = 800;
+
+  /// 计算 posY 普通播放的 stiffness
+  ///
+  /// 公式（spec.md "Scenario: posY 滚动弹簧（普通播放）"）：
+  /// ```
+  /// ratio = (1 - (interval - 100) / 700) ** 0.2
+  /// stiffness = 170 + ratio * 50
+  /// ```
+  /// 其中 intervalMs 会被 clamp 到 [100, 800]：
+  /// - interval=100ms（密集）→ ratio=1.0 → stiffness=220（最灵敏）
+  /// - interval=800ms（稀疏）→ ratio=0.0 → stiffness=170（最迟缓）
+  static double posYNormalStiffness(int intervalMs) {
+    final clamped =
+        intervalMs.clamp(posYNormalIntervalMinMs, posYNormalIntervalMaxMs)
+            .toDouble();
+    final ratio = math.pow(1 - (clamped - 100) / 700, 0.2).toDouble();
+    return 170 + ratio * 50;
+  }
+
+  /// 计算 posY 普通播放的 damping
+  ///
+  /// 公式：`damping = sqrt(stiffness) * 2.2`
+  ///
+  /// 例：stiffness=220 → damping≈32.63；stiffness=170 → damping≈28.68。
+  static double posYNormalDamping(double stiffness) {
+    return math.sqrt(stiffness) * 2.2;
+  }
+}

--- a/lib/widgets/apple_lyrics/layout/lyric_preferences.dart
+++ b/lib/widgets/apple_lyrics/layout/lyric_preferences.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// 歌词显示偏好设置（字号 + 行间距）。
+///
+/// 提供全局静态访问 + ChangeNotifier 通知，供 AppleLyricsView、
+/// 设置页滑块、长按菜单共同读写。
+///
+/// 偏好通过 SharedPreferences 持久化。
+///
+/// 字号范围：[minFontSize] ~ [maxFontSize]，默认 [defaultFontSize]。
+/// 行间距系数范围：[minLineSpacing] ~ [maxLineSpacing]，默认 [defaultLineSpacing]。
+/// 实际行高 = (fontSize / defaultFontSize) * lineSpacing。
+class LyricPreferences extends ChangeNotifier {
+  LyricPreferences._();
+  static final LyricPreferences instance = LyricPreferences._();
+
+  // ============== 范围与默认值 ==============
+
+  /// 字号最小值（px）
+  static const double minFontSize = 12;
+
+  /// 字号最大值（px）
+  static const double maxFontSize = 30;
+
+  /// 字号默认值（px）
+  static const double defaultFontSize = 15;
+
+  /// 行间距系数最小值
+  ///
+  /// 下限 0.5 允许把行间距压到比默认行高更紧（0.5×），用于紧凑排版偏好。
+  static const double minLineSpacing = 0.5;
+
+  /// 行间距系数最大值
+  static const double maxLineSpacing = 2.0;
+
+  /// 行间距系数默认值
+  static const double defaultLineSpacing = 1.5;
+
+  // ============== SharedPreferences keys ==============
+
+  static const String _keyFontSize = 'lyric_font_size';
+  static const String _keyLineSpacing = 'lyric_line_spacing';
+
+  // ============== 当前值 ==============
+
+  double _fontSize = defaultFontSize;
+  double _lineSpacing = defaultLineSpacing;
+  bool _loaded = false;
+
+  double get fontSize => _fontSize;
+  double get lineSpacing => _lineSpacing;
+
+  /// 计算实际行高系数。
+  ///
+  /// 公式：`actualLineHeight = (fontSize / defaultFontSize) * lineSpacing`
+  /// 例如：
+  /// - fontSize=15, lineSpacing=1.5 → (15/15)*1.5 = 1.5
+  /// - fontSize=15, lineSpacing=1.0 → (15/15)*1.0 = 1.0
+  /// - fontSize=20, lineSpacing=1.0 → (20/15)*1.0 ≈ 1.33
+  double get lineHeightMultiplier =>
+      (_fontSize / defaultFontSize) * _lineSpacing;
+
+  /// 从 SharedPreferences 加载。App 启动时调用一次。
+  Future<void> load() async {
+    if (_loaded) return;
+    final prefs = await SharedPreferences.getInstance();
+    _fontSize = prefs.getDouble(_keyFontSize) ?? defaultFontSize;
+    _lineSpacing = prefs.getDouble(_keyLineSpacing) ?? defaultLineSpacing;
+    _loaded = true;
+    notifyListeners();
+  }
+
+  /// 设置字号并持久化。会触发 [notifyListeners]。
+  Future<void> setFontSize(double size) async {
+    final clamped = size.clamp(minFontSize, maxFontSize);
+    if (clamped == _fontSize) return;
+    _fontSize = clamped;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setDouble(_keyFontSize, _fontSize);
+  }
+
+  /// 设置行间距系数并持久化。
+  Future<void> setLineSpacing(double spacing) async {
+    final clamped = spacing.clamp(minLineSpacing, maxLineSpacing);
+    if (clamped == _lineSpacing) return;
+    _lineSpacing = clamped;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setDouble(_keyLineSpacing, _lineSpacing);
+  }
+
+  /// 重置为默认值。
+  Future<void> reset() async {
+    _fontSize = defaultFontSize;
+    _lineSpacing = defaultLineSpacing;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setDouble(_keyFontSize, _fontSize);
+    await prefs.setDouble(_keyLineSpacing, _lineSpacing);
+  }
+}

--- a/lib/widgets/apple_lyrics/layout/lyric_preferences_panel.dart
+++ b/lib/widgets/apple_lyrics/layout/lyric_preferences_panel.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+
+import 'lyric_preferences.dart';
+
+/// 歌词字号/行间距调节面板。
+///
+/// 可嵌入设置页或作为 BottomSheet 弹出。
+/// 用 AnimatedBuilder 监听 [LyricPreferences]，滑动滑块时实时刷新歌词。
+///
+/// 字号范围 12~30px，行间距系数范围 1.0~2.0。
+/// 行高公式：`actualLineHeight = (fontSize / defaultFontSize) * lineSpacing`。
+class LyricPreferencesPanel extends StatelessWidget {
+  const LyricPreferencesPanel({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final prefs = LyricPreferences.instance;
+    return AnimatedBuilder(
+      animation: prefs,
+      builder: (context, _) {
+        return Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // 标题栏
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    '歌词显示',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  TextButton(
+                    onPressed: () => prefs.reset(),
+                    child: const Text('重置'),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              // 字号滑块
+              Text('字号：${prefs.fontSize.round()} px'),
+              Slider(
+                min: LyricPreferences.minFontSize,
+                max: LyricPreferences.maxFontSize,
+                divisions:
+                    (LyricPreferences.maxFontSize -
+                            LyricPreferences.minFontSize)
+                        .round(),
+                value: prefs.fontSize,
+                onChanged: prefs.setFontSize,
+              ),
+              const SizedBox(height: 8),
+              // 行间距滑块
+              Text('行间距：${prefs.lineSpacing.toStringAsFixed(1)} ×'),
+              Slider(
+                min: LyricPreferences.minLineSpacing,
+                max: LyricPreferences.maxLineSpacing,
+                divisions: ((LyricPreferences.maxLineSpacing -
+                            LyricPreferences.minLineSpacing) *
+                        10)
+                    .round(),
+                value: prefs.lineSpacing,
+                onChanged: prefs.setLineSpacing,
+              ),
+              const SizedBox(height: 8),
+              // 实际行高预览
+              Text(
+                '实际行高倍数：${prefs.lineHeightMultiplier.toStringAsFixed(2)} ×',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/widgets/apple_lyrics/models/lyric_line.dart
+++ b/lib/widgets/apple_lyrics/models/lyric_line.dart
@@ -1,0 +1,108 @@
+/// 统一歌词模型。
+///
+/// 定义 [LyricWord]（字级时间戳）与 [LyricLine]（行级时间戳 + 字列表）
+/// 两个不可变值对象，供所有歌词解析器（KRC / LRC / 纯文本）输出统一结构，
+/// 渲染层只认模型不关心来源。详见 spec.md "Requirement: 统一歌词模型"。
+library;
+
+import 'package:flutter/foundation.dart';
+
+/// 单个歌词字（逐字时间戳）。
+///
+/// 用于 KRC 逐字渲染：每个字携带独立的起止时间，渲染器据此计算
+/// mask alpha 渐变（已播字亮 / 未播字暗）。LRC 与纯文本不产生 [LyricWord]。
+class LyricWord {
+  /// 起始时间，毫秒，绝对时间（相对歌曲起点）。
+  final int startTime;
+
+  /// 持续时长，毫秒。
+  final int duration;
+
+  /// 歌词字面文本。
+  final String text;
+
+  /// 常量构造函数。
+  const LyricWord({
+    required this.startTime,
+    required this.duration,
+    required this.text,
+  });
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is LyricWord &&
+          runtimeType == other.runtimeType &&
+          startTime == other.startTime &&
+          duration == other.duration &&
+          text == other.text;
+
+  @override
+  int get hashCode => Object.hash(startTime, duration, text);
+
+  @override
+  String toString() =>
+      'LyricWord(startTime: $startTime, duration: $duration, text: \'$text\')';
+}
+
+/// 单行歌词。
+///
+/// 既能承载逐字时间戳（[words] 非空，KRC 来源），也能承载整行时间戳
+/// （[words] 为空，LRC / 纯文本来源）。渲染器通过 [hasWordTiming] 判断
+/// 是否启用逐字 mask 渲染或整行降级渲染。
+class LyricLine {
+  /// 起始时间，毫秒。
+  final int startTime;
+
+  /// 持续时长，毫秒。
+  final int duration;
+
+  /// 整行纯文本（合并 [words] 的文本或直接来自 LRC 行）。
+  final String text;
+
+  /// 逐字时间戳列表，可能为空（LRC / 纯文本）。默认空常量列表。
+  final List<LyricWord> words;
+
+  /// 翻译文本，可空（如无翻译数据）。
+  final String? translation;
+
+  /// 常量构造函数。[words] 默认空常量列表。
+  const LyricLine({
+    required this.startTime,
+    required this.duration,
+    required this.text,
+    this.words = const [],
+    this.translation,
+  });
+
+  /// 该行是否有逐字时间戳。渲染器据此切换逐字 / 整行模式。
+  bool get hasWordTiming => words.isNotEmpty;
+
+  /// 行结束时间 = [startTime] + [duration]。
+  int get endTime => startTime + duration;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is LyricLine &&
+          runtimeType == other.runtimeType &&
+          startTime == other.startTime &&
+          duration == other.duration &&
+          text == other.text &&
+          translation == other.translation &&
+          listEquals(words, other.words);
+
+  @override
+  int get hashCode => Object.hash(
+        startTime,
+        duration,
+        text,
+        translation,
+        Object.hashAll(words),
+      );
+
+  @override
+  String toString() =>
+      'LyricLine(startTime: $startTime, duration: $duration, text: \'$text\', '
+      'words: ${words.length}, translation: ${translation == null ? 'null' : '\'$translation\''})';
+}

--- a/lib/widgets/apple_lyrics/parsers/krc_parser.dart
+++ b/lib/widgets/apple_lyrics/parsers/krc_parser.dart
@@ -1,0 +1,164 @@
+/// KRC 明文歌词解析器
+///
+/// 解析已由 Node 侧解密/解码的 KRC 明文格式：
+/// ```
+/// [id:$00000000]
+/// [ar:トゲナシトゲアリ]
+/// [ti:運命の華]
+/// [12500,4200]<0,300,0>運<300,400,0>命<700,500,0>の<1200,600,0>華
+/// ```
+///
+/// 行级时间戳格式：`[start_ms,duration_ms]`
+/// 字级时间戳格式：`<offset,duration,property>字文本`
+/// 字的绝对 startTime = 行 startTime + 字 offset
+///
+/// KRC 与 LRC 不同：KRC 携带逐字时间戳信息，输出的 [LyricLine.words] 非空
+/// （[LyricLine.hasWordTiming] 为 true），渲染层应启用逐字 mask 渲染。
+/// 详见 spec.md "Requirement: KRC 解析器"。
+library;
+
+import 'package:md3music/widgets/apple_lyrics/models/lyric_line.dart';
+
+/// KRC 明文解析器。
+///
+/// 将 KRC 明文解析为 [LyricLine] 列表（含逐字 [LyricWord]）。
+/// 所有解析失败的情况（如格式损坏、抛异常）一律返回空列表，不向外抛异常。
+class KrcParser {
+  KrcParser._();
+
+  /// 行首时间戳：`[start_ms,duration_ms]` 后接任意内容
+  static final RegExp _lineTimestampRegex = RegExp(r'^\[(\d+),(\d+)\](.*)$');
+
+  /// 字级标签：`<offset,duration>` 或 `<offset,duration,property>`
+  /// property 字段可选（可能是 0 或其他整数，解析时忽略）
+  static final RegExp _wordTagRegex = RegExp(r'<(-?\d+),(-?\d+)(?:,-?\d+)?>');
+
+  /// KRC 元数据行前缀列表
+  ///
+  /// 这些前缀匹配的行将被跳过，不进入歌词列表。
+  static const List<String> _metadataPrefixes = [
+    '[id:',
+    '[ar:',
+    '[ti:',
+    '[by:',
+    '[hash:',
+    '[al:',
+    '[sign:',
+    '[qq:',
+    '[total:',
+    '[offset:',
+    '[language:',
+  ];
+
+  /// 解析 KRC 明文为 LyricLine 列表，失败返回空列表
+  ///
+  /// 输入为已解密的 KRC 明文（含元数据头与逐字行）。
+  /// 任何解析失败（包括格式损坏）都不抛异常，返回空列表或部分解析结果。
+  static List<LyricLine> parse(String krcText) {
+    try {
+      final List<LyricLine> lines = [];
+      if (krcText.isEmpty) return lines;
+
+      // 按行拆分，兼容 \n 与 \r\n
+      final rawLines = krcText.split(RegExp(r'\r?\n'));
+      for (final rawLine in rawLines) {
+        final line = rawLine.trim();
+
+        // 空行跳过
+        if (line.isEmpty) continue;
+
+        // 元数据行跳过
+        if (_isMetadata(line)) continue;
+
+        // 行首时间戳匹配
+        final lineMatch = _lineTimestampRegex.firstMatch(line);
+        if (lineMatch == null) continue;
+
+        // 解析行 startTime / duration（损坏时跳过此行）
+        final int lineStart;
+        final int lineDuration;
+        try {
+          lineStart = int.parse(lineMatch.group(1)!);
+          lineDuration = int.parse(lineMatch.group(2)!);
+        } catch (_) {
+          continue;
+        }
+
+        // 剩余部分解析字级标签
+        final rest = lineMatch.group(3) ?? '';
+        final words = _parseWords(rest, lineStart);
+
+        // 字级数据为空时，整行视为无效（无逐字信息则跳过）
+        if (words.isEmpty) continue;
+
+        // 整行文本由所有字文本拼接
+        final text = words.map((w) => w.text).join();
+
+        lines.add(LyricLine(
+          startTime: lineStart,
+          duration: lineDuration,
+          text: text,
+          words: words,
+        ));
+      }
+
+      // 按 startTime 升序排序，保证多行场景输出有序
+      lines.sort((a, b) => a.startTime.compareTo(b.startTime));
+
+      return lines;
+    } catch (_) {
+      // 整个解析失败时返回空列表，不抛异常
+      return [];
+    }
+  }
+
+  /// 判断是否为元数据行
+  static bool _isMetadata(String line) {
+    for (final prefix in _metadataPrefixes) {
+      if (line.startsWith(prefix)) return true;
+    }
+    return false;
+  }
+
+  /// 解析字级时间戳
+  ///
+  /// 输入是行首时间戳后的剩余部分，形如：
+  /// `<0,300,0>運<300,400,0>命<700,500,0>の<1200,600,0>華`
+  ///
+  /// 每个字的文本是当前 `<...>` 标签结束位置到下一个 `<...>` 标签开始位置
+  /// 之间的所有内容。使用 `String.substring` 截取，会完整保留代理对
+  /// （emoji 等）与组合字符，无需额外字符迭代处理。
+  static List<LyricWord> _parseWords(String rest, int lineStart) {
+    final List<LyricWord> words = [];
+    if (rest.isEmpty) return words;
+
+    final matches = _wordTagRegex.allMatches(rest).toList();
+    if (matches.isEmpty) return words;
+
+    for (int i = 0; i < matches.length; i++) {
+      final m = matches[i];
+
+      // 解析 offset / duration（损坏时跳过此字标签）
+      final offset = int.tryParse(m.group(1) ?? '');
+      final duration = int.tryParse(m.group(2) ?? '');
+      if (offset == null || duration == null) continue;
+
+      // 字的文本：当前标签结束 → 下一个标签开始（或字符串末尾）
+      final int textEnd =
+          (i + 1 < matches.length) ? matches[i + 1].start : rest.length;
+      final String wordText = rest.substring(m.end, textEnd);
+
+      // 空文本字跳过（避免无意义 word）
+      if (wordText.isEmpty) continue;
+
+      // 字的绝对 startTime = 行 startTime + 字 offset
+      words.add(LyricWord(
+        startTime: lineStart + offset,
+        duration: duration,
+        text: wordText,
+      ));
+    }
+
+    return words;
+  }
+}

--- a/lib/widgets/apple_lyrics/parsers/lrc_parser.dart
+++ b/lib/widgets/apple_lyrics/parsers/lrc_parser.dart
@@ -1,0 +1,90 @@
+/// LRC 歌词解析器
+///
+/// 解析标准 LRC 格式歌词文本，输出统一的 [LyricLine] 列表。
+///
+/// 支持的 LRC 特性：
+/// - 时间戳 `[mm:ss.xx]`（2 位毫秒，按厘秒处理）与 `[mm:ss.xxx]`（3 位毫秒）
+/// - 一行多时间戳：`[00:10.00][00:30.00]Chorus` 展开为多条 [LyricLine]
+/// - 元数据行过滤：`[ar:]`、`[ti:]`、`[al:]`、`[by:]`、`[offset:]` 等
+///
+/// LRC 没有逐字时间戳信息，因此输出的 [LyricLine.words] 始终为空
+/// （[LyricLine.hasWordTiming] 为 false），渲染层应使用整行降级模式。
+/// 详见 spec.md "Requirement: LRC 解析器"。
+library;
+
+import 'package:md3music/widgets/apple_lyrics/models/lyric_line.dart';
+
+/// LRC 明文解析器。
+///
+/// 将标准 LRC 文本解析为 [LyricLine] 列表。所有解析失败的情况
+/// （如格式损坏、抛异常）一律返回空列表，不向外抛异常。
+class LrcParser {
+  LrcParser._();
+
+  /// 时间戳正则：匹配 `[mm:ss.xx]` 或 `[mm:ss.xxx]`，全局可一行多次。
+  static final RegExp _timestampRegex =
+      RegExp(r'\[(\d{2}):(\d{2})\.(\d{2,3})\]');
+
+  /// 元数据前缀正则：匹配 LRC 元数据标签前缀，这些行不属于歌词内容。
+  static final RegExp _metadataPrefixRegex = RegExp(
+    r'^\[(ar|ti|al|by|offset|id|hash|total|language|sign|qq):',
+  );
+
+  /// 解析 LRC 明文为 [LyricLine] 列表。
+  ///
+  /// 解析失败时返回空列表，不抛异常。
+  static List<LyricLine> parse(String lrcText) {
+    try {
+      final List<LyricLine> result = [];
+
+      // 按行拆分，兼容 \n 与 \r\n
+      final lines = lrcText.split(RegExp(r'\r?\n'));
+
+      for (final rawLine in lines) {
+        final line = rawLine.trim();
+
+        // 空行跳过
+        if (line.isEmpty) continue;
+
+        // 元数据行跳过（[ar:]/[ti:]/[offset:] 等不匹配 mm:ss.xx 格式）
+        if (_metadataPrefixRegex.hasMatch(line)) continue;
+
+        // 提取一行内所有时间戳（支持一行多时间戳）
+        final matches = _timestampRegex.allMatches(line).toList();
+        // 无时间戳的纯文本行跳过（不属于 LRC 标准格式）
+        if (matches.isEmpty) continue;
+
+        // 剩余部分作为歌词文本（最后一个时间戳之后的内容）
+        final lastMatch = matches.last;
+        final text = line.substring(lastMatch.end).trim();
+
+        // 为每个时间戳生成一条 LyricLine（一行多时间戳展开）
+        for (final match in matches) {
+          final minutes = int.parse(match.group(1)!);
+          final seconds = int.parse(match.group(2)!);
+          final msStr = match.group(3)!;
+          // 2 位毫秒按厘秒换算（×10），3 位毫秒直接使用
+          final milliseconds =
+              int.parse(msStr) * (msStr.length == 2 ? 10 : 1);
+
+          final startTime = (minutes * 60 + seconds) * 1000 + milliseconds;
+
+          result.add(LyricLine(
+            startTime: startTime,
+            duration: 0, // LRC 没有行 duration 信息，由渲染层根据下一行 startTime 计算
+            text: text,
+            // words 默认 const []，translation 默认 null
+          ));
+        }
+      }
+
+      // 按 startTime 升序排序
+      result.sort((a, b) => a.startTime.compareTo(b.startTime));
+
+      return result;
+    } catch (_) {
+      // 失败兜底：返回空列表，不抛异常
+      return [];
+    }
+  }
+}

--- a/lib/widgets/apple_lyrics/parsers/lyric_parser_chain.dart
+++ b/lib/widgets/apple_lyrics/parsers/lyric_parser_chain.dart
@@ -1,0 +1,137 @@
+/// 解析器链调度器。
+///
+/// 按优先级 KRC → LRC → 纯文本自动检测输入格式并委托给对应的解析器。
+/// 检测策略基于"首个非空非元数据行"的格式：
+/// - `^\[\d+,\d+\]` → KRC（行级毫秒时间戳）
+/// - `^\[\d{2}:\d{2}\.\d{2,3}\]` → LRC（`[mm:ss.xx]` 时间戳）
+/// - 否则 → 纯文本
+///
+/// 若所有行都是空行或元数据行，降级为纯文本解析。
+/// 详见 spec.md "Requirement: 统一歌词模型" 与 tasks.md Task 5.3。
+library;
+
+import 'package:md3music/widgets/apple_lyrics/models/lyric_line.dart';
+import 'package:md3music/widgets/apple_lyrics/parsers/krc_parser.dart';
+import 'package:md3music/widgets/apple_lyrics/parsers/lrc_parser.dart';
+import 'package:md3music/widgets/apple_lyrics/parsers/plaintext_parser.dart';
+
+/// 歌词格式枚举，用于 [LyricParserChain.parseAs] 显式指定格式。
+enum LyricFormat { krc, lrc, plaintext }
+
+/// 歌词解析器链调度器。
+///
+/// 通过 [parse] 自动检测格式并委托给 [KrcParser] / [LrcParser] / [PlainTextParser]，
+/// 或通过 [parseAs] 显式指定格式。所有委托方法均不抛异常（解析器内部已兜底），
+/// 本调度器同样不抛异常，任何意外情况降级为纯文本。
+class LyricParserChain {
+  LyricParserChain._();
+
+  /// KRC 行首时间戳正则：`[start_ms,duration_ms]` 后接任意内容。
+  static final RegExp _krcLineRegex = RegExp(r'^\[\d+,\d+\]');
+
+  /// LRC 行首时间戳正则：`[mm:ss.xx]` 或 `[mm:ss.xxx]` 后接任意内容。
+  static final RegExp _lrcLineRegex = RegExp(r'^\[\d{2}:\d{2}\.\d{2,3}\]');
+
+  /// 元数据行前缀列表（KRC 与 LRC 合并去重，两者完全一致）。
+  ///
+  /// 这些前缀匹配的行在自动检测时会被跳过，不参与首行格式判断。
+  /// 例如 KRC 文件首行通常是 `[id:$00000000]`，第二行才是
+  /// `[12500,4200]<0,300,0>運...`，调度器需要跳过元数据行后才判断。
+  static const List<String> _metadataPrefixes = [
+    '[id:',
+    '[ar:',
+    '[ti:',
+    '[by:',
+    '[hash:',
+    '[al:',
+    '[sign:',
+    '[qq:',
+    '[total:',
+    '[offset:',
+    '[language:',
+  ];
+
+  /// 自动检测格式并解析，按优先级 KRC → LRC → 纯文本。
+  ///
+  /// 检测逻辑：找到首个非空非元数据行，用正则匹配其前缀决定走哪个解析器；
+  /// 若所有行均为空或元数据，降级为纯文本解析。
+  static List<LyricLine> parse(String text) {
+    try {
+      final format = detectFormat(text);
+      return _delegate(text, format);
+    } catch (_) {
+      // 任何意外都降级纯文本，保证不抛异常
+      return PlainTextParser.parse(text);
+    }
+  }
+
+  /// 显式指定格式解析（可选辅助方法）。
+  ///
+  /// 调用方已知格式时可直接指定，跳过自动检测。例如外部已通过文件扩展名
+  /// 或服务端字段确认是 KRC，可直接 `parseAs(text, LyricFormat.krc)`。
+  static List<LyricLine> parseAs(String text, LyricFormat format) {
+    try {
+      return _delegate(text, format);
+    } catch (_) {
+      return PlainTextParser.parse(text);
+    }
+  }
+
+  /// 检测输入文本的歌词格式。
+  ///
+  /// 算法：
+  /// 1. 按行 split（兼容 `\r\n` / `\n`）
+  /// 2. 跳过空行（trim 后为空）
+  /// 3. 跳过元数据行（匹配 [_metadataPrefixes] 任一前缀）
+  /// 4. 找到首个非空非元数据行后，用正则检测：
+  ///    - 匹配 [_krcLineRegex] → [LyricFormat.krc]
+  ///    - 匹配 [_lrcLineRegex] → [LyricFormat.lrc]
+  ///    - 否则 → [LyricFormat.plaintext]
+  /// 5. 若所有行都是空或元数据，降级为 [LyricFormat.plaintext]
+  static LyricFormat detectFormat(String text) {
+    if (text.isEmpty) return LyricFormat.plaintext;
+
+    final lines = text.split(RegExp(r'\r?\n'));
+    for (final rawLine in lines) {
+      final line = rawLine.trim();
+
+      // 空行跳过
+      if (line.isEmpty) continue;
+
+      // 元数据行跳过
+      if (_isMetadata(line)) continue;
+
+      // 找到首个非空非元数据行，用正则检测格式
+      if (_krcLineRegex.hasMatch(line)) {
+        return LyricFormat.krc;
+      }
+      if (_lrcLineRegex.hasMatch(line)) {
+        return LyricFormat.lrc;
+      }
+      return LyricFormat.plaintext;
+    }
+
+    // 所有行均为空或元数据，降级纯文本
+    return LyricFormat.plaintext;
+  }
+
+  /// 按格式委托给对应解析器。
+  static List<LyricLine> _delegate(String text, LyricFormat format) {
+    switch (format) {
+      case LyricFormat.krc:
+        return KrcParser.parse(text);
+      case LyricFormat.lrc:
+        return LrcParser.parse(text);
+      case LyricFormat.plaintext:
+        return PlainTextParser.parse(text);
+    }
+  }
+
+  /// 判断是否为元数据行（KRC 与 LRC 共用同一套前缀）。
+  static bool _isMetadata(String line) {
+    for (final prefix in _metadataPrefixes) {
+      if (line.startsWith(prefix)) return true;
+    }
+    return false;
+  }
+}

--- a/lib/widgets/apple_lyrics/parsers/plaintext_parser.dart
+++ b/lib/widgets/apple_lyrics/parsers/plaintext_parser.dart
@@ -1,0 +1,51 @@
+/// 纯文本歌词兜底解析器。
+///
+/// 当 KRC / LRC 解析器都失败时使用：输入是没有任何时间戳的纯文本歌词，
+/// 每一行直接生成一个 [LyricLine]，所有行 `startTime=0`、`duration=0`、
+/// `words=[]`（无逐字时间戳）。渲染层会走整行降级渲染路径。
+///
+/// 详见 spec.md "Requirement: 纯文本兜底解析器"。
+library;
+
+import '../models/lyric_line.dart';
+
+/// 纯文本歌词解析器。
+///
+/// 仅按行分割文本，不解析任何时间信息。所有 [LyricLine.startTime] 与
+/// [LyricLine.duration] 均为 0，[LyricLine.words] 为空常量列表，
+/// [LyricLine.hasWordTiming] 恒为 false。
+class PlainTextParser {
+  /// 解析纯文本为 [LyricLine] 列表。
+  ///
+  /// 规则：
+  /// 1. 按行 split 输入文本（兼容 `\r\n` / `\n`）。
+  /// 2. 每行 trim 后若非空，生成一个 [LyricLine]。
+  /// 3. 空行跳过。
+  /// 4. 所有行 `startTime` 均为 0，按出现顺序排列。
+  /// 5. 失败返回空列表（优雅降级，不抛异常）。
+  static List<LyricLine> parse(String text) {
+    try {
+      final lines = text.split(RegExp(r'\r\n|\n'));
+      final result = <LyricLine>[];
+      for (final raw in lines) {
+        final trimmed = raw.trim();
+        if (trimmed.isEmpty) continue; // 空行跳过
+        result.add(
+          LyricLine(
+            startTime: 0,
+            duration: 0,
+            text: trimmed,
+            // 显式标注类型为 List<LyricWord>，确保与外部 `const <LyricWord>[]`
+            // 引用一致（const canonicalization 按运行时类型区分）。
+            words: const <LyricWord>[],
+            translation: null,
+          ),
+        );
+      }
+      return result;
+    } catch (_) {
+      // 任何异常都返回空列表，保证优雅降级
+      return const [];
+    }
+  }
+}

--- a/lib/widgets/apple_lyrics/preview/lyrics_preview_page.dart
+++ b/lib/widgets/apple_lyrics/preview/lyrics_preview_page.dart
@@ -1,0 +1,204 @@
+/// AppleLyricsView 渲染预览页（开发调试用）。
+///
+/// 参照 spec.md "Requirement: 单元测试与渲染预览页" 与 tasks.md Task 22。
+/// 不依赖 just_audio 与 KugouProvider，可独立运行：
+/// - 文本框输入 KRC/LRC 原文，点击"渲染"按钮解析并显示 [AppleLyricsView]
+/// - 时间滑块（0~60000ms）模拟播放进度，验证动画时序
+/// - "播放/暂停"按钮通过 [AnimationController] 每帧 +16ms 自动推进时间
+/// - 顶部 PopupMenuButton 提供示例数据一键加载
+library;
+
+import 'package:flutter/material.dart';
+import 'package:md3music/widgets/apple_lyrics/apple_lyrics_view.dart';
+import 'package:md3music/widgets/apple_lyrics/layout/lyric_preferences_panel.dart';
+import 'package:md3music/widgets/apple_lyrics/models/lyric_line.dart';
+import 'package:md3music/widgets/apple_lyrics/parsers/lyric_parser_chain.dart';
+
+class LyricsPreviewPage extends StatefulWidget {
+  const LyricsPreviewPage({super.key});
+
+  @override
+  State<LyricsPreviewPage> createState() => _LyricsPreviewPageState();
+}
+
+class _LyricsPreviewPageState extends State<LyricsPreviewPage>
+    with SingleTickerProviderStateMixin {
+  late final TextEditingController _textController;
+  // 用 AnimationController.repeat() 的 addListener 作为每帧回调（≈16ms/帧），
+  // 在 _isPlaying=true 时推进 _currentTimeMs，模拟播放器时钟。
+  // 选用 AnimationController 而非 Timer，是因为它受 Ticker 驱动，
+  // 在页面不可见时自动暂停，节省 CPU。
+  late final AnimationController _playController;
+
+  List<LyricLine> _parsedLines = const [];
+  int _currentTimeMs = 0;
+  bool _isPlaying = false;
+
+  /// 时间滑块与自动播放的循环周期上限（毫秒），覆盖示例数据最大 startTime。
+  static const int _maxTimeMs = 60000;
+
+  @override
+  void initState() {
+    super.initState();
+    _textController = TextEditingController(text: _krcSample);
+    _parseAndRender();
+    _playController = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 1),
+    )..addListener(() {
+        if (!_isPlaying) return;
+        setState(() {
+          // 每帧 +16ms 模拟 60fps 播放推进，到达上限后循环回到 0
+          _currentTimeMs = (_currentTimeMs + 16) % _maxTimeMs;
+        });
+      });
+    _playController.repeat();
+  }
+
+  /// 解析文本框内容并刷新预览，重置时间到 0。
+  void _parseAndRender() {
+    final text = _textController.text;
+    setState(() {
+      _parsedLines = LyricParserChain.parse(text);
+      _currentTimeMs = 0;
+    });
+  }
+
+  void _togglePlay() {
+    setState(() {
+      _isPlaying = !_isPlaying;
+    });
+  }
+
+  @override
+  void dispose() {
+    _playController.dispose();
+    _textController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('歌词预览'),
+        actions: [
+          // 歌词显示设置（字号/行间距）
+          IconButton(
+            icon: const Icon(Icons.lyrics),
+            tooltip: '歌词显示设置',
+            onPressed: () {
+              showModalBottomSheet(
+                context: context,
+                isScrollControlled: true,
+                builder: (context) => SafeArea(
+                  child: const LyricPreferencesPanel(),
+                ),
+              );
+            },
+          ),
+          // 示例数据按钮：一键加载 KRC / LRC 示例并立即渲染
+          PopupMenuButton<String>(
+            onSelected: (value) {
+              _textController.text = value == 'krc' ? _krcSample : _lrcSample;
+              _parseAndRender();
+            },
+            itemBuilder: (_) => const [
+              PopupMenuItem(value: 'krc', child: Text('加载 KRC 示例')),
+              PopupMenuItem(value: 'lrc', child: Text('加载 LRC 示例')),
+            ],
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          // 1. 歌词渲染区（占大部分空间）
+          Expanded(
+            flex: 3,
+            child: AppleLyricsView(
+              lines: _parsedLines,
+              currentTimeMs: _currentTimeMs,
+              isPlaying: _isPlaying,
+              onSeek: (ms) => setState(() => _currentTimeMs = ms),
+            ),
+          ),
+          // 2. 控制区：时间滑块 + 播放/暂停 + 可折叠文本输入
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              children: [
+                Row(
+                  children: [
+                    Text('${(_currentTimeMs / 1000).toStringAsFixed(1)}s'),
+                    Expanded(
+                      child: Slider(
+                        value: _currentTimeMs.toDouble(),
+                        min: 0,
+                        max: _maxTimeMs.toDouble(),
+                        onChanged: (v) =>
+                            setState(() => _currentTimeMs = v.toInt()),
+                      ),
+                    ),
+                    IconButton(
+                      icon: Icon(_isPlaying ? Icons.pause : Icons.play_arrow),
+                      onPressed: _togglePlay,
+                    ),
+                  ],
+                ),
+                // 3. 文本输入框（可折叠），方便快速替换歌词数据
+                ExpansionTile(
+                  title: const Text('歌词文本'),
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: TextField(
+                        controller: _textController,
+                        maxLines: 10,
+                        decoration: const InputDecoration(
+                          border: OutlineInputBorder(),
+                          hintText: '输入 KRC 或 LRC 歌词文本',
+                        ),
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: ElevatedButton(
+                        onPressed: _parseAndRender,
+                        child: const Text('渲染'),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// KRC 示例：包含元数据、逐字时间戳、间奏行，用于验证 Apple Music 逐字动画。
+const String _krcSample = '''[id:\$00000000]
+[ar:トゲナシトゲアリ]
+[ti:運命の華]
+[total:195735]
+[offset:0]
+[0,3000]<0,300,0>運<300,400,0>命<700,500,0>の<1200,600,0>華<1800,1200,0>
+[3000,4000]<0,350,0>泣<350,450,0>き<800,500,0>出<1300,700,0>し<2000,1000,0>た<3000,1000,0>
+[7000,3000]<0,500,0>運<500,500,0>命<1000,500,0>の<1500,500,0>華<2000,1000,0>
+[10000,5000]<0,400,0>咲<400,600,0>き<1000,800,0>誇<1800,1000,0>れ<2800,1200,0>ば<4000,1000,0>
+[15000,0]間奏
+[20000,3000]<0,500,0>終<500,500,0>わ<1000,500,0>り<1500,500,0>な<2000,500,0>き<2500,500,0>旅<3000,0,0>
+''';
+
+/// LRC 示例：仅整行时间戳，用于验证降级渲染模式（整行渐入渐出）。
+const String _lrcSample = '''[ar:Sample Artist]
+[ti:Sample Song]
+[00:00.00]First line of lyrics
+[00:03.00]Second line here
+[00:07.00]Third line continues
+[00:10.00]Fourth line of the song
+[00:15.00]Fifth line ending
+[00:20.00]Outro
+''';

--- a/lib/widgets/apple_lyrics/renderers/emphasize_effect.dart
+++ b/lib/widgets/apple_lyrics/renderers/emphasize_effect.dart
@@ -1,0 +1,278 @@
+/// 强调辉光（emphasize）效果
+///
+/// 参照 spec.md "Requirement: 强调辉光（emphasize）效果" 与 AMLL `lyric-line.ts:510-651` 实现。
+/// 当字时长 >= 1000ms 且符合字符长度要求（CJK 任意 / 非 CJK 1~7）时触发辉光：
+/// - 字内进度 0~0.5 用 bezIn 曲线渐入（缩放放大、辉光增强）
+/// - 字内进度 0.5~1 用 bezOut 曲线渐出（缩放回 1.0、辉光衰减）
+/// - 末尾字（isLastWord）amount/blur 加强 1.6/1.5 倍
+/// - 字符间错位 delay：wordIndex 越大，字活跃起始时间越晚
+library;
+
+import 'dart:math';
+
+import 'package:flutter/foundation.dart';
+
+import '../models/lyric_line.dart';
+
+/// 强调辉光状态。
+///
+/// 不可变值对象，由 [EmphasizeEffect.computeState] 输出，供绘制层
+/// （如 CustomPainter）读取 scale、glowLevel、shadowBlurEm 三个参数
+/// 应用 transform 与 textShadow。
+@immutable
+class EmphasizeState {
+  /// 缩放比例，1.0~1.12（含末尾字加强后可能略高）。
+  final double scale;
+
+  /// 辉光强度 0~1.2（作为 textShadow 的 alpha 通道）。
+  final double glowLevel;
+
+  /// 阴影模糊半径（em 单位），封顶 0.3。
+  final double shadowBlurEm;
+
+  const EmphasizeState({
+    required this.scale,
+    required this.glowLevel,
+    required this.shadowBlurEm,
+  });
+
+  /// 空闲状态：无辉光、无缩放、无阴影。
+  ///
+  /// 当 word 未触发辉光（[EmphasizeEffect.shouldEmphasize] 返回 false），
+  /// 或当前时间不在字内进度 [0, 1] 范围时返回此常量。
+  static const EmphasizeState idle = EmphasizeState(
+    scale: 1.0,
+    glowLevel: 0,
+    shadowBlurEm: 0,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is EmphasizeState &&
+          runtimeType == other.runtimeType &&
+          scale == other.scale &&
+          glowLevel == other.glowLevel &&
+          shadowBlurEm == other.shadowBlurEm;
+
+  @override
+  int get hashCode => Object.hash(scale, glowLevel, shadowBlurEm);
+
+  @override
+  String toString() =>
+      'EmphasizeState(scale: $scale, glowLevel: $glowLevel, '
+      'shadowBlurEm: $shadowBlurEm)';
+}
+
+/// 强调辉光效果计算器。
+///
+/// 无状态工具类：所有计算基于入参，内部不持有可变状态。
+/// 通过 [shouldEmphasize] 判断 word 是否需要辉光，
+/// 通过 [computeState] 计算某时刻的辉光参数（scale / glowLevel / shadowBlurEm）。
+class EmphasizeEffect {
+  EmphasizeEffect();
+
+  // ============== 触发条件常量 ==============
+
+  /// 触发阈值：字时长 >= 1000ms
+  static const int _durationThresholdMs = 1000;
+
+  /// 非 CJK 字最大长度
+  static const int _nonCjkMaxLength = 7;
+
+  // ============== amount / blur 公式常量 ==============
+
+  /// amount 缩放系数（spec.md：amount *= 0.6）
+  static const double _amountScale = 0.6;
+
+  /// amount 封顶（spec.md：amount > 1.2 时封顶为 1.2）
+  static const double _amountCap = 1.2;
+
+  /// blur 缩放系数（spec.md：blur *= 0.5）
+  static const double _blurScale = 0.5;
+
+  /// blur 封顶（spec.md：blur > 0.8 时封顶为 0.8）
+  static const double _blurCap = 0.8;
+
+  /// 末尾字 amount 加强系数（spec.md：isLastWord 时 amount *= 1.6）
+  static const double _lastWordAmountBoost = 1.6;
+
+  /// 末尾字 blur 加强系数（spec.md：isLastWord 时 blur *= 1.5）
+  static const double _lastWordBlurBoost = 1.5;
+
+  /// 缩放公式中 transX 的系数（spec.md：scale = 1 + transX * 0.1 * amount）
+  static const double _scaleTransFactor = 0.1;
+
+  /// shadowBlurEm 封顶（spec.md：textShadow: 0 0 min(0.3, blur*0.3)em）
+  static const double _shadowBlurEmCap = 0.3;
+
+  /// 字符错位 delay 分母常数（spec.md：du / 2.5 / anchorCharCount）
+  static const double _delayDivisor = 2.5;
+
+  // ============== bezier 控制点 ==============
+  //
+  // spec.md："bezIn = bezier(0.2, 0.4, 0.58, 1.0)"、"bezOut = bezier(0.3, 0.0, 0.58, 1.0)"
+  // 对应 CSS cubic-bezier(x1, y1, x2, y2) 记法，P0=(0,0), P3=(1,1)。
+  // 本实现按 spec 公式仅使用前两个值作为 P1/P2（P0=0, P3=1 内置）。
+
+  /// bezIn 控制点 P1（曲线前半段）
+  static const double _bezInP1 = 0.2;
+
+  /// bezIn 控制点 P2（曲线前半段）
+  static const double _bezInP2 = 0.4;
+
+  /// bezOut 控制点 P1（曲线后半段）
+  static const double _bezOutP1 = 0.3;
+
+  /// bezOut 控制点 P2（曲线后半段）
+  static const double _bezOutP2 = 0.0;
+
+  // ============== 公开 API ==============
+
+  /// 判断 word 是否触发辉光。
+  ///
+  /// 触发条件（spec.md "Requirement: 强调辉光（emphasize）效果"）：
+  /// - 字时长 [LyricWord.duration] >= 1000ms
+  /// - 且为 CJK 字符（任意长度）或 非 CJK 字符长度 1~7
+  ///
+  /// CJK 判定：[String.runes] 中任一字符落在 CJK 统一表意 / 平假名 /
+  /// 片假名 / CJK 标点 / 韩文 任一 Unicode 范围内，即视为 CJK 字符。
+  static bool shouldEmphasize(LyricWord word) {
+    if (word.duration < _durationThresholdMs) return false;
+    final text = word.text;
+    if (text.isEmpty) return false;
+    final runes = text.runes.toList();
+    final hasCJK = runes.any(_isCJKCodePoint);
+    if (hasCJK) {
+      // CJK 字符：任意长度均触发
+      return true;
+    }
+    // 非 CJK 字符：长度需在 1~7 之间
+    return runes.length >= 1 && runes.length <= _nonCjkMaxLength;
+  }
+
+  /// 计算某时刻的辉光状态。
+  ///
+  /// [word] 目标字（含 startTime / duration）。
+  /// [currentTimeMs] 当前播放时间（毫秒，绝对时间）。
+  /// [isLastWord] 是否末尾字（影响 amount/blur 加强系数）。
+  /// [wordIndex] 字索引（用于字符错位 delay 计算）。
+  /// [anchorCharCount] 该字字符数（用于 delay 分母）。
+  ///
+  /// 返回 [EmphasizeState]：scale / glowLevel / shadowBlurEm。
+  /// - 当 currentTimeMs 不在 [wordDe, wordDe + duration] 区间时返回 [EmphasizeState.idle]
+  /// - 字内进度 t < 0.5 用 bezIn 曲线渐入；t >= 0.5 用 bezOut 曲线渐出
+  EmphasizeState computeState({
+    required LyricWord word,
+    required int currentTimeMs,
+    required bool isLastWord,
+    required int wordIndex,
+    required int anchorCharCount,
+  }) {
+    // 边界保护：duration 为 0 会触发除零，anchorCharCount 为 0 同理
+    if (word.duration <= 0) return EmphasizeState.idle;
+    if (anchorCharCount <= 0) return EmphasizeState.idle;
+
+    // 字起始时间
+    final int de = word.startTime;
+
+    // 字符错位 delay：wordDe = de + (du / 2.5 / anchorCharCount) * i
+    // wordIndex 越大，字活跃起始时间越晚，造成"逐字波动"的视觉效果
+    final double delay =
+        (word.duration / _delayDivisor / anchorCharCount) * wordIndex;
+    final double wordDe = de + delay;
+
+    // 字内进度 t（未 clamp，超出 [0,1] 视为未激活）
+    final double t = (currentTimeMs - wordDe) / word.duration;
+
+    // 超出 [0, 1] 范围：字未激活或已结束，返回 idle
+    if (t < 0 || t > 1) return EmphasizeState.idle;
+
+    // 计算 transX：前半段用 bezIn(t*2)，后半段用 bezOut((1-t)*2)
+    // 前半段从 0 渐增到 1（bezIn(0)=0, bezIn(1)=1），后半段从 1 渐减回 0
+    final double transX;
+    if (t < 0.5) {
+      transX = cubicBezier(t * 2, _bezInP1, _bezInP2, 0.58, 1.0);
+    } else {
+      transX = cubicBezier((1 - t) * 2, _bezOutP1, _bezOutP2, 0.58, 1.0);
+    }
+
+    // amount 计算（spec.md 公式）
+    // amount = (duration / 2000)，>1 时取 sqrt，<=1 时取立方，再 *0.6，封顶 1.2
+    double amount = word.duration / 2000;
+    if (amount > 1) {
+      amount = sqrt(amount);
+    } else {
+      amount = amount * amount * amount; // ^3
+    }
+    amount *= _amountScale;
+    if (amount > _amountCap) amount = _amountCap;
+
+    // blur 计算（spec.md 公式）
+    // blur = (duration / 3000) * 0.5，封顶 0.8
+    double blur = word.duration / 3000;
+    blur *= _blurScale;
+    if (blur > _blurCap) blur = _blurCap;
+
+    // 末尾字加强（spec.md：isLastWord 时 amount *= 1.6, blur *= 1.5）
+    // 注意：加强在封顶之后，故末尾字实际 amount 可能超过 1.2
+    if (isLastWord) {
+      amount *= _lastWordAmountBoost;
+      blur *= _lastWordBlurBoost;
+    }
+
+    // 最终输出三参数
+    // scale = 1 + transX * 0.1 * amount
+    // glowLevel = transX * amount（作为 textShadow 的 alpha 通道）
+    // shadowBlurEm = min(0.3, blur * 0.3)
+    final double scale = 1 + transX * _scaleTransFactor * amount;
+    final double glowLevel = transX * amount;
+    final double shadowBlurEm = min(_shadowBlurEmCap, blur * 0.3);
+
+    return EmphasizeState(
+      scale: scale,
+      glowLevel: glowLevel,
+      shadowBlurEm: shadowBlurEm,
+    );
+  }
+
+  /// 重置。
+  ///
+  /// 本类无内部可变状态，此方法为 API 占位，与 [WordRenderer.reset] 对齐
+  /// 便于上层统一调用 reset 而无需区分渲染器类型。
+  void reset() {}
+
+  // ============== 工具方法 ==============
+
+  /// cubic bezier 求值。
+  ///
+  /// 标准 cubic bezier 公式：B(t) = (1-t)^3*P0 + 3*(1-t)^2*t*P1 + 3*(1-t)*t^2*P2 + t^3*P3
+  /// 其中 P0=0, P3=1（CSS cubic-bezier 约定），故简化为：
+  /// B(t) = 3*(1-t)^2*t*p1 + 3*(1-t)*t^2*p2 + t^3
+  ///
+  /// [p3]、[p4] 仅用于完整记录 CSS cubic-bezier(x1, y1, x2, y2) 的四个参数
+  /// （方便对照 spec.md "bezIn = bezier(0.2, 0.4, 0.58, 1.0)"），
+  /// 实际计算只使用 [p1]、[p2]（对应 P1、P2）。
+  @visibleForTesting
+  static double cubicBezier(
+      double t, double p1, double p2, double p3, double p4) {
+    final u = 1 - t;
+    return 3 * u * u * t * p1 + 3 * u * t * t * p2 + t * t * t;
+  }
+
+  /// 判断 code point 是否落在 CJK Unicode 范围内。
+  ///
+  /// 覆盖范围（spec.md "CJK 检测"）：
+  /// - CJK 统一表意：U+4E00 ~ U+9FFF
+  /// - 平假名：U+3040 ~ U+309F
+  /// - 片假名：U+30A0 ~ U+30FF
+  /// - CJK 标点：U+3000 ~ U+303F
+  /// - 韩文：U+AC00 ~ U+D7AF
+  static bool _isCJKCodePoint(int codePoint) {
+    return (codePoint >= 0x4E00 && codePoint <= 0x9FFF) || // CJK 统一表意
+        (codePoint >= 0x3040 && codePoint <= 0x309F) || // 平假名
+        (codePoint >= 0x30A0 && codePoint <= 0x30FF) || // 片假名
+        (codePoint >= 0x3000 && codePoint <= 0x303F) || // CJK 标点
+        (codePoint >= 0xAC00 && codePoint <= 0xD7AF); // 韩文
+  }
+}

--- a/lib/widgets/apple_lyrics/renderers/interlude_dots.dart
+++ b/lib/widgets/apple_lyrics/renderers/interlude_dots.dart
@@ -1,0 +1,319 @@
+library;
+
+import 'dart:math' as math;
+
+import 'package:flutter/widgets.dart';
+
+import '../layout/lyric_layout.dart';
+
+/// 间奏点动画组件（严格照搬 AMLL 原版实现）。
+///
+/// 参考：https://github.com/amll-dev/applemusic-like-lyrics
+/// packages/core/src/lyric-player/dom/interlude-dots.ts
+///
+/// AMLL 动画规则：
+/// - **整体呼吸缩放**（持续整个间奏）：
+///   `scale = 1 + sin(1.5π - currentDuration/breatheDuration * 2) / 20`
+///   breatheDuration = interludeDuration / ceil(interludeDuration / 1500)
+///   即间奏时长被分成若干个 1500ms 周期，整体微幅缩放
+///
+/// - **入场缩放**（前 2000ms）：
+///   `scale *= easeOutExpo(currentDuration / 2000)`
+///   easeOutExpo: `x == 1 ? 1 : 1 - 2^(-10*x)`
+///
+/// - **globalOpacity**：
+///   - 前 500ms：0（全黑不可见）
+///   - 500-1000ms：线性 0 → 1
+///   - 1000ms ~ end-375ms：1
+///   - end-375ms ~ end：线性 1 → 0
+///
+/// - **3 个点逐个亮起**（dotsDuration = interludeDuration - 750）：
+///   - dot0: 0.25 → 1.0，从 0 开始线性
+///   - dot1: 0.25 → 1.0，从 dotsDuration/3 开始
+///   - dot2: 0.25 → 1.0，从 dotsDuration*2/3 开始
+///   未亮时 alpha=0.25（基础暗态），亮起过程线性 0.25 → 1.0
+///
+/// - **消失缩放**（最后 750ms）：
+///   `scale *= 1 - easeInOutBack((750 - remaining) / 750 / 2)`
+///   easeInOutBack 带 overshoot 回弹效果
+///
+/// - **最终缩放系数**：`scale *= 0.7`（点比基准尺寸小一些）
+class InterludeDots {
+  InterludeDots();
+
+  // ============== 时长参数（ms）==============
+  /// AMLL 标准呼吸周期（ms）
+  static const int _targetBreatheDuration = 1500;
+
+  /// 入场缩放时长（ms）—— easeOutBack 超出回弹
+  static const int _enterScaleMs = 400;
+
+  /// globalOpacity 前 N ms 全黑
+  static const int _opacityHideMs = 0;
+
+  /// globalOpacity 渐显时长（ms）
+  static const int _opacityFadeMs = 200;
+
+  /// 消失缩放时长（ms）—— easeOutBack 带回弹
+  static const int _exitScaleMs = 750;
+
+  /// globalOpacity 渐隐时长（ms）
+  static const int _opacityFadeOutMs = 400;
+
+  /// 3 个点的相位错开角度（弧度）：0, 2π/3, 4π/3。
+  static final List<double> dotPhases = [
+    0.0,
+    2 * math.pi / 3,
+    4 * math.pi / 3,
+  ];
+
+  /// 间奏阈值：相邻行间隔 >= 此值才显示间奏点。
+  static const int thresholdMs = LyricLayout.interludeThresholdMs;
+
+  // ============== 状态 ==============
+
+  int? _startTime;
+  int? _endTime;
+
+  /// 内部动画时钟（ms）—— 由 tick(dt) 推进，不受 positionStream 5fps 限制
+  ///
+  /// **关键**：动画时间用 Ticker 帧时钟（60fps），不用播放时间 currentTimeMs。
+  /// 当 setInterlude 设置新间奏时，_animationTimeMs 重置为 0。
+  /// 每帧 tick(dt) 时 `_animationTimeMs += dt * 1000`。
+  double _animationTimeMs = 0;
+
+  /// 当前是否处于间奏时段（由外部 _updateInterlude 设置）。
+  bool _isActive = false;
+
+  // ============== Getter ==============
+
+  int? get startTime => _startTime;
+  int? get endTime => _endTime;
+
+  /// 当前是否需要绘制（间奏激活时）。
+  bool get shouldRender => _isActive;
+
+  // ============== 状态设置 ==============
+
+  /// 设置当前间奏时段。
+  ///
+  /// **重要**：本方法会被外部每帧调用，必须用"相同间奏不重置"保护。
+  /// 只有切换到新间奏（startTime/endTime 变化）或从无到有才更新状态。
+  /// 传 null 表示清除间奏。
+  void setInterlude(int? startTime, int? endTime) {
+    if (startTime == null || endTime == null) {
+      _isActive = false;
+      _startTime = null;
+      _endTime = null;
+      _animationTimeMs = 0;
+      return;
+    }
+    // 相同间奏不重置（保持 _animationTimeMs 等状态，避免每帧重置）
+    if (_startTime == startTime && _endTime == endTime && _isActive) {
+      return;
+    }
+    _startTime = startTime;
+    _endTime = endTime;
+    _isActive = true;
+    // 新间奏开始，重置动画时钟
+    _animationTimeMs = 0;
+  }
+
+  void clear() {
+    _startTime = null;
+    _endTime = null;
+    _animationTimeMs = 0;
+    _isActive = false;
+  }
+
+  // ============== 时间推进 ==============
+
+  /// 推进动画时钟（由 _onTick 每帧调用，基于 Ticker elapsed）。
+  ///
+  /// **关键**：用 dt（帧间隔秒）推进内部时钟，不用 currentTimeMs。
+  /// 这样动画始终 60fps 流畅，不受 positionStream 5fps 限制。
+  void tick(double dt) {
+    if (!_isActive) return;
+    _animationTimeMs += dt * 1000;
+  }
+
+  bool isInterlude(int currentTimeMs) {
+    final start = _startTime;
+    final end = _endTime;
+    if (start == null || end == null) return false;
+    return currentTimeMs >= start && currentTimeMs < end;
+  }
+
+  // ============== 缓动函数 ==============
+
+  /// easeOutBack（带超出回弹）
+  /// 公式：1 + c3 * (x-1)^3 + c1 * (x-1)^2，c1=1.70158, c3=c1+1=2.70158
+  /// x=0 → 0, x=1 → 1, 中间会超出 1 再回弹到 1
+  static double _easeOutBack(double x) {
+    if (x <= 0.0) return 0.0;
+    if (x >= 1.0) return 1.0;
+    const double c1 = 1.70158;
+    const double c3 = c1 + 1.0;
+    final double t = x - 1.0;
+    return 1.0 + c3 * t * t * t + c1 * t * t;
+  }
+
+  /// easeInBack（带负 overshoot）
+  /// 公式：c3 * x^3 - c1 * x^2，c1=1.70158, c3=c1+1=2.70158
+  /// x=0 → 0, x=1 → 1, 中间会先变负（低于 0）再上升到 1
+  /// 用于消失动画：1 - easeInBack(t) 中间会 >1（先放大），t=1 时 → 0
+  static double _easeInBack(double x) {
+    if (x <= 0.0) return 0.0;
+    if (x >= 1.0) return 1.0;
+    const double c1 = 1.70158;
+    const double c3 = c1 + 1.0;
+    return c3 * x * x * x - c1 * x * x;
+  }
+
+  /// clamp01
+  static double _clamp01(double x) => x.clamp(0.0, 1.0).toDouble();
+
+  /// clamp(value, min, max)
+  static double _clamp(double min, double value, double max) {
+    if (value < min) return min;
+    if (value > max) return max;
+    return value;
+  }
+
+  /// clampPositive（>=0）
+  static double _clampPositive(double x) => x < 0 ? 0 : x;
+
+  // ============== 绘制 ==============
+
+  /// 绘制 3 个间奏点（整体缩放版）。
+  ///
+  /// 动画时间线（用户确认版本）：
+  /// - 入场：前 400ms easeOutBack scale 0→1（带超出回弹）
+  /// - 全程：呼吸缩放（微幅 sin 波动）
+  /// - 消失：最后 750ms easeInBack scale 1→0（先放大 10% 再缩小到 0）
+  /// - opacity：前 200ms 渐显，最后 400ms 渐隐
+  /// - 3 点错开亮起：dotsDuration = interludeDuration - 750
+  ///
+  /// **整体缩放**：以第 2 个点圆心为中心，用 canvas.save() + translate + scale
+  /// 实现整体缩放，3 个点作为整体放大/缩小，而非各自独立缩放。
+  ///
+  /// [startX]：左对齐起点（与歌词 startX 一致）
+  /// [centerY]：占位区域的中心 y 坐标
+  /// [dotRadius]：单点基准半径
+  /// [spacing]：点间距（点圆心到圆心）
+  void paintAtLineY(
+    Canvas canvas,
+    double startX,
+    double centerY, {
+    double dotRadius = 4,
+    double spacing = 16,
+  }) {
+    if (!_isActive) return;
+    final start = _startTime;
+    final end = _endTime;
+    if (start == null || end == null) return;
+
+    final int interludeDuration = end - start;
+    final double currentDuration = _animationTimeMs;
+
+    // 超过间奏时段，不绘制
+    if (currentDuration > interludeDuration) return;
+
+    // ===== 1. 整体呼吸缩放（微幅 sin 波动）=====
+    final int breatheDuration = (interludeDuration ~/
+            math.max(1, (interludeDuration / _targetBreatheDuration).ceil()))
+        .clamp(1, interludeDuration);
+    double scale = 1.0 +
+        math.sin(1.5 * math.pi -
+                (currentDuration / breatheDuration) * 2) /
+            20;
+
+    // ===== 2. 入场缩放（前 400ms easeOutBack 超出回弹）=====
+    if (currentDuration < _enterScaleMs) {
+      scale *= _easeOutBack(currentDuration / _enterScaleMs);
+    }
+
+    // ===== 3. globalOpacity（前 200ms 渐显）=====
+    double globalOpacity = 1.0;
+    if (currentDuration < _opacityHideMs) {
+      globalOpacity = 0;
+    } else if (currentDuration < _opacityFadeMs) {
+      globalOpacity *= (currentDuration - _opacityHideMs) /
+          (_opacityFadeMs - _opacityHideMs);
+    }
+
+    // ===== 4. 消失缩放（最后 750ms：先稍微放大再缩小到 0）=====
+    // 用 1 - easeInBack(t)：
+    // - t=0：1（保持原 scale）
+    // - t=0.5：1 - (-0.1) = 1.1（放大 10%）
+    // - t=1：1 - 1 = 0（完全消失）
+    final double remaining = interludeDuration - currentDuration;
+    if (remaining < _exitScaleMs) {
+      final double t = (_exitScaleMs - remaining) / _exitScaleMs;
+      scale *= 1.0 - _easeInBack(t);
+    }
+
+    // ===== 5. globalOpacity 渐隐（最后 400ms）=====
+    if (remaining < _opacityFadeOutMs) {
+      globalOpacity *= _clamp01(remaining / _opacityFadeOutMs);
+    }
+
+    // ===== 6. 3 个点逐个亮起 =====
+    final double dotsDuration =
+        _clampPositive((interludeDuration - _exitScaleMs).toDouble());
+
+    scale = _clampPositive(scale);
+    if (scale <= 0 || globalOpacity <= 0) return;
+
+    // ===== 整体缩放：以第 2 个点圆心为中心 =====
+    // 3 个点的相对位置（相对第 2 个点圆心）：
+    //   dot0: (-spacing, 0)
+    //   dot1: (0, 0)  ← 中心
+    //   dot2: (+spacing, 0)
+    // 第 2 个点圆心绝对位置：startX + spacing + dotRadius（左对齐 + 1 间距 + 半径）
+    final double centerX = startX + spacing + dotRadius;
+    final double centerY2 = centerY;
+
+    canvas.save();
+    canvas.translate(centerX, centerY2);
+    canvas.scale(scale);
+
+    for (int i = 0; i < 3; i++) {
+      // dot0: currentDuration * 3 / dotsDuration * 0.75 + 0.25 (clamp 0.25~1)
+      // dot1: (currentDuration - dotsDuration/3) * 3 / dotsDuration * 0.75 + 0.25
+      // dot2: (currentDuration - dotsDuration*2/3) * 3 / dotsDuration * 0.75 + 0.25
+      final double offset = i * dotsDuration / 3;
+      final double t = (currentDuration - offset) * 3 / dotsDuration;
+      final double dotAlpha = _clamp(0.25, t * 0.75 + 0.25, 1.0);
+      final double alpha = _clamp01(globalOpacity * dotAlpha);
+
+      if (alpha <= 0) continue;
+
+      // 相对中心点的 x 偏移：-spacing, 0, +spacing
+      final double dx = (i - 1) * spacing;
+      final double dy = 0.0;
+      final paint = Paint()
+        ..style = PaintingStyle.fill
+        ..color = Color.fromRGBO(255, 255, 255, alpha);
+      canvas.drawCircle(Offset(dx, dy), dotRadius, paint);
+    }
+
+    canvas.restore();
+  }
+
+  /// 兼容旧接口 [paint]，转发到 [paintAtLineY]。
+  void paint(
+    Canvas canvas,
+    Offset center,
+    double radius,
+    double dotRadius,
+  ) {
+    paintAtLineY(
+      canvas,
+      center.dx,
+      center.dy,
+      dotRadius: dotRadius,
+      spacing: radius,
+    );
+  }
+}

--- a/lib/widgets/apple_lyrics/renderers/line_renderer.dart
+++ b/lib/widgets/apple_lyrics/renderers/line_renderer.dart
@@ -1,0 +1,148 @@
+/// 整行降级渲染器（用于 LRC 与纯文本，无逐字时间戳；亦用于非当前行的 KRC 行）
+///
+/// 参照 spec.md "Requirement: 逐字 mask alpha 渲染" 中"非当前行渲染"场景与
+/// tasks.md Task 10 实现。启用整行模式的场景：
+/// - hasWordTiming=false 的行（LRC/纯文本）：始终用本类
+/// - hasWordTiming=true 的非当前行（KRC）：用本类降级渲染（性能优化）
+///
+/// 渲染规则：
+/// - 当前行（isActive）：整行 alpha = dynamicBrightAlpha（随 scale 0.2~1.0）
+/// - 非当前行：整行 alpha = dynamicDarkAlpha（随 scale 0.2~0.4，SOLID 模式）
+/// - 行内无 mask 渐变，整行使用同一 alpha
+/// - 行切换通过指数衰减实现淡入淡出过渡（变亮 ATTACK_SPEED=50，变暗 RELEASE_SPEED=7）
+///
+/// 与 [WordRenderer] 的关系：
+/// - [WordRenderer] 处理当前行 + hasWordTiming=true 的逐字模式（有 mask 渐变 + 上浮）
+/// - 本类处理 hasWordTiming=false 的行 + 非当前行的 KRC 行（无 mask 渐变）
+/// - 上层 AppleLyricsView 根据 isActive 与 hasWordTiming 调度使用哪个 renderer
+/// - 非当前行不需要逐字渐变，用本类每帧只 1 次 layout，大幅降低 CPU
+///
+/// 本类不是 Widget，是核心绘制逻辑类，由外部 CustomPainter 调用 [paintLine]。
+/// 动画驱动由外部 AnimationController + Ticker 调用 [tick] 实现。
+library;
+
+import 'dart:math';
+
+import 'package:flutter/widgets.dart';
+
+import '../layout/lyric_layout.dart';
+import '../models/lyric_line.dart';
+
+/// 整行降级渲染器。
+///
+/// 持有当前 isActive 状态与单一 [_currentAlpha] 值（整行共用一个 alpha），
+/// 通过 [tick] 推进指数衰减动画，通过 [paintLine] 用当前 alpha 绘制白色文本。
+class LineRenderer {
+  LineRenderer();
+
+  // ============== 内部状态 ==============
+
+  /// 当前是否为当前行（高亮）。默认 false（SOLID 暗态）。
+  bool _isActive = false;
+
+  /// 当前整行 alpha 值。初始 [LyricLayout.currentDarkAlpha]=0.2（SOLID 非当前行暗态）。
+  double _currentAlpha = LyricLayout.currentDarkAlpha;
+
+  /// 目标 alpha 值。isActive=true 时 1.0，false 时 0.2。
+  double _targetAlpha = LyricLayout.currentDarkAlpha;
+
+  /// 复用的 TextPainter 实例（避免每帧创建对象）。
+  ///
+  /// **性能优化**：之前每帧 paintLine 都创建新 TextPainter + GC，
+  /// 现在复用实例，只重新 set text + layout（alpha 变了需要重新 layout）。
+  final TextPainter _painter = TextPainter(textDirection: TextDirection.ltr);
+
+  // ============== 状态查询 ==============
+
+  /// 当前 alpha（用于测试与外部协调）。
+  double get currentAlpha => _currentAlpha;
+
+  /// 当前是否为当前行。
+  bool get isActive => _isActive;
+
+  /// 目标 alpha（用于测试断言）。
+  @visibleForTesting
+  double get targetAlpha => _targetAlpha;
+
+  // ============== 状态设置 ==============
+
+  /// 设置当前行状态。
+  ///
+  /// [isActive] 为 true 时整行高亮（alpha 目标 dynamicBrightAlpha），
+  /// 为 false 时整行 SOLID 暗态（alpha 目标 dynamicDarkAlpha）。
+  /// [scale] 是行缩放，0.97（inactive）~1.0（active），
+  /// 用于计算 dynamic alpha（与 [WordRenderer] 公式一致）：
+  /// - factor = clamp01((scale - 0.97) / 0.03)
+  /// - dynamicDarkAlpha = factor * 0.2 + 0.2（范围 0.2~0.4）
+  /// - dynamicBrightAlpha = factor * 0.8 + 0.2（范围 0.2~1.0）
+  void setLineState({required bool isActive, required double scale}) {
+    _isActive = isActive;
+    final double factor = ((scale - LyricLayout.inactiveScale) /
+            (LyricLayout.activeScale - LyricLayout.inactiveScale))
+        .clamp(0.0, 1.0)
+        .toDouble();
+    final double dynamicDark = factor * 0.2 + 0.2;
+    final double dynamicBright = factor * 0.8 + 0.2;
+    _targetAlpha = isActive ? dynamicBright : dynamicDark;
+  }
+
+  // ============== 动画推进 ==============
+
+  /// 推进动画。
+  ///
+  /// [dt] 距上一帧的时间间隔（秒）。
+  /// 用指数衰减公式 `_currentAlpha += (_targetAlpha - _currentAlpha) * (1 - exp(-speed * dt))`
+  /// 平滑过渡：变亮用 [LyricLayout.attackSpeed]（50.0），变暗用 [LyricLayout.releaseSpeed]（7.0）。
+  /// 差值小于 [LyricLayout.alphaEpsilon]（0.001）时吸附到目标。
+  void tick(double dt) {
+    if (dt <= 0) return;
+    // 变亮用 ATTACK（快），变暗用 RELEASE（慢）
+    final double speed = _targetAlpha >= _currentAlpha
+        ? LyricLayout.attackSpeed
+        : LyricLayout.releaseSpeed;
+    final double decay = 1.0 - exp(-speed * dt);
+    double next = _currentAlpha + (_targetAlpha - _currentAlpha) * decay;
+    // 阈值收敛：差值小于 alphaEpsilon 直接吸附到目标
+    if ((next - _targetAlpha).abs() < LyricLayout.alphaEpsilon) {
+      next = _targetAlpha;
+    }
+    _currentAlpha = next;
+  }
+
+  // ============== 绘制 ==============
+
+  /// 绘制整行歌词。
+  ///
+  /// [offset] 是行起始绘制原点。文字颜色固定白色 #FFFFFFFF，
+  /// alpha 由 [_currentAlpha] 控制（整行同一 alpha，无 mask 渐变）。
+  /// 使用复用的 [_painter] 实例测量整行宽度并绘制。
+  ///
+  /// [maxWidth] 为可用最大文字宽度，超出时 TextPainter 自动换行（默认不换行）。
+  ///
+  /// **性能优化**：复用 [_painter] 实例，避免每帧创建 TextPainter 对象 + GC。
+  /// layout 仍需每帧执行（alpha 变化需重新 set TextSpan）。
+  void paintLine(
+      Canvas canvas, Offset offset, LyricLine line, double fontSize,
+      {double maxWidth = double.infinity}) {
+    if (line.text.isEmpty) return;
+    _painter.text = TextSpan(
+      text: line.text,
+      style: TextStyle(
+        // 文字颜色固定白色，alpha 整行统一（无 mask 渐变）
+        color: Color.fromRGBO(255, 255, 255, _currentAlpha),
+        fontSize: fontSize,
+        height: LyricLayout.lineHeight,
+      ),
+    );
+    _painter.layout(
+        maxWidth: maxWidth == double.infinity ? double.infinity : maxWidth);
+    _painter.paint(canvas, offset);
+  }
+
+  /// 重置状态：alpha 回到初始值（0.2），isActive=false。
+  void reset() {
+    _isActive = false;
+    _currentAlpha = LyricLayout.currentDarkAlpha;
+    _targetAlpha = LyricLayout.currentDarkAlpha;
+  }
+}

--- a/lib/widgets/apple_lyrics/renderers/word_renderer.dart
+++ b/lib/widgets/apple_lyrics/renderers/word_renderer.dart
@@ -1,0 +1,357 @@
+/// 逐字 mask alpha 渲染器（核心渲染组件）
+///
+/// 参照 spec.md "Requirement: 逐字 mask alpha 渲染" 实现。
+/// 文字本身固定白色，靠 mask alpha 区分已播 / 未播字：
+/// - 当前行（GRADIENT 模式）：已播字 alpha = dynamicBrightAlpha，未播字 alpha = dynamicDarkAlpha，
+///   当前字按指数衰减在两者之间过渡，左亮右暗。
+/// - 非当前行（SOLID 模式）：整行均匀 alpha = dynamicDarkAlpha。
+///
+/// 本类不是 Widget，是核心绘制逻辑类，由外部 CustomPainter 调用 [paintLine]。
+/// 动画驱动由外部 AnimationController + Ticker 调用 [tick] 实现（SubTask 7.7）。
+library;
+
+import 'dart:collection';
+import 'dart:math';
+
+import 'package:flutter/widgets.dart';
+
+import '../layout/lyric_layout.dart';
+import '../models/lyric_line.dart';
+
+/// 逐字 mask alpha 渲染器。
+///
+/// 持有当前 scale、isActive、currentLineProgress 与每个 word 的当前 alpha 值，
+/// 通过 [tick] 推进指数衰减动画，通过 [paintLine] 用对应 alpha 逐字绘制白色文本。
+class WordRenderer {
+  WordRenderer();
+
+  // ============== 内部状态 ==============
+
+  /// 当前是否为当前行（GRADIENT 模式）。默认 false（SOLID）。
+  bool _isActive = false;
+
+  /// 当前行缩放，0.97（inactive）~1.0（active）。默认 inactive。
+  double _scale = LyricLayout.inactiveScale;
+
+  /// 当前行播放进度（0~1，相对当前行）。默认 0。
+  double _currentLineProgress = 0.0;
+
+  /// 当前绑定的 LyricLine。用于检测 line 切换并重置 alpha map。
+  LyricLine? _boundLine;
+
+  /// 缓存的字号（用于检测 fontSize 变化时重新测量 word 宽度）。
+  double _boundFontSize = -1;
+
+  /// 每个 word 的缓存宽度（在 [_ensureBound] 时一次性测量）。
+  ///
+  /// **性能优化**：之前每帧 paintLine 都为每个 word 创建 TextPainter + layout
+  /// 来测量宽度（用于换行判断）。现在只在 line 切换或 fontSize 变化时测量一次。
+  /// 10 word/行 × 60fps = 每秒 600 次 layout → 缓存后降为 0 次/帧。
+  List<double> _wordWidths = const <double>[];
+
+  /// 复用的 TextPainter 实例（避免每帧创建对象）。
+  ///
+  /// 注意：text setter 会标记需要 layout，所以 layout 还是要做，
+  /// 但省了 TextPainter 对象创建+GC 的开销。
+  final TextPainter _painter = TextPainter(textDirection: TextDirection.ltr);
+
+  /// 每个 word index 的当前 alpha 值。
+  final Map<int, double> _wordAlphas = <int, double>{};
+
+  /// 每个 word index 的当前 Y 轴偏移（上浮特效）。
+  ///
+  /// AMLL 规范：当前字会轻微上浮（最大约 -3px），用指数衰减平滑过渡。
+  /// 已播字回到 0，未播字保持 0，当前字上浮。
+  final Map<int, double> _wordYOffsets = <int, double>{};
+
+  /// AMLL 上浮最大幅度（px）：当前字最大上浮 -3px。
+  static const double _maxLiftPx = -3.0;
+
+  /// AMLL 上浮 ATTACK 速度：当前字上浮指数衰减系数。
+  static const double _liftAttackSpeed = 30.0;
+
+  /// AMLL 上浮 RELEASE 速度：当前字回落指数衰减系数。
+  static const double _liftReleaseSpeed = 10.0;
+
+  // ============== 状态查询 ==============
+
+  /// 当前 alpha map（不可变视图，供测试断言）。
+  ///
+  /// 使用 [UnmodifiableMapView] 包装，外部只读，修改不影响内部状态。
+  @visibleForTesting
+  Map<int, double> get wordAlphas =>
+      UnmodifiableMapView<int, double>(_wordAlphas);
+
+  /// 当前 scale 对应的 factor（0~1）。
+  ///
+  /// 公式：`factor = clamp01((scale - 0.97) / 0.03)`
+  double get factor {
+    final raw = (_scale - LyricLayout.inactiveScale) /
+        (LyricLayout.activeScale - LyricLayout.inactiveScale);
+    return raw.clamp(0.0, 1.0).toDouble();
+  }
+
+  /// 动态暗态 alpha（未播字 / 非当前行 SOLID）。
+  ///
+  /// 公式：`dynamicDarkAlpha = factor * 0.2 + 0.2`，范围 0.2~0.4。
+  double get dynamicDarkAlpha => factor * 0.2 + 0.2;
+
+  /// 动态亮态 alpha（已播字 / 当前字目标）。
+  ///
+  /// 公式：`dynamicBrightAlpha = factor * 0.8 + 0.2`，范围 0.2~1.0。
+  double get dynamicBrightAlpha => factor * 0.8 + 0.2;
+
+  /// 当前是否为当前行。
+  bool get isActive => _isActive;
+
+  /// 当前行播放进度（0~1）。
+  double get currentLineProgress => _currentLineProgress;
+
+  // ============== 状态设置 ==============
+
+  /// 设置当前行状态。
+  ///
+  /// [isActive] 为 true 时启用 GRADIENT 模式（已播亮 / 未播暗），
+  /// 为 false 时启用 SOLID 模式（整行均匀暗）。
+  /// [scale] 是行缩放，0.97（inactive）~1.0（active）。
+  void setLineState({required bool isActive, required double scale}) {
+    _isActive = isActive;
+    _scale = scale;
+  }
+
+  // ============== 动画推进 ==============
+
+  /// 推进动画。
+  ///
+  /// [dt] 距上一帧的时间间隔（秒）。[progress] 当前行播放进度 0~1，
+  /// 用于判断每个 word 是"已播"、"当前"、"未播"，分别计算目标 alpha。
+  /// 用指数衰减公式 `alpha += (target - alpha) * (1 - exp(-speed * dt))`
+  /// 平滑过渡：变亮用 [LyricLayout.attackSpeed]（50.0），变暗用 [LyricLayout.releaseSpeed]（7.0）。
+  /// 差值小于 [LyricLayout.alphaEpsilon]（0.001）时吸附到目标。
+  void tick(double dt, double progress) {
+    _currentLineProgress = progress.clamp(0.0, 1.0).toDouble();
+    if (dt <= 0) return;
+    if (_boundLine == null || _boundLine!.words.isEmpty) return;
+
+    final double dark = dynamicDarkAlpha;
+    final double bright = dynamicBrightAlpha;
+    final int wordCount = _boundLine!.words.length;
+
+    for (int i = 0; i < wordCount; i++) {
+      final double target = _targetAlphaFor(i, wordCount, dark, bright);
+      final double current = _wordAlphas[i] ?? dark;
+      // 变亮用 ATTACK（快），变暗用 RELEASE（慢）
+      final double speed = target >= current
+          ? LyricLayout.attackSpeed
+          : LyricLayout.releaseSpeed;
+      final double decay = 1.0 - exp(-speed * dt);
+      double next = current + (target - current) * decay;
+      // 阈值收敛：差值小于 alphaEpsilon 直接吸附到目标
+      if ((next - target).abs() < LyricLayout.alphaEpsilon) {
+        next = target;
+      }
+      _wordAlphas[i] = next;
+
+      // AMLL 上浮特效：当前字上浮到 _maxLiftPx，其他字回到 0
+      final double targetY = _targetYOffsetFor(i, wordCount);
+      final double currentY = _wordYOffsets[i] ?? 0;
+      final double ySpeed = targetY >= currentY
+          ? _liftAttackSpeed
+          : _liftReleaseSpeed;
+      final double yDecay = 1.0 - exp(-ySpeed * dt);
+      double nextY = currentY + (targetY - currentY) * yDecay;
+      if ((nextY - targetY).abs() < LyricLayout.alphaEpsilon) {
+        nextY = targetY;
+      }
+      _wordYOffsets[i] = nextY;
+    }
+  }
+
+  /// 计算指定 word index 的目标 Y 偏移（AMLL 上浮特效）。
+  ///
+  /// - 非当前行：所有 word Y=0（不上浮）。
+  /// - 当前行：
+  ///   - 已播字（index < 当前 word 索引）：Y=_maxLiftPx（保持上浮，不回落）。
+  ///   - 当前字（index == 当前 word 索引）：按 word 内进度 0 → _maxLiftPx 上浮。
+  ///     **使用 smoothstep 曲线（ease-in-out）**：`t' = t*t*(3-2*t)`
+  ///     起步和结束更柔，避免线性变化的生硬感。
+  ///   - 未播字（index > 当前 word 索引）：Y=0。
+  ///
+  /// 用户确认（grill-me Q2 (A) AMLL 原版）：已播字保持上浮状态，
+  /// 营造整行从左到右逐渐浮起的效果，而非"弹一下回落"。
+  ///
+  /// 用户反馈（grill-me 第三轮）：上浮动画不够细腻，一顿一顿的。
+  /// 改用 smoothstep 曲线让起步和结束更平滑。
+  double _targetYOffsetFor(int index, int wordCount) {
+    if (!_isActive) return 0;
+    final double wordPos = _currentLineProgress * wordCount;
+    final int currentIdx = wordPos.floor();
+    if (index < currentIdx) {
+      // 已播字：保持上浮
+      return _maxLiftPx;
+    }
+    if (index == currentIdx) {
+      // 当前 word 内进度（0~1），用 smoothstep 曲线（ease-in-out）
+      // smoothstep: t*t*(3-2*t)，起步和结束更柔
+      final double wp = wordPos - currentIdx;
+      final double eased = wp * wp * (3 - 2 * wp);
+      return _maxLiftPx * eased;
+    }
+    // 未播字：不上浮
+    return 0;
+  }
+
+  /// 计算指定 word index 的目标 alpha。
+  ///
+  /// - 非当前行：所有 word 目标 = [dynamicDarkAlpha]（SOLID）。
+  /// - 当前行：根据 [_currentLineProgress] 映射到 word 索引位置：
+  ///   - 已播字（index < 当前 word 索引）目标 = [dynamicBrightAlpha]。
+  ///   - 未播字（index > 当前 word 索引）目标 = [dynamicDarkAlpha]。
+  ///   - 当前字（index == 当前 word 索引）按 word 内进度在 dark~bright 之间线性插值。
+  double _targetAlphaFor(
+      int index, int wordCount, double dark, double bright) {
+    if (!_isActive) return dark;
+    // 当前行 GRADIENT：progress 映射到 word 索引位置
+    final double wordPos = _currentLineProgress * wordCount;
+    final int currentIdx = wordPos.floor();
+    if (index < currentIdx) {
+      return bright;
+    } else if (index > currentIdx) {
+      return dark;
+    } else {
+      // 当前 word 内进度（0~1）线性插值 dark → bright
+      final double wp = wordPos - currentIdx;
+      return dark + (bright - dark) * wp;
+    }
+  }
+
+  // ============== 绘制 ==============
+
+  /// 绘制单行歌词。
+  ///
+  /// [offset] 是行起始绘制原点。文字颜色固定白色 #FFFFFFFF，
+  /// 通过逐字 alpha 区分已播 / 未播。
+  ///
+  /// [maxWidth] 为该行可用最大文字宽度（视口宽 - 左右 1em 边距）。
+  /// 当 word 累加 dx 超过 [maxWidth] 且 dx > 0 时换行：
+  /// dx 归零，currentY += mainLineHeight × wrapLineHeightFactor（0.8x 行高）。
+  ///
+  /// **性能优化**：
+  /// - word 宽度用 [_wordWidths] 缓存（[_ensureBound] 时一次性测量），
+  ///   换行判断不再每帧创建 TextPainter + layout
+  /// - 复用 [_painter] 实例，避免每帧创建对象（layout 还是要做，
+  ///   因为 alpha 变了需要重新设置 TextSpan，但省了对象创建+GC）
+  void paintLine(
+      Canvas canvas, Offset offset, LyricLine line, double fontSize,
+      {double maxWidth = double.infinity}) {
+    _ensureBound(line, fontSize);
+
+    if (line.words.isEmpty) {
+      _paintSolidFallback(canvas, offset, line, fontSize, maxWidth: maxWidth);
+      return;
+    }
+
+    double dx = 0; // 相对 offset.dx 的水平偏移
+    double currentY = offset.dy; // 当前视觉行的 y 坐标
+    final double dark = dynamicDarkAlpha;
+    // 换行内部行高 = 主行高 × 0.8（与 LyricLayout.measureLineHeight 一致）
+    final double wrapLineHeight =
+        fontSize * LyricLayout.lineHeight * LyricLayout.wrapLineHeightFactor;
+    final double lineHeight = LyricLayout.lineHeight;
+
+    for (int i = 0; i < line.words.length; i++) {
+      final LyricWord word = line.words[i];
+      final double alpha = _wordAlphas[i] ?? dark;
+      // AMLL 上浮特效：当前字 Y 偏移（上浮）
+      final double yOffset = _wordYOffsets[i] ?? 0;
+      // 用缓存宽度做换行判断（避免每帧 TextPainter.layout 测量）
+      final double width =
+          i < _wordWidths.length ? _wordWidths[i] : 0;
+      // 自动换行：累计宽度超过 maxWidth 且本视觉行已有 word 时换行
+      if (dx + width > maxWidth && dx > 0) {
+        dx = 0;
+        currentY += wrapLineHeight;
+      }
+      // 复用 _painter 实例绘制（set text + layout + paint）
+      _painter.text = TextSpan(
+        text: word.text,
+        style: TextStyle(
+          color: Color.fromRGBO(255, 255, 255, alpha),
+          fontSize: fontSize,
+          height: lineHeight,
+        ),
+      );
+      _painter.layout();
+      _painter.paint(canvas, Offset(offset.dx + dx, currentY + yOffset));
+      dx += width;
+    }
+  }
+
+  /// 整行降级绘制（无 word 时间戳时使用）。
+  ///
+  /// [maxWidth] 用于自动换行（默认 [double.infinity] 不换行）。
+  /// 复用 [_painter] 实例避免对象创建。
+  void _paintSolidFallback(
+      Canvas canvas, Offset offset, LyricLine line, double fontSize,
+      {double maxWidth = double.infinity}) {
+    if (line.text.isEmpty) return;
+    final double alpha = dynamicDarkAlpha;
+    _painter.text = TextSpan(
+      text: line.text,
+      style: TextStyle(
+        color: Color.fromRGBO(255, 255, 255, alpha),
+        fontSize: fontSize,
+        height: LyricLayout.lineHeight,
+      ),
+    );
+    _painter.layout(
+        maxWidth: maxWidth == double.infinity ? double.infinity : maxWidth);
+    _painter.paint(canvas, offset);
+  }
+
+  /// 检测 line 切换并重置 alpha map，同时测量并缓存所有 word 宽度。
+  ///
+  /// 若传入的 line 与当前绑定不是同一对象引用（[identical] 失败），
+  /// 或 fontSize 变化，重新初始化每个 word 的 alpha 为 [dynamicDarkAlpha]，
+  /// 并测量每个 word 的宽度缓存到 [_wordWidths]。
+  ///
+  /// **性能优化**：word 宽度只在此时测量一次，paintLine 用缓存宽度做换行判断，
+  /// 避免每帧创建 N 个 TextPainter + layout。
+  void _ensureBound(LyricLine line, double fontSize) {
+    final sameLine = identical(_boundLine, line);
+    final sameFontSize = _boundFontSize == fontSize;
+    if (sameLine && sameFontSize) return;
+    _boundLine = line;
+    _boundFontSize = fontSize;
+    _wordAlphas.clear();
+    _wordYOffsets.clear();
+    final double dark = dynamicDarkAlpha;
+    // 测量所有 word 宽度并缓存
+    _wordWidths = List<double>.filled(line.words.length, 0);
+    for (int i = 0; i < line.words.length; i++) {
+      _painter.text = TextSpan(
+        text: line.words[i].text,
+        style: TextStyle(
+          fontSize: fontSize,
+          height: LyricLayout.lineHeight,
+        ),
+      );
+      _painter.layout();
+      _wordWidths[i] = _painter.width;
+      _wordAlphas[i] = dark;
+      _wordYOffsets[i] = 0;
+    }
+  }
+
+  /// 重置状态：清空 alpha map、Y 偏移、归零 progress、scale 回到 inactive、isActive=false、解绑 line。
+  void reset() {
+    _isActive = false;
+    _scale = LyricLayout.inactiveScale;
+    _currentLineProgress = 0.0;
+    _boundLine = null;
+    _boundFontSize = -1;
+    _wordWidths = const <double>[];
+    _wordAlphas.clear();
+    _wordYOffsets.clear();
+  }
+}

--- a/lib/widgets/playing_spectrum_indicator.dart
+++ b/lib/widgets/playing_spectrum_indicator.dart
@@ -1,0 +1,146 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+
+/// 正在播放频谱标识。
+///
+/// 用 Ticker 驱动 3 根粒度柱高度做 sin 波动，周期 800ms，
+/// 三根柱相位错开 0 / 0.4 / 0.8，呈现类似 Apple Music / 网易云的「正在播放」装饰性动画。
+///
+/// 仅是装饰性动画（不订阅 amplitudeStream / 不需要任何权限），
+/// 用来替代 [CircularProgressIndicator] loading 圈作为歌曲列表「正在播放」标识。
+class PlayingSpectrumIndicator extends StatefulWidget {
+  final Color color;
+
+  /// 整体尺寸（正方形），默认 14×14
+  final double size;
+
+  /// 是否正在播放：true 时 ticker 运行动画，false 时 ticker 停止保留最后一帧
+  final bool isPlaying;
+
+  const PlayingSpectrumIndicator({
+    super.key,
+    required this.color,
+    this.size = 14,
+    this.isPlaying = true,
+  });
+
+  @override
+  State<PlayingSpectrumIndicator> createState() =>
+      _PlayingSpectrumIndicatorState();
+}
+
+class _PlayingSpectrumIndicatorState extends State<PlayingSpectrumIndicator>
+    with SingleTickerProviderStateMixin {
+  late final Ticker _ticker;
+  Duration _lastElapsed = Duration.zero;
+  double _t = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _ticker = createTicker(_onTick);
+    // 根据 isPlaying 决定是否启动 ticker
+    if (widget.isPlaying) {
+      _ticker.start();
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant PlayingSpectrumIndicator oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // isPlaying 状态变化时启停 ticker：
+    // - false → true：重置 _lastElapsed 避免 dt 跳跃，然后 start
+    // - true → false：stop 保留最后一帧（setState 不再调用，画面冻结）
+    if (widget.isPlaying != oldWidget.isPlaying) {
+      if (widget.isPlaying) {
+        _lastElapsed = Duration.zero;
+        _ticker.start();
+      } else {
+        _ticker.stop();
+      }
+    }
+  }
+
+  void _onTick(Duration elapsed) {
+    final dt = (elapsed - _lastElapsed).inMicroseconds / 1000000.0;
+    _lastElapsed = elapsed;
+    _t += dt;
+    setState(() {});
+  }
+
+  @override
+  void dispose() {
+    _ticker.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final size = widget.size;
+    // 3 根柱基础高度 + 振幅
+    final baseHeight = size * 0.4;
+    final ampHeight = size * 0.5;
+    // 周期 800ms = 0.8s
+    final period = 0.8;
+
+    final barHeights = List<double>.generate(3, (i) {
+      // 相位错开 0 / 0.4 / 0.8
+      final phase = i * 0.4;
+      final s = (math.sin((_t / period + phase) * 2 * math.pi) + 1) / 2;
+      return baseHeight + ampHeight * s;
+    });
+
+    return SizedBox(
+      width: size,
+      height: size,
+      child: CustomPaint(
+        painter: _SpectrumPainter(
+          color: widget.color,
+          barHeights: barHeights,
+          barWidth: size / 4.5,
+          spacing: size / 6,
+        ),
+      ),
+    );
+  }
+}
+
+class _SpectrumPainter extends CustomPainter {
+  final Color color;
+  final List<double> barHeights;
+  final double barWidth;
+  final double spacing;
+
+  const _SpectrumPainter({
+    required this.color,
+    required this.barHeights,
+    required this.barWidth,
+    required this.spacing,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()..color = color;
+    final totalWidth = 3 * barWidth + 2 * spacing;
+    final startX = (size.width - totalWidth) / 2;
+    for (int i = 0; i < 3; i++) {
+      final x = startX + i * (barWidth + spacing);
+      final h = barHeights[i];
+      final y = (size.height - h) / 2;
+      canvas.drawRRect(
+        RRect.fromRectAndRadius(
+          Rect.fromLTWH(x, y, barWidth, h),
+          Radius.circular(barWidth / 2),
+        ),
+        paint,
+      );
+    }
+  }
+
+  @override
+  bool shouldRepaint(_SpectrumPainter oldDelegate) =>
+      oldDelegate.color != color ||
+      oldDelegate.barHeights != barHeights;
+}

--- a/lib/widgets/scroll_aware_app_bar.dart
+++ b/lib/widgets/scroll_aware_app_bar.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+
+/// 通用滚动感知 AppBar。
+///
+/// 顶栏背景色从透明渐变到 surface：
+/// - 滚动 offset 0 → [fadeRange]（默认 80px）范围背景从透明 → surface
+/// - 标题 opacity 同步从 0 → 1（避免初始就有标题文字时遮挡内容）
+/// - actions 始终可见
+///
+/// 用法：
+/// ```dart
+/// final _scrollController = ScrollController();
+/// Scaffold(
+///   appBar: ScrollAwareAppBar(
+///     title: '我的收藏',
+///     scrollController: _scrollController,
+///     actions: [...],
+///   ),
+///   body: ListView(
+///     controller: _scrollController,
+///     children: [...],
+///   ),
+/// )
+/// ```
+///
+/// **原理**：通过传入的 [ScrollController] 监听滚动 offset，调用方需要
+/// 把同一个 controller 传给 ListView / CustomScrollView。
+class ScrollAwareAppBar extends StatefulWidget implements PreferredSizeWidget {
+  final String title;
+  final List<Widget>? actions;
+  final ScrollController? scrollController;
+  final double fadeRange;
+  final Widget? leading;
+
+  const ScrollAwareAppBar({
+    super.key,
+    required this.title,
+    this.actions,
+    this.scrollController,
+    this.fadeRange = 80,
+    this.leading,
+  });
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+
+  @override
+  State<ScrollAwareAppBar> createState() => _ScrollAwareAppBarState();
+}
+
+class _ScrollAwareAppBarState extends State<ScrollAwareAppBar> {
+  double _scrollOffset = 0;
+
+  void _onScroll() {
+    if (!mounted) return;
+    final offset = widget.scrollController?.offset ?? 0;
+    if ((offset - _scrollOffset).abs() > 0.5) {
+      setState(() => _scrollOffset = offset);
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    widget.scrollController?.addListener(_onScroll);
+  }
+
+  @override
+  void didUpdateWidget(covariant ScrollAwareAppBar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.scrollController != widget.scrollController) {
+      oldWidget.scrollController?.removeListener(_onScroll);
+      widget.scrollController?.addListener(_onScroll);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.scrollController?.removeListener(_onScroll);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    final t = (_scrollOffset / widget.fadeRange).clamp(0.0, 1.0);
+
+    // 背景从透明渐变到 surface
+    final backgroundColor =
+        Color.lerp(Colors.transparent, colorScheme.surface, t)!;
+
+    return AppBar(
+      backgroundColor: backgroundColor,
+      elevation: 0,
+      scrolledUnderElevation: 0, // 关闭 Material 3 自带突变变色
+      surfaceTintColor: Colors.transparent, // 关闭 surfaceTint 着色
+      foregroundColor: colorScheme.onSurface,
+      leading: widget.leading,
+      // 标题始终显示（用户反馈：初始就应可见，不依赖滚动）
+      title: Text(
+        widget.title,
+        style: textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w600),
+      ),
+      actions: widget.actions,
+      centerTitle: false,
+    );
+  }
+}

--- a/lib/widgets/seed_color_picker.dart
+++ b/lib/widgets/seed_color_picker.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+
+import '../core/theme/app_theme.dart';
+
+/// 预设种子色选择面板。
+///
+/// 8 色圆形网格（4 列 × 2 行），当前选中项带勾选标记。
+/// 取自 [AppTheme.presetSeedColors]（M3 官方 Theme Builder 的 key tone 40）。
+class SeedColorPicker extends StatelessWidget {
+  /// 当前选中的颜色（用于高亮显示）。
+  final Color currentColor;
+
+  /// 选中颜色后的回调。
+  final ValueChanged<Color> onSelected;
+
+  const SeedColorPicker({
+    super.key,
+    required this.currentColor,
+    required this.onSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '选择主题色',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 16),
+          GridView.builder(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 4,
+              crossAxisSpacing: 12,
+              mainAxisSpacing: 12,
+              childAspectRatio: 1,
+            ),
+            itemCount: AppTheme.presetSeedColors.length,
+            itemBuilder: (ctx, i) {
+              final color = AppTheme.presetSeedColors[i];
+              final isSelected = color.value == currentColor.value;
+              return GestureDetector(
+                onTap: () => onSelected(color),
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: color,
+                    shape: BoxShape.circle,
+                    border: Border.all(
+                      color: isSelected
+                          ? colorScheme.onSurface
+                          : colorScheme.outlineVariant,
+                      width: isSelected ? 3 : 1,
+                    ),
+                  ),
+                  child: isSelected
+                      ? const Icon(Icons.check, color: Colors.white, size: 20)
+                      : null,
+                ),
+              );
+            },
+          ),
+          const SizedBox(height: 8),
+          Text(
+            '8 色取自 Material 3 官方 Theme Builder 的 key tone 40',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/song_list_item.dart
+++ b/lib/widgets/song_list_item.dart
@@ -7,6 +7,7 @@ import '../providers/downloads_provider.dart';
 import '../providers/favorites_provider.dart';
 import '../providers/player_provider.dart';
 import '../services/kugou_api/kugou_api_client.dart';
+import 'playing_spectrum_indicator.dart';
 
 class SongListItem extends StatelessWidget {
   final Song song;
@@ -34,7 +35,7 @@ class SongListItem extends StatelessWidget {
           children: [
             ListTile(
               leading: const Icon(Icons.music_note),
-              title: Text(song.title, style: const TextStyle(fontSize: 14)),
+              title: Text(song.displayName, style: const TextStyle(fontSize: 14)),
               subtitle: Text(song.artist, style: const TextStyle(fontSize: 12)),
             ),
             const Divider(height: 1),
@@ -93,7 +94,7 @@ class SongListItem extends StatelessWidget {
     showDialog(
       context: context,
       builder: (ctx) => AlertDialog(
-        title: Text('下载: ${song.title}'),
+        title: Text('下载: ${song.displayName}'),
         content: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
@@ -194,7 +195,7 @@ class SongListItem extends StatelessWidget {
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   Text(
-                    song.title,
+                    song.displayName,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     style: TextStyle(
@@ -224,18 +225,17 @@ class SongListItem extends StatelessWidget {
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
-                if (isCurrentSong && playerProvider.isPlaying)
+                if (isCurrentSong)
                   Padding(
                     padding: const EdgeInsets.only(right: 2),
-                    child: SizedBox(
-                      width: 13, height: 13,
-                      child: CircularProgressIndicator(strokeWidth: 1.5, color: colorScheme.primary),
+                    // 频谱动画标识：3 根粒度柱 sin 波动
+                    // 暂停时 isPlaying=false → ticker 停止，保留最后一帧
+                    // 继续播放时 isPlaying=true → ticker 恢复，动画继续
+                    child: PlayingSpectrumIndicator(
+                      color: colorScheme.primary,
+                      size: 14,
+                      isPlaying: playerProvider.isPlaying,
                     ),
-                  )
-                else if (isCurrentSong)
-                  Padding(
-                    padding: const EdgeInsets.only(right: 2),
-                    child: Icon(Icons.equalizer, size: 13, color: colorScheme.primary),
                   ),
                 if (showDuration)
                   Padding(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   http: ^1.2.1
   provider: ^6.1.2
   cached_network_image: ^3.3.1
+  flutter_cache_manager: ^3.4.1
   shared_preferences: ^2.5.0
   permission_handler: ^12.0.0
   path_provider: ^2.1.0
@@ -27,11 +28,16 @@ dependencies:
   cookie_jar: ^4.0.8
   url_launcher: ^6.3.0
   package_info_plus: ^8.2.0
+  ffi: ^2.1.0
+  palette_generator: ^0.3.3+7
+  dynamic_color: ^1.7.0
+  material_color_utilities: ^0.13.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
+  fake_async: ^1.3.1
 
 flutter:
   uses-material-design: true

--- a/test/providers/kugou_provider_test.dart
+++ b/test/providers/kugou_provider_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:md3music/providers/kugou_provider.dart';
+import 'package:md3music/services/kugou_api/kugou_models.dart';
+
+/// KugouProvider 歌词 getter 行为测试（Task 16）。
+///
+/// 覆盖 spec.md "Requirement: Provider 暴露 KRC / LRC 双 getter" 的可测部分。
+///
+/// **测试边界说明**：
+/// 项目未引入 mocktail / http_mock_adapter，且 `KugouApiClient` 是私有单例字段
+/// （`final KugouApiClient _apiClient = KugouApiClient();`），无法注入 mock。
+/// 因此 `getLyric` 成功 / 失败的 HTTP 路径不在此处直接覆盖，而是由以下两层
+/// 单元测试间接保证：
+///  1. `test/services/kugou_api/kugou_api_client_test.dart` 覆盖
+///     `mergeLyricResponses` 静态方法的 5 种合并场景（Task 15 双请求核心逻辑）；
+///  2. `test/services/kugou_api/kugou_models_test.dart` 覆盖
+///     `KugouLyric.displayLyric` / `displayKrcLyric` / `displayLrcLyric`
+///     的降级行为（Task 14 模型层契约）。
+///
+/// 本文件聚焦 Provider 层：getter 是否存在、是否共享 `_lyric` 存储、
+/// 是否不破坏现有调用方。`getLyric` 的方法签名兼容性由 Dart 编译器保证
+/// （`full_player.dart:91` 调用 `kugouProvider.getLyric(songId, songName: song.title)`，
+/// 任何签名变更都会导致编译失败）。
+void main() {
+  group('KugouProvider 歌词 getter (Task 16)', () {
+    late KugouProvider provider;
+
+    setUp(() {
+      provider = KugouProvider();
+    });
+
+    tearDown(() {
+      provider.dispose();
+    });
+
+    test('SubTask 16.2: 暴露 krcLyric 与 lrcLyric 两个 getter，返回 KugouLyric?',
+        () {
+      // 初始状态：两个新 getter 都应返回 null
+      // 返回类型 KugouLyric? 由 getter 声明静态保证，无需运行时校验
+      expect(provider.krcLyric, isNull);
+      expect(provider.lrcLyric, isNull);
+    });
+
+    test(
+        'SubTask 16.3: 保留现有 lyric getter 兼容旧代码（返回 krcLyric ?? lrcLyric）',
+        () {
+      // 初始时三个 getter 均为 null，关系 lyric == krcLyric ?? lrcLyric 成立
+      expect(provider.lyric, isNull);
+      expect(provider.lyric, equals(provider.krcLyric ?? provider.lrcLyric));
+
+      // Task 15 返回单个合并后的 KugouLyric，krcLyric 与 lrcLyric 引用同一对象，
+      // 因此二者应始终 identical（同一 _lyric 实例），由模型层
+      // displayKrcLyric/displayLrcLyric 区分 KRC / LRC 部分。
+      // 初始 null 时 identical 成立；非 null 时也成立。
+      expect(identical(provider.krcLyric, provider.lrcLyric), isTrue);
+    });
+
+    test('lyric / krcLyric / lrcLyric 三者在初始状态下一致为 null', () {
+      expect(provider.lyric, isNull);
+      expect(provider.krcLyric, isNull);
+      expect(provider.lrcLyric, isNull);
+      // 一致性不变式：lyric 永远等于 krcLyric ?? lrcLyric
+      expect(provider.lyric, equals(provider.krcLyric ?? provider.lrcLyric));
+    });
+
+    test('其他现有 getter 行为不受影响（isLoading / error / songUrl 等）', () {
+      // 这些 getter 与歌词无关，Task 16 不应破坏它们
+      expect(provider.isLoading, isFalse);
+      expect(provider.error, isNull);
+      expect(provider.songUrl, isNull);
+      expect(provider.comments, isNull);
+      expect(provider.searchResults, isNull);
+      expect(provider.hotSearchKeywords, isEmpty);
+      expect(provider.recommendSongs, isEmpty);
+      expect(provider.personalFmSongs, isEmpty);
+      expect(provider.rankSongs, isEmpty);
+      expect(provider.currentPlaylistSongs, isEmpty);
+    });
+
+    test('KugouLyric 模型契约：displayLyric 优先返回 KRC，降级 LRC', () {
+      // 直接构造 KugouLyric 验证 Provider 依赖的模型契约
+      // （此契约由 Task 14 实现，由 kugou_models_test.dart 完整覆盖，
+      // 这里再验证一次确保 Provider 通过 lyric?.displayLyric 拿到的是 KRC 优先）
+      const lrcText = '[00:01.00]Hello LRC';
+      const krcText = '[1000,2000]<0,1000,0>Hello';
+
+      // 同时有 KRC + LRC：displayLyric 返回 KRC
+      final bothLyric = KugouLyric(
+        content: 'raw',
+        decodedContent: lrcText,
+        decodedKrcContent: krcText,
+      );
+      expect(bothLyric.displayLyric, krcText);
+      expect(bothLyric.displayKrcLyric, krcText);
+      expect(bothLyric.displayLrcLyric, lrcText);
+
+      // 仅 LRC：displayLyric 降级返回 LRC
+      final lrcOnlyLyric = KugouLyric(
+        content: 'raw',
+        decodedContent: lrcText,
+      );
+      expect(lrcOnlyLyric.displayLyric, lrcText);
+      expect(lrcOnlyLyric.displayKrcLyric, isNull);
+      expect(lrcOnlyLyric.displayLrcLyric, lrcText);
+
+      // 仅 KRC：displayLyric 返回 KRC，displayLrcLyric 为 null
+      final krcOnlyLyric = KugouLyric(
+        content: 'raw',
+        decodedKrcContent: krcText,
+      );
+      expect(krcOnlyLyric.displayLyric, krcText);
+      expect(krcOnlyLyric.displayKrcLyric, krcText);
+      expect(krcOnlyLyric.displayLrcLyric, isNull);
+    });
+  });
+}

--- a/test/services/kugou_api/kugou_api_client_test.dart
+++ b/test/services/kugou_api/kugou_api_client_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:md3music/services/kugou_api/kugou_api_client.dart';
+import 'package:md3music/services/kugou_api/kugou_models.dart';
+
+/// KugouApiClient.getLyric 双请求（LRC + KRC）合并逻辑测试。
+///
+/// 说明：项目未引入 mocktail / http_mock_adapter，且 `_get` 为私有方法，
+/// 因此本测试聚焦于抽出的静态合并方法 `mergeLyricResponses`，
+/// 它是 getLyric 双请求路径的核心逻辑（Future.wait 后调用）。
+/// 覆盖 spec.md "Requirement: KRC 双请求与降级" 的 5 种场景。
+void main() {
+  group('KugouApiClient.mergeLyricResponses', () {
+    // 模拟 LRC 响应 data 节点：decodeContent 为 LRC 明文
+    const lrcText = '[00:01.00]Hello LRC\n[00:03.00]World';
+    final lrcJson = <String, dynamic>{
+      'content': 'BASE64_LRC_RAW',
+      'decodeContent': lrcText,
+      'translated_content': '[00:01.00]你好',
+    };
+
+    // 模拟 KRC 响应 data 节点：Node 侧把解码后的 KRC 明文放在 decodeContent 字段
+    // （这是双请求场景下 KRC 响应的典型形态）
+    const krcText = '[1000,2000]<0,1000,0>Hello';
+    final krcJson = <String, dynamic>{
+      'content': 'BASE64_KRC_RAW',
+      'decodeContent': krcText,
+    };
+
+    test('场景1: 双请求成功 — decodedContent 与 decodedKrcContent 都有值', () {
+      final lyric = KugouApiClient.mergeLyricResponses(lrcJson, krcJson);
+
+      expect(lyric, isNotNull);
+      // LRC 明文来自 LRC 响应的 decodeContent
+      expect(lyric!.decodedContent, lrcText);
+      // KRC 明文来自 KRC 响应的 decodeContent（在合并逻辑中映射到 decodedKrcContent）
+      expect(lyric.decodedKrcContent, krcText);
+      // translatedContent 来自 LRC 响应
+      expect(lyric.translatedContent, '[00:01.00]你好');
+      // content 优先用 LRC 的原始字段
+      expect(lyric.content, 'BASE64_LRC_RAW');
+      // displayLyric 优先返回 KRC
+      expect(lyric.displayLyric, krcText);
+      expect(lyric.displayKrcLyric, krcText);
+      expect(lyric.displayLrcLyric, lrcText);
+    });
+
+    test('场景1变体: KRC 响应显式带 decodeKrcContent 字段时优先用专用字段', () {
+      // 上游若显式返回 decodeKrcContent 字段，应优先于 decodeContent
+      final krcJsonWithExplicitField = <String, dynamic>{
+        'content': 'BASE64_KRC_RAW',
+        'decodeContent': 'SHOULD_NOT_BE_USED',
+        'decodeKrcContent': krcText,
+      };
+      final lyric = KugouApiClient.mergeLyricResponses(
+        lrcJson,
+        krcJsonWithExplicitField,
+      );
+      expect(lyric, isNotNull);
+      expect(lyric!.decodedKrcContent, krcText);
+      expect(lyric.decodedContent, lrcText);
+    });
+
+    test('场景2: 仅 LRC 成功（KRC 失败）— decodedKrcContent 为 null', () {
+      // KRC 请求失败 → krcJson 为 null
+      final lyric = KugouApiClient.mergeLyricResponses(lrcJson, null);
+
+      expect(lyric, isNotNull);
+      expect(lyric!.decodedContent, lrcText);
+      expect(lyric.decodedKrcContent, isNull);
+      expect(lyric.translatedContent, '[00:01.00]你好');
+      // 无 KRC 时 displayLyric 降级到 LRC
+      expect(lyric.displayLyric, lrcText);
+    });
+
+    test('场景3: 仅 KRC 成功（LRC 失败）— decodedContent 为 null', () {
+      // LRC 请求失败 → lrcJson 为 null
+      final lyric = KugouApiClient.mergeLyricResponses(null, krcJson);
+
+      expect(lyric, isNotNull);
+      expect(lyric!.decodedContent, isNull);
+      expect(lyric.decodedKrcContent, krcText);
+      // 无 LRC 时 displayLyric 降级到 KRC
+      expect(lyric.displayLyric, krcText);
+      expect(lyric.displayKrcLyric, krcText);
+      expect(lyric.displayLrcLyric, isNull);
+    });
+
+    test('场景4: 两者都失败 — 返回 null', () {
+      final lyric = KugouApiClient.mergeLyricResponses(null, null);
+      expect(lyric, isNull);
+    });
+
+    test('场景5: 显式 fmt=krc 单请求路径 — 仅 KRC 响应被解析为 KugouLyric', () {
+      // 此场景对应 getLyric(fmt: 'krc') 的单请求路径：
+      // 直接 KugouLyric.fromJson(krcJson)，不走合并逻辑。
+      // 单请求路径下 fromJson 把 decodeContent 映射到 decodedContent
+      // （因为 fromJson 不知道响应是 LRC 还是 KRC）。
+      // 这是单请求路径的已知行为；双请求路径通过 mergeLyricResponses
+      // 才能正确把 KRC 响应的 decodeContent 映射到 decodedKrcContent。
+      final krcJsonStandalone = <String, dynamic>{
+        'content': 'BASE64_KRC_RAW',
+        'decodeContent': krcText,
+      };
+      final lyric = KugouLyric.fromJson(krcJsonStandalone);
+
+      // 单请求路径下 decodeContent 落入 decodedContent
+      expect(lyric.decodedContent, krcText);
+      expect(lyric.decodedKrcContent, isNull);
+      expect(lyric.displayLyric, krcText);
+    });
+
+    test('合并时 translatedContent 优先取 LRC，LRC 缺失则取 KRC', () {
+      // LRC 没有 translated_content，KRC 有
+      final lrcNoTrans = <String, dynamic>{
+        'content': 'LRC_RAW',
+        'decodeContent': lrcText,
+      };
+      final krcWithTrans = <String, dynamic>{
+        'content': 'KRC_RAW',
+        'decodeContent': krcText,
+        'translated_content': '[00:01.00]KRC翻译',
+      };
+      final lyric = KugouApiClient.mergeLyricResponses(lrcNoTrans, krcWithTrans);
+      expect(lyric, isNotNull);
+      expect(lyric!.translatedContent, '[00:01.00]KRC翻译');
+    });
+
+    test('空 JSON 输入不崩溃，返回非 null 但字段为空/null', () {
+      final lyric = KugouApiClient.mergeLyricResponses(
+        <String, dynamic>{},
+        <String, dynamic>{},
+      );
+      expect(lyric, isNotNull);
+      expect(lyric!.content, '');
+      expect(lyric.decodedContent, isNull);
+      expect(lyric.decodedKrcContent, isNull);
+    });
+  });
+}

--- a/test/services/kugou_api/kugou_models_test.dart
+++ b/test/services/kugou_api/kugou_models_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:md3music/services/kugou_api/kugou_models.dart';
+
+/// KugouLyric.fromJson 双格式歌词（LRC + KRC）解析与 getter 降级行为测试
+void main() {
+  group('KugouLyric.fromJson', () {
+    test('同时有 decodeContent 与 decodeKrcContent 时，displayLyric 优先返回 KRC', () {
+      const lrcText = '[00:01.00]Hello LRC';
+      const krcText = '[1000,2000]<0,1000,0>Hello';
+      final lyric = KugouLyric.fromJson({
+        'content': 'BASE64_RAW',
+        'decodeContent': lrcText,
+        'decodeKrcContent': krcText,
+      });
+
+      expect(lyric.content, 'BASE64_RAW');
+      expect(lyric.decodedContent, lrcText);
+      expect(lyric.decodedKrcContent, krcText);
+
+      // 优先返回 KRC
+      expect(lyric.displayLyric, krcText);
+      // 单独 getter
+      expect(lyric.displayLrcLyric, lrcText);
+      expect(lyric.displayKrcLyric, krcText);
+    });
+
+    test('仅 decodeContent 时，displayLyric 返回 LRC，displayKrcLyric 为 null', () {
+      const lrcText = '[00:01.00]Hello LRC';
+      final lyric = KugouLyric.fromJson({
+        'content': 'BASE64_RAW',
+        'decodeContent': lrcText,
+      });
+
+      expect(lyric.decodedContent, lrcText);
+      expect(lyric.decodedKrcContent, isNull);
+
+      // 无 KRC 时降级到 LRC
+      expect(lyric.displayLyric, lrcText);
+      expect(lyric.displayLrcLyric, lrcText);
+      expect(lyric.displayKrcLyric, isNull);
+    });
+
+    test('两者都无，只有 content 时，displayLyric 返回原始 content', () {
+      final lyric = KugouLyric.fromJson({
+        'content': 'BASE64_RAW',
+      });
+
+      expect(lyric.content, 'BASE64_RAW');
+      expect(lyric.decodedContent, isNull);
+      expect(lyric.decodedKrcContent, isNull);
+
+      // KRC、LRC 均无，最终降级到原始 content
+      expect(lyric.displayLyric, 'BASE64_RAW');
+      expect(lyric.displayLrcLyric, isNull);
+      expect(lyric.displayKrcLyric, isNull);
+    });
+
+    test('KRC 字段名降级：decoded_krc_content 与 krcContent 也能被解析', () {
+      const krcSnake = '[1000,2000]<0,1000,0>snake';
+      const krcCamel = '[2000,2000]<0,1000,0>camel';
+
+      final lyricSnake = KugouLyric.fromJson({
+        'decoded_krc_content': krcSnake,
+      });
+      expect(lyricSnake.decodedKrcContent, krcSnake);
+      expect(lyricSnake.displayKrcLyric, krcSnake);
+      expect(lyricSnake.displayLrcLyric, isNull);
+
+      final lyricCamel = KugouLyric.fromJson({
+        'krcContent': krcCamel,
+      });
+      expect(lyricCamel.decodedKrcContent, krcCamel);
+      expect(lyricCamel.displayKrcLyric, krcCamel);
+    });
+
+    test('空 JSON 时 content 为空字符串，所有 getter 均降级为空/null', () {
+      final lyric = KugouLyric.fromJson(<String, dynamic>{});
+
+      expect(lyric.content, '');
+      expect(lyric.decodedContent, isNull);
+      expect(lyric.decodedKrcContent, isNull);
+      expect(lyric.displayLyric, '');
+      expect(lyric.displayLrcLyric, isNull);
+      expect(lyric.displayKrcLyric, isNull);
+    });
+  });
+}

--- a/test/widgets/apple_lyrics/animation/spring_test.dart
+++ b/test/widgets/apple_lyrics/animation/spring_test.dart
@@ -1,0 +1,194 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:md3music/widgets/apple_lyrics/animation/spring.dart';
+
+void main() {
+  group('Spring', () {
+    test('从 position=0 到 target=1 应收敛到 1', () {
+      final spring = Spring(stiffness: 100, damping: 20, mass: 1);
+      spring.setPosition(0, 0);
+      spring.setTarget(1);
+
+      // 默认参数下 discriminant=0 为临界阻尼，约 1.5s 内收敛
+      for (int i = 0; i < 200; i++) {
+        spring.tick(0.016);
+      }
+
+      expect(spring.position, closeTo(1, 0.01));
+      expect(spring.isSettled, isTrue);
+    });
+
+    test('高 stiffness 收敛更快', () {
+      // damping=20 时：低 stiffness(50) 进入过阻尼（20 > 2*sqrt(50)≈14.14）单调慢收敛；
+      // 高 stiffness(400) 为欠阻尼（20 < 2*sqrt(400)=40）快速震荡收敛
+      final soft = Spring(stiffness: 50, damping: 20, mass: 1);
+      final stiff = Spring(stiffness: 400, damping: 20, mass: 1);
+      soft.setPosition(0, 0);
+      soft.setTarget(1);
+      stiff.setPosition(0, 0);
+      stiff.setTarget(1);
+
+      // 模拟 0.32 秒（20 步）
+      for (int i = 0; i < 20; i++) {
+        soft.tick(0.016);
+        stiff.tick(0.016);
+      }
+
+      // 高 stiffness 应更接近目标 1
+      expect((1 - stiff.position).abs(),
+          lessThan((1 - soft.position).abs()));
+    });
+
+    test('isSettled 在运动中返回 false，稳定后返回 true', () {
+      final spring = Spring(stiffness: 100, damping: 20, mass: 1);
+      spring.setPosition(0, 0);
+      spring.setTarget(1);
+
+      // 刚 setTarget，尚未 tick，处于待运动状态
+      expect(spring.isSettled, isFalse);
+
+      // tick 一次后仍在运动
+      spring.tick(0.016);
+      expect(spring.isSettled, isFalse);
+
+      // 模拟足够长时间直到稳定
+      for (int i = 0; i < 300; i++) {
+        spring.tick(0.016);
+      }
+      expect(spring.isSettled, isTrue);
+    });
+
+    test('setTarget 在运动中改变目标能正常过渡', () {
+      final spring = Spring(stiffness: 100, damping: 20, mass: 1);
+      spring.setPosition(0, 0);
+      spring.setTarget(1);
+
+      // 运动 0.096 秒
+      for (int i = 0; i < 6; i++) {
+        spring.tick(0.016);
+      }
+      final double midPos = spring.position;
+      expect(midPos, greaterThan(0));
+      expect(midPos, lessThan(1));
+
+      // 运动中改变目标到 2
+      spring.setTarget(2);
+      expect(spring.isSettled, isFalse);
+
+      // 继续运动直到稳定
+      for (int i = 0; i < 500; i++) {
+        spring.tick(0.016);
+      }
+      expect(spring.position, closeTo(2, 0.01));
+      expect(spring.isSettled, isTrue);
+    });
+
+    test('reset() 后回到 0', () {
+      final spring = Spring(stiffness: 100, damping: 20, mass: 1);
+      spring.setPosition(0, 0);
+      spring.setTarget(1);
+      for (int i = 0; i < 50; i++) {
+        spring.tick(0.016);
+      }
+      expect(spring.position, isNot(equals(0)));
+
+      spring.reset();
+      expect(spring.position, equals(0));
+      expect(spring.velocity, equals(0));
+      expect(spring.target, equals(0));
+      expect(spring.isSettled, isTrue);
+    });
+
+    test('大 dt 输入不导致数值发散', () {
+      final spring = Spring(stiffness: 100, damping: 20, mass: 1);
+      spring.setPosition(0, 0);
+      spring.setTarget(1);
+
+      // 一次性 tick 10 秒，子步进应保证不发散
+      spring.tick(10.0);
+
+      expect(spring.position, isNot(equals(double.infinity)));
+      expect(spring.position.isNaN, isFalse);
+      expect(spring.position, closeTo(1, 0.01));
+      expect(spring.isSettled, isTrue);
+    });
+
+    test('setPosition 设置初始状态并标记为稳定', () {
+      final spring = Spring();
+      spring.setPosition(5, 0);
+      expect(spring.position, equals(5));
+      expect(spring.target, equals(5));
+      expect(spring.isSettled, isTrue);
+
+      // tick 后不应改变（已稳定）
+      spring.tick(0.1);
+      expect(spring.position, equals(5));
+    });
+
+    test('setParams 动态调整参数后能继续收敛', () {
+      final spring = Spring(stiffness: 100, damping: 20, mass: 1);
+      spring.setPosition(0, 0);
+      spring.setTarget(1);
+
+      // 运动 0.096 秒
+      for (int i = 0; i < 6; i++) {
+        spring.tick(0.016);
+      }
+
+      // 运动中改变参数
+      spring.setParams(stiffness: 400, damping: 30);
+
+      // 继续运动直到稳定
+      for (int i = 0; i < 500; i++) {
+        spring.tick(0.016);
+      }
+      expect(spring.position, closeTo(1, 0.01));
+      expect(spring.isSettled, isTrue);
+    });
+
+    test('过阻尼情况稳定收敛不发散', () {
+      // damping=30 > 2*sqrt(100)=20，过阻尼
+      final spring = Spring(stiffness: 100, damping: 30, mass: 1);
+      spring.setPosition(0, 0);
+      spring.setTarget(1);
+
+      for (int i = 0; i < 500; i++) {
+        spring.tick(0.016);
+      }
+
+      expect(spring.position, isNot(equals(double.infinity)));
+      expect(spring.position.isNaN, isFalse);
+      expect(spring.position, closeTo(1, 0.01));
+      expect(spring.isSettled, isTrue);
+    });
+
+    test('欠阻尼情况会震荡收敛', () {
+      // damping=5 < 2*sqrt(100)=20，欠阻尼
+      final spring = Spring(stiffness: 100, damping: 5, mass: 1);
+      spring.setPosition(0, 0);
+      spring.setTarget(1);
+
+      double maxOvershoot = 0;
+      for (int i = 0; i < 500; i++) {
+        spring.tick(0.016);
+        if (spring.position > maxOvershoot) {
+          maxOvershoot = spring.position;
+        }
+      }
+
+      // 欠阻尼应产生超调（超过目标值 1）
+      expect(maxOvershoot, greaterThan(1));
+      expect(spring.position, closeTo(1, 0.01));
+      expect(spring.isSettled, isTrue);
+    });
+
+    test('tick(0) 与负 dt 不影响状态', () {
+      final spring = Spring(stiffness: 100, damping: 20, mass: 1);
+      spring.setPosition(0, 0);
+      spring.setTarget(1);
+      spring.tick(0);
+      expect(spring.position, equals(0));
+      spring.tick(-1);
+      expect(spring.position, equals(0));
+    });
+  });
+}

--- a/test/widgets/apple_lyrics/apple_lyrics_view_test.dart
+++ b/test/widgets/apple_lyrics/apple_lyrics_view_test.dart
@@ -1,0 +1,291 @@
+/// AppleLyricsView 单元测试
+///
+/// 覆盖 spec.md "Requirement: 点击跳转" 与 tasks.md Task 17 各场景：
+/// 1. 空 lines 列表 build 不崩溃
+/// 2. findCurrentLineIndex 纯逻辑测试（currentTimeMs=0 → index=0 等）
+/// 3. currentTimeMs 落在某行内：当前行正确切换
+/// 4. 点击某行：触发 onSeek 回调，参数为该行 startTime
+/// 5. hasWordTiming 切换：混合 KRC 行与 LRC 行时 build 不崩溃
+/// 6. currentTimeMs 推进后 build 不崩溃（posY 变化由弹簧驱动，此处验证不崩溃）
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:md3music/widgets/apple_lyrics/apple_lyrics_view.dart';
+import 'package:md3music/widgets/apple_lyrics/models/lyric_line.dart';
+
+void main() {
+  group('AppleLyricsView.findCurrentLineIndex', () {
+    test('空列表返回 -1', () {
+      expect(AppleLyricsView.findCurrentLineIndex(const [], 0), -1);
+    });
+
+    test('currentTimeMs=0 当前行 index=0', () {
+      final lines = <LyricLine>[
+        LyricLine(startTime: 0, duration: 1000, text: 'A'),
+        LyricLine(startTime: 1000, duration: 1000, text: 'B'),
+      ];
+      expect(AppleLyricsView.findCurrentLineIndex(lines, 0), 0);
+    });
+
+    test('currentTimeMs 落在某行内返回正确索引', () {
+      final lines = <LyricLine>[
+        LyricLine(startTime: 0, duration: 1000, text: 'A'),
+        LyricLine(startTime: 1000, duration: 1000, text: 'B'),
+        LyricLine(startTime: 2000, duration: 1000, text: 'C'),
+      ];
+      expect(AppleLyricsView.findCurrentLineIndex(lines, 0), 0);
+      expect(AppleLyricsView.findCurrentLineIndex(lines, 500), 0);
+      expect(AppleLyricsView.findCurrentLineIndex(lines, 1000), 1);
+      expect(AppleLyricsView.findCurrentLineIndex(lines, 1500), 1);
+      expect(AppleLyricsView.findCurrentLineIndex(lines, 2000), 2);
+      // 时间超过最后一行：返回最后一行
+      expect(AppleLyricsView.findCurrentLineIndex(lines, 9999), 2);
+    });
+
+    test('时间早于第一行返回 0', () {
+      final lines = <LyricLine>[
+        LyricLine(startTime: 1000, duration: 1000, text: 'A'),
+      ];
+      expect(AppleLyricsView.findCurrentLineIndex(lines, 500), 0);
+      expect(AppleLyricsView.findCurrentLineIndex(lines, 0), 0);
+    });
+  });
+
+  group('AppleLyricsView build', () {
+    // 辅助：泵送多帧让弹簧动画推进
+    Future<void> pumpFrames(WidgetTester tester, int frames) async {
+      for (int i = 0; i < frames; i++) {
+        await tester.pump(const Duration(milliseconds: 16));
+      }
+    }
+
+    testWidgets('空 lines 列表 build 不崩溃', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppleLyricsView(
+              lines: const [],
+              currentTimeMs: 0,
+            ),
+          ),
+        ),
+      );
+      await pumpFrames(tester, 5);
+      expect(find.byType(AppleLyricsView), findsOneWidget);
+    });
+
+    testWidgets('有 lines 但 currentTimeMs=0 build 不崩溃', (tester) async {
+      final lines = <LyricLine>[
+        LyricLine(startTime: 0, duration: 1000, text: 'Line 1'),
+        LyricLine(startTime: 1000, duration: 1000, text: 'Line 2'),
+      ];
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppleLyricsView(
+              lines: lines,
+              currentTimeMs: 0,
+            ),
+          ),
+        ),
+      );
+      await pumpFrames(tester, 5);
+      expect(find.byType(AppleLyricsView), findsOneWidget);
+    });
+
+    testWidgets('混合 KRC 与 LRC 行 build 不崩溃', (tester) async {
+      final lines = <LyricLine>[
+        // KRC 行（hasWordTiming=true）
+        LyricLine(
+          startTime: 0,
+          duration: 1000,
+          text: 'KRC行',
+          words: [
+            LyricWord(startTime: 0, duration: 500, text: 'KRC'),
+            LyricWord(startTime: 500, duration: 500, text: '行'),
+          ],
+        ),
+        // LRC 行（hasWordTiming=false）
+        LyricLine(startTime: 1000, duration: 1000, text: 'LRC行'),
+      ];
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppleLyricsView(
+              lines: lines,
+              currentTimeMs: 500,
+              isPlaying: true,
+            ),
+          ),
+        ),
+      );
+      await pumpFrames(tester, 10);
+      expect(find.byType(AppleLyricsView), findsOneWidget);
+    });
+
+    testWidgets('enableScale=false 时不崩溃', (tester) async {
+      final lines = <LyricLine>[
+        LyricLine(startTime: 0, duration: 1000, text: 'A'),
+      ];
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppleLyricsView(
+              lines: lines,
+              currentTimeMs: 0,
+              enableScale: false,
+            ),
+          ),
+        ),
+      );
+      await pumpFrames(tester, 5);
+      expect(find.byType(AppleLyricsView), findsOneWidget);
+    });
+
+    testWidgets('currentTimeMs 推进后 build 不崩溃（posY 变化）', (tester) async {
+      final lines = <LyricLine>[
+        LyricLine(startTime: 0, duration: 1000, text: 'A'),
+        LyricLine(startTime: 1000, duration: 1000, text: 'B'),
+        LyricLine(startTime: 2000, duration: 1000, text: 'C'),
+      ];
+      // 初始构建：currentTimeMs=0
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppleLyricsView(
+              lines: lines,
+              currentTimeMs: 0,
+              isPlaying: true,
+            ),
+          ),
+        ),
+      );
+      await pumpFrames(tester, 10);
+
+      // 推进到第二行
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppleLyricsView(
+              lines: lines,
+              currentTimeMs: 1500,
+              isPlaying: true,
+            ),
+          ),
+        ),
+      );
+      await pumpFrames(tester, 10);
+
+      // 推进到第三行
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppleLyricsView(
+              lines: lines,
+              currentTimeMs: 2500,
+              isPlaying: true,
+            ),
+          ),
+        ),
+      );
+      await pumpFrames(tester, 10);
+
+      expect(find.byType(AppleLyricsView), findsOneWidget);
+    });
+  });
+
+  group('AppleLyricsView 点击跳转', () {
+    testWidgets('点击某行触发 onSeek 回调，参数为该行 startTime', (tester) async {
+      int? seekTime;
+      final lines = <LyricLine>[
+        LyricLine(startTime: 0, duration: 2000, text: 'Line 1'),
+      ];
+
+      // 使用固定尺寸便于计算点击位置
+      tester.view.physicalSize = const Size(800, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 800,
+              height: 600,
+              child: AppleLyricsView(
+                lines: lines,
+                currentTimeMs: 0,
+                isPlaying: true,
+                onSeek: (t) => seekTime = t,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // 泵送足够帧让弹簧动画稳定（posY 接近 targetY）
+      // 60帧 ≈ 1秒，足够弹簧收敛
+      for (int i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 16));
+      }
+
+      // 计算点击位置：
+      // fontSize = max(800*0.08, 12) = 64
+      // lineHeight = 64 * 1.2 = 76.8
+      // targetY = -(0*76.8 + 38.4 - 600*0.35) = -(38.4 - 210) = 171.6
+      // 第0行中心 y ≈ 171.6 + 38.4 = 210
+      await tester.tapAt(const Offset(400, 210));
+      await tester.pump();
+
+      expect(seekTime, isNotNull);
+      expect(seekTime, 0);
+    });
+
+    testWidgets('点击第二行触发 onSeek 回调，参数为第二行 startTime', (tester) async {
+      int? seekTime;
+      final lines = <LyricLine>[
+        LyricLine(startTime: 0, duration: 1000, text: 'Line 1'),
+        LyricLine(startTime: 1000, duration: 1000, text: 'Line 2'),
+      ];
+
+      tester.view.physicalSize = const Size(800, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 800,
+              height: 600,
+              child: AppleLyricsView(
+                lines: lines,
+                currentTimeMs: 1000,
+                isPlaying: true,
+                onSeek: (t) => seekTime = t,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // 泵送足够帧让弹簧动画稳定
+      for (int i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 16));
+      }
+
+      // 第1行（index=1）中心 y：
+      // posY = targetYForLine(1, 76.8) = -(1*76.8 + 38.4 - 600*0.35) = 94.8
+      // 第1行顶部 y = 1 * lineHeight + posY = 76.8 + 94.8 = 171.6
+      // 第1行中心 y = 171.6 + lineHeight/2 = 171.6 + 38.4 = 210
+      await tester.tapAt(const Offset(400, 210));
+      await tester.pump();
+
+      expect(seekTime, isNotNull);
+      expect(seekTime, 1000);
+    });
+  });
+}

--- a/test/widgets/apple_lyrics/controllers/line_scale_controller_test.dart
+++ b/test/widgets/apple_lyrics/controllers/line_scale_controller_test.dart
@@ -1,0 +1,198 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:md3music/widgets/apple_lyrics/controllers/line_scale_controller.dart';
+import 'package:md3music/widgets/apple_lyrics/layout/lyric_layout.dart';
+
+/// LineScaleController 单元测试
+///
+/// 覆盖 spec.md "Requirement: 行缩放动画" 与 tasks.md Task 12 的全部子任务：
+/// 1. 初始状态
+/// 2. isActive=true 收敛到 1.0
+/// 3. isActive=false 收敛到 0.97
+/// 4. 背景行非活跃收敛到 0.75
+/// 5. 背景行活跃收敛到 1.0
+/// 6. enableScale=false 强制 1.0
+/// 7. 对唱行 scaleOrigin 为 centerRight
+/// 8. 非对唱行 scaleOrigin 为 centerLeft
+/// 9. 行切换弹簧过渡
+/// 10. isAnimating 运动中 true，稳定后 false
+/// 11. tick 稳定后返回 false
+/// 12. reset 后 scale=1.0
+void main() {
+  group('LineScaleController', () {
+    test('1. 初始状态：currentScale = 1.0，isAnimating = false', () {
+      final controller = LineScaleController();
+      expect(controller.currentScale, equals(LyricLayout.activeScale));
+      expect(controller.isAnimating, isFalse);
+    });
+
+    test('2. setLineState(isActive=true) 后 scale 收敛到 1.0', () {
+      final controller = LineScaleController();
+      controller.setLineState(isActive: true);
+
+      // target 已为 1.0，与初始位置相同，应直接稳定
+      expect(controller.currentScale, equals(LyricLayout.activeScale));
+
+      // 多次 tick 后仍为 1.0
+      for (int i = 0; i < 100; i++) {
+        controller.tick(0.016);
+      }
+      expect(controller.currentScale, closeTo(1.0, 1e-3));
+      expect(controller.isAnimating, isFalse);
+    });
+
+    test('3. setLineState(isActive=false) 后 scale 收敛到 0.97', () {
+      final controller = LineScaleController();
+      controller.setLineState(isActive: false);
+
+      // 设定后应处于运动中
+      expect(controller.isAnimating, isTrue);
+
+      // 模拟 5 秒（每步 16ms），应收敛到 0.97
+      for (int i = 0; i < 300; i++) {
+        controller.tick(0.016);
+      }
+      expect(controller.currentScale, closeTo(LyricLayout.inactiveScale, 1e-3));
+      expect(controller.isAnimating, isFalse);
+    });
+
+    test('4. 背景行 setLineState(isActive=false, isBackground=true) 收敛到 0.75',
+        () {
+      final controller = LineScaleController();
+      controller.setLineState(isActive: false, isBackground: true);
+
+      expect(controller.isAnimating, isTrue);
+
+      for (int i = 0; i < 300; i++) {
+        controller.tick(0.016);
+      }
+      expect(
+        controller.currentScale,
+        closeTo(LyricLayout.backgroundInactiveScale, 1e-3),
+      );
+      expect(controller.isAnimating, isFalse);
+    });
+
+    test('5. 背景行 setLineState(isActive=true, isBackground=true) 收敛到 1.0', () {
+      final controller = LineScaleController();
+      controller.setLineState(isActive: true, isBackground: true);
+
+      // target=1.0 与初始位置相同，应稳定
+      expect(controller.currentScale, equals(LyricLayout.backgroundActiveScale));
+
+      for (int i = 0; i < 100; i++) {
+        controller.tick(0.016);
+      }
+      expect(controller.currentScale, closeTo(1.0, 1e-3));
+      expect(controller.isAnimating, isFalse);
+    });
+
+    test('6. enableScale=false：无论 isActive 如何 target=1.0', () {
+      final controller = LineScaleController();
+
+      // 先将 scale 弹到 0.97（非活跃主行）
+      controller.setLineState(isActive: false);
+      for (int i = 0; i < 300; i++) {
+        controller.tick(0.016);
+      }
+      expect(controller.currentScale, closeTo(LyricLayout.inactiveScale, 1e-3));
+
+      // 关闭缩放：即使 isActive=false，也应回到 1.0
+      controller.setLineState(isActive: false, enableScale: false);
+      expect(controller.isAnimating, isTrue);
+
+      for (int i = 0; i < 300; i++) {
+        controller.tick(0.016);
+      }
+      expect(controller.currentScale, closeTo(1.0, 1e-3));
+      expect(controller.isAnimating, isFalse);
+    });
+
+    test('7. 对唱行 scaleOrigin 返回 Alignment.centerRight', () {
+      final controller = LineScaleController();
+      controller.setLineState(isActive: true, isDuet: true);
+      expect(controller.scaleOrigin, equals(Alignment.centerRight));
+    });
+
+    test('8. 非对唱行 scaleOrigin 返回 Alignment.centerLeft', () {
+      final controller = LineScaleController();
+      controller.setLineState(isActive: true, isDuet: false);
+      expect(controller.scaleOrigin, equals(Alignment.centerLeft));
+    });
+
+    test('9. 行切换：从 isActive=true 切到 isActive=false，scale 从 1.0 过渡到 0.97',
+        () {
+      final controller = LineScaleController();
+
+      // 先设为活跃（已在 1.0）
+      controller.setLineState(isActive: true);
+      expect(controller.currentScale, equals(1.0));
+
+      // 切换为非活跃
+      controller.setLineState(isActive: false);
+      expect(controller.isAnimating, isTrue);
+
+      // 推进少量步数，scale 应在 (0.97, 1.0) 之间，尚未到达 0.97
+      for (int i = 0; i < 10; i++) {
+        controller.tick(0.016);
+      }
+      expect(controller.currentScale, lessThan(1.0));
+      expect(controller.currentScale, greaterThan(LyricLayout.inactiveScale));
+
+      // 继续推进至收敛
+      for (int i = 0; i < 290; i++) {
+        controller.tick(0.016);
+      }
+      expect(controller.currentScale, closeTo(LyricLayout.inactiveScale, 1e-3));
+      expect(controller.isAnimating, isFalse);
+    });
+
+    test('10. isAnimating：运动中 true，稳定后 false', () {
+      final controller = LineScaleController();
+
+      // 触发运动
+      controller.setLineState(isActive: false);
+      expect(controller.isAnimating, isTrue);
+
+      // 运动中
+      controller.tick(0.016);
+      expect(controller.isAnimating, isTrue);
+
+      // 推进至稳定
+      for (int i = 0; i < 300; i++) {
+        controller.tick(0.016);
+      }
+      expect(controller.isAnimating, isFalse);
+    });
+
+    test('11. tick 在稳定后返回 false', () {
+      final controller = LineScaleController();
+      controller.setLineState(isActive: false);
+
+      // 推进至稳定
+      for (int i = 0; i < 300; i++) {
+        controller.tick(0.016);
+      }
+
+      // 稳定后 tick 应返回 false
+      final needsRepaint = controller.tick(0.016);
+      expect(needsRepaint, isFalse);
+    });
+
+    test('12. reset() 后 scale=1.0', () {
+      final controller = LineScaleController();
+
+      // 先弹到 0.97
+      controller.setLineState(isActive: false);
+      for (int i = 0; i < 300; i++) {
+        controller.tick(0.016);
+      }
+      expect(controller.currentScale, closeTo(LyricLayout.inactiveScale, 1e-3));
+
+      // reset 后回到 1.0 且稳定
+      controller.reset();
+      expect(controller.currentScale, equals(LyricLayout.activeScale));
+      expect(controller.isAnimating, isFalse);
+    });
+  });
+}

--- a/test/widgets/apple_lyrics/controllers/lyric_scroll_controller_test.dart
+++ b/test/widgets/apple_lyrics/controllers/lyric_scroll_controller_test.dart
@@ -1,0 +1,268 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:md3music/widgets/apple_lyrics/controllers/lyric_scroll_controller.dart';
+import 'package:md3music/widgets/apple_lyrics/layout/lyric_layout.dart';
+
+/// LyricScrollController 单元测试
+///
+/// 覆盖 spec.md "Requirement: 弹簧物理动画引擎" 与 tasks.md Task 11 的全部子任务：
+/// 1. 初始状态
+/// 2. setCurrentLine 后 spring target 改变且收敛
+/// 3. targetYForLine 公式
+/// 4. seeking 模式切换为固定参数 (90, 15)
+/// 5. 普通模式动态参数（interval 100ms→220, 800ms→170）
+/// 6. onUserScroll 直接修改 posY
+/// 7. onUserScrollEnd 后 5000ms 自动回弹（fakeAsync）
+/// 8. isClickGesture 阈值判定
+/// 9. tick 在稳定后返回 false
+/// 10. dispose 不崩溃
+void main() {
+  group('LyricScrollController', () {
+    test('1. 初始状态：posY = 0，currentLineIndex = -1', () {
+      final controller = LyricScrollController();
+      expect(controller.posY, equals(0));
+      expect(controller.currentLineIndex, equals(-1));
+      expect(controller.viewportHeight, equals(0));
+      controller.dispose();
+    });
+
+    test('2. setCurrentLine 后 Spring target 改变，posY 经 tick 收敛到目标', () {
+      final controller = LyricScrollController();
+      controller.setViewportSize(const Size(400, 600));
+      // 第 0 行，行高 40，对齐位置 0.35
+      // targetY = -(0 + 20 - 600*0.35) = -(0 + 20 - 210) = 190
+      controller.setCurrentLine(
+        0,
+        isSeeking: false,
+        lineHeight: 40,
+        intervalMs: 500,
+      );
+
+      // setTarget 后 spring 应处于待运动状态
+      expect(controller.currentTarget, closeTo(190, 1e-9));
+      // 初始 posY 仍为 0，待 tick 推进
+      expect(controller.posY, equals(0));
+
+      // 模拟 5 秒（每步 16ms），应收敛到 target
+      bool needsRepaint = true;
+      for (int i = 0; i < 300; i++) {
+        needsRepaint = controller.tick(0.016);
+      }
+      expect(controller.posY, closeTo(190, 0.5));
+      expect(needsRepaint, isFalse);
+      controller.dispose();
+    });
+
+    test('3. targetYForLine：viewport=600, lineHeight=40, lineIndex=0 → 190', () {
+      final controller = LyricScrollController();
+      controller.setViewportSize(const Size(400, 600));
+      // lineIndex=0: -(0 + 20 - 210) = 190
+      expect(controller.targetYForLine(0, 40), closeTo(190, 1e-9));
+      // lineIndex=1: -(40 + 20 - 210) = 150
+      expect(controller.targetYForLine(1, 40), closeTo(150, 1e-9));
+      // lineIndex=5: -(200 + 20 - 210) = -10
+      expect(controller.targetYForLine(5, 40), closeTo(-10, 1e-9));
+      controller.dispose();
+    });
+
+    test('4. setSeekingMode(true) 后弹簧参数为 stiffness=90, damping=15', () {
+      final controller = LyricScrollController();
+      // 初始默认为 seeking 参数
+      expect(controller.currentStiffness, equals(LyricLayout.posYSeekingStiffness));
+      expect(controller.currentDamping, equals(LyricLayout.posYSeekingDamping));
+
+      // 切换到普通模式（intervalMs=500，中间值）
+      controller.setCurrentLine(
+        0,
+        isSeeking: false,
+        lineHeight: 40,
+        intervalMs: 500,
+      );
+      // 普通模式 stiffness 在 [170, 220] 之间
+      expect(controller.currentStiffness,
+          allOf(greaterThanOrEqualTo(170), lessThanOrEqualTo(220)));
+      expect(controller.currentStiffness, isNot(equals(90)));
+
+      // 切换到 seeking 模式
+      controller.setSeekingMode(true);
+      expect(controller.currentStiffness, equals(90));
+      expect(controller.currentDamping, equals(15));
+      controller.dispose();
+    });
+
+    test('5. 普通模式动态参数：interval 100ms→stiffness=220，800ms→stiffness=170', () {
+      final controller = LyricScrollController();
+      controller.setViewportSize(const Size(400, 600));
+
+      // 间隔 100ms（密集）→ stiffness=220（最灵敏）
+      controller.setCurrentLine(
+        0,
+        isSeeking: false,
+        lineHeight: 40,
+        intervalMs: 100,
+      );
+      expect(controller.currentStiffness, closeTo(220, 1e-3));
+      // damping = sqrt(220) * 2.2
+      expect(controller.currentDamping,
+          closeTo(LyricLayout.posYNormalDamping(220), 1e-9));
+
+      // 间隔 800ms（稀疏）→ stiffness=170（最迟缓）
+      controller.setCurrentLine(
+        1,
+        isSeeking: false,
+        lineHeight: 40,
+        intervalMs: 800,
+      );
+      expect(controller.currentStiffness, closeTo(170, 1e-3));
+      expect(controller.currentDamping,
+          closeTo(LyricLayout.posYNormalDamping(170), 1e-9));
+
+      // 超出 clamp 范围：50ms 应等价于 100ms（→ 220）
+      controller.setCurrentLine(
+        2,
+        isSeeking: false,
+        lineHeight: 40,
+        intervalMs: 50,
+      );
+      expect(controller.currentStiffness, closeTo(220, 1e-3));
+
+      // 超出 clamp 范围：2000ms 应等价于 800ms（→ 170）
+      controller.setCurrentLine(
+        3,
+        isSeeking: false,
+        lineHeight: 40,
+        intervalMs: 2000,
+      );
+      expect(controller.currentStiffness, closeTo(170, 1e-3));
+      controller.dispose();
+    });
+
+    test('6. onUserScroll 直接修改 posY：拖动 50px 后 posY 变化', () {
+      final controller = LyricScrollController();
+      controller.setViewportSize(const Size(400, 600));
+      // 先设置当前行让 posY 有一个基准
+      controller.setCurrentLine(
+        0,
+        isSeeking: false,
+        lineHeight: 40,
+        intervalMs: 500,
+      );
+      // 推进到稳定
+      for (int i = 0; i < 300; i++) {
+        controller.tick(0.016);
+      }
+      final double stableY = controller.posY;
+      expect(stableY, closeTo(190, 0.5));
+
+      // 用户向下拖动 50px（posY 增大）
+      controller.onUserScroll(50);
+      expect(controller.posY, closeTo(stableY + 50, 1e-9));
+
+      // 继续拖动 -30px
+      controller.onUserScroll(-30);
+      expect(controller.posY, closeTo(stableY + 20, 1e-9));
+      controller.dispose();
+    });
+
+    test('7. onUserScrollEnd 后 5000ms 自动回弹（fakeAsync 模拟时间）', () {
+      fakeAsync((async) {
+        final controller = LyricScrollController();
+        controller.setViewportSize(const Size(400, 600));
+        controller.setCurrentLine(
+          0,
+          isSeeking: false,
+          lineHeight: 40,
+          intervalMs: 500,
+        );
+        // 推进到稳定
+        for (int i = 0; i < 300; i++) {
+          controller.tick(0.016);
+        }
+        final double stableY = controller.posY;
+        expect(stableY, closeTo(190, 0.5));
+
+        // 用户拖动 80px
+        controller.onUserScroll(80);
+        expect(controller.posY, closeTo(stableY + 80, 1e-9));
+
+        // 手势结束，开始 5000ms 倒计时
+        controller.onUserScrollEnd();
+
+        // 模拟时间推进 4999ms（每 16ms tick 一次），不应回弹
+        // 4999 / 16 ≈ 312 次
+        for (int i = 0; i < 312; i++) {
+          controller.tick(0.016);
+          async.elapse(const Duration(milliseconds: 16));
+        }
+        // posY 仍应接近 stableY + 80（未回弹）
+        expect(controller.posY, closeTo(stableY + 80, 1.0));
+
+        // 继续推进到 5000ms+，应触发回弹
+        for (int i = 0; i < 600; i++) {
+          controller.tick(0.016);
+          async.elapse(const Duration(milliseconds: 16));
+        }
+        // 回弹后应收敛回 stableY
+        expect(controller.posY, closeTo(stableY, 1.0));
+        controller.dispose();
+      });
+    });
+
+    test('8. isClickGesture：5px→true，15px→false', () {
+      final controller = LyricScrollController();
+      // 阈值 10px：< 10 视为点击
+      expect(controller.isClickGesture(5), isTrue);
+      expect(controller.isClickGesture(-5), isTrue); // 绝对值判定
+      expect(controller.isClickGesture(0), isTrue);
+      expect(controller.isClickGesture(15), isFalse);
+      expect(controller.isClickGesture(-15), isFalse);
+      // 边界：10px 不视为点击（< 10 才是）
+      expect(controller.isClickGesture(10), isFalse);
+      expect(controller.isClickGesture(9.99), isTrue);
+      controller.dispose();
+    });
+
+    test('9. tick 在稳定后返回 false（无需重绘）', () {
+      final controller = LyricScrollController();
+      controller.setViewportSize(const Size(400, 600));
+      controller.setCurrentLine(
+        0,
+        isSeeking: false,
+        lineHeight: 40,
+        intervalMs: 500,
+      );
+
+      // 运动 1 步后应返回 true（仍需重绘）
+      bool needsRepaint = controller.tick(0.016);
+      expect(needsRepaint, isTrue);
+
+      // 推进到稳定
+      for (int i = 0; i < 500; i++) {
+        needsRepaint = controller.tick(0.016);
+      }
+      // 稳定后应返回 false
+      expect(needsRepaint, isFalse);
+      controller.dispose();
+    });
+
+    test('10. dispose 释放资源不崩溃', () {
+      final controller = LyricScrollController();
+      controller.setViewportSize(const Size(400, 600));
+      controller.setCurrentLine(
+        0,
+        isSeeking: false,
+        lineHeight: 40,
+        intervalMs: 500,
+      );
+      controller.onUserScroll(30);
+      controller.tick(0.016);
+
+      // dispose 应不抛异常
+      controller.dispose();
+
+      // 多次 dispose 也不应崩溃
+      controller.dispose();
+    });
+  });
+}

--- a/test/widgets/apple_lyrics/models/lyric_line_test.dart
+++ b/test/widgets/apple_lyrics/models/lyric_line_test.dart
@@ -1,0 +1,227 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:md3music/widgets/apple_lyrics/models/lyric_line.dart';
+
+/// LyricWord / LyricLine 模型单元测试
+/// 覆盖：构造与字段访问、hasWordTiming、endTime、相等性判定
+void main() {
+  group('LyricWord', () {
+    test('构造与字段访问', () {
+      const word = LyricWord(
+        startTime: 12500,
+        duration: 300,
+        text: '运',
+      );
+      expect(word.startTime, 12500);
+      expect(word.duration, 300);
+      expect(word.text, '运');
+    });
+
+    test('相等性：相同字段相等', () {
+      const a = LyricWord(startTime: 100, duration: 200, text: 'a');
+      const b = LyricWord(startTime: 100, duration: 200, text: 'a');
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('不等性：任一字段不同不相等', () {
+      const base = LyricWord(startTime: 100, duration: 200, text: 'a');
+      expect(
+        base == const LyricWord(startTime: 999, duration: 200, text: 'a'),
+        isFalse,
+      );
+      expect(
+        base == const LyricWord(startTime: 100, duration: 999, text: 'a'),
+        isFalse,
+      );
+      expect(
+        base == const LyricWord(startTime: 100, duration: 200, text: 'b'),
+        isFalse,
+      );
+    });
+
+    test('toString 包含字段信息', () {
+      const word = LyricWord(startTime: 1, duration: 2, text: 'X');
+      final s = word.toString();
+      expect(s, contains('startTime: 1'));
+      expect(s, contains('duration: 2'));
+      expect(s, contains("'X'"));
+    });
+  });
+
+  group('LyricLine', () {
+    test('构造与字段访问', () {
+      const line = LyricLine(
+        startTime: 12500,
+        duration: 4200,
+        text: '运命的华',
+        translation: '命运之花',
+      );
+      expect(line.startTime, 12500);
+      expect(line.duration, 4200);
+      expect(line.text, '运命的华');
+      expect(line.translation, '命运之花');
+      expect(line.words, isEmpty);
+    });
+
+    test('words 字段默认空列表', () {
+      const line = LyricLine(startTime: 0, duration: 0, text: '');
+      expect(line.words, isEmpty);
+    });
+
+    test('hasWordTiming：words 为空时返回 false', () {
+      const line = LyricLine(startTime: 0, duration: 1000, text: 'hi');
+      expect(line.hasWordTiming, isFalse);
+    });
+
+    test('hasWordTiming：words 非空时返回 true', () {
+      const line = LyricLine(
+        startTime: 0,
+        duration: 1000,
+        text: 'hi',
+        words: [
+          LyricWord(startTime: 0, duration: 500, text: 'h'),
+          LyricWord(startTime: 500, duration: 500, text: 'i'),
+        ],
+      );
+      expect(line.hasWordTiming, isTrue);
+    });
+
+    test('endTime getter 计算正确：startTime + duration', () {
+      const line = LyricLine(startTime: 12500, duration: 4200, text: '');
+      expect(line.endTime, 16700);
+    });
+
+    test('相等性：所有字段相同（含 words 列表）相等', () {
+      const a = LyricLine(
+        startTime: 100,
+        duration: 200,
+        text: 'abc',
+        words: [LyricWord(startTime: 100, duration: 50, text: 'a')],
+        translation: 't',
+      );
+      const b = LyricLine(
+        startTime: 100,
+        duration: 200,
+        text: 'abc',
+        words: [LyricWord(startTime: 100, duration: 50, text: 'a')],
+        translation: 't',
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('不等性：任一字段不同不相等', () {
+      const base = LyricLine(
+        startTime: 100,
+        duration: 200,
+        text: 'abc',
+        words: [LyricWord(startTime: 100, duration: 50, text: 'a')],
+        translation: 't',
+      );
+      // startTime 不同
+      expect(
+        base ==
+            const LyricLine(
+              startTime: 999,
+              duration: 200,
+              text: 'abc',
+              words: [LyricWord(startTime: 100, duration: 50, text: 'a')],
+              translation: 't',
+            ),
+        isFalse,
+      );
+      // duration 不同
+      expect(
+        base ==
+            const LyricLine(
+              startTime: 100,
+              duration: 999,
+              text: 'abc',
+              words: [LyricWord(startTime: 100, duration: 50, text: 'a')],
+              translation: 't',
+            ),
+        isFalse,
+      );
+      // text 不同
+      expect(
+        base ==
+            const LyricLine(
+              startTime: 100,
+              duration: 200,
+              text: 'XXX',
+              words: [LyricWord(startTime: 100, duration: 50, text: 'a')],
+              translation: 't',
+            ),
+        isFalse,
+      );
+      // translation 不同
+      expect(
+        base ==
+            const LyricLine(
+              startTime: 100,
+              duration: 200,
+              text: 'abc',
+              words: [LyricWord(startTime: 100, duration: 50, text: 'a')],
+              translation: 'other',
+            ),
+        isFalse,
+      );
+      // words 数量不同
+      expect(
+        base ==
+            const LyricLine(
+              startTime: 100,
+              duration: 200,
+              text: 'abc',
+              words: [
+                LyricWord(startTime: 100, duration: 50, text: 'a'),
+                LyricWord(startTime: 150, duration: 50, text: 'b'),
+              ],
+              translation: 't',
+            ),
+        isFalse,
+      );
+      // words 内容不同
+      expect(
+        base ==
+            const LyricLine(
+              startTime: 100,
+              duration: 200,
+              text: 'abc',
+              words: [LyricWord(startTime: 100, duration: 50, text: 'z')],
+              translation: 't',
+            ),
+        isFalse,
+      );
+    });
+
+    test('相等性：translation 一个为 null 一个为非 null 不相等', () {
+      const withTranslation = LyricLine(
+        startTime: 100,
+        duration: 200,
+        text: 'abc',
+        translation: 't',
+      );
+      const withoutTranslation = LyricLine(
+        startTime: 100,
+        duration: 200,
+        text: 'abc',
+      );
+      expect(withTranslation == withoutTranslation, isFalse);
+    });
+
+    test('toString 包含关键信息', () {
+      const line = LyricLine(
+        startTime: 100,
+        duration: 200,
+        text: 'abc',
+        words: [LyricWord(startTime: 100, duration: 50, text: 'a')],
+      );
+      final s = line.toString();
+      expect(s, contains('startTime: 100'));
+      expect(s, contains('duration: 200'));
+      expect(s, contains("'abc'"));
+      expect(s, contains('words: 1'));
+    });
+  });
+}

--- a/test/widgets/apple_lyrics/parsers/krc_parser_test.dart
+++ b/test/widgets/apple_lyrics/parsers/krc_parser_test.dart
@@ -1,0 +1,236 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:md3music/widgets/apple_lyrics/parsers/krc_parser.dart';
+
+/// KrcParser 单元测试
+///
+/// 覆盖：标准行解析、多行解析、元数据过滤、空输入、损坏行跳过、
+/// property 非 0、整行文本拼接、UTF-8 中日字符、字标签紧密相连等场景。
+/// 参照 spec.md 附录 B 真实样本「運命の華」。
+void main() {
+  group('KrcParser.parse', () {
+    test('1. 标准单行解析：1 个 LyricLine + 2 个 LyricWord', () {
+      const input = '[12500,4200]<0,300,0>運<300,400,0>命';
+      final result = KrcParser.parse(input);
+
+      expect(result, hasLength(1));
+      final line = result.first;
+      expect(line.startTime, 12500);
+      expect(line.duration, 4200);
+      expect(line.text, '運命');
+      expect(line.hasWordTiming, isTrue);
+
+      expect(line.words, hasLength(2));
+      // 第一个字：行 startTime(12500) + offset(0) = 12500
+      expect(line.words[0].startTime, 12500);
+      expect(line.words[0].duration, 300);
+      expect(line.words[0].text, '運');
+      // 第二个字：行 startTime(12500) + offset(300) = 12800
+      expect(line.words[1].startTime, 12800);
+      expect(line.words[1].duration, 400);
+      expect(line.words[1].text, '命');
+    });
+
+    test('2. 多行解析：3 行歌词，按 startTime 升序', () {
+      const input = '''
+[12500,4200]<0,300,0>運<300,400,0>命<700,500,0>の<1200,600,0>華
+[16700,3800]<0,350,0>泣<350,450,0>き
+[20500,4000]<0,400,0>新<400,500,0>しい
+''';
+      final result = KrcParser.parse(input);
+
+      expect(result, hasLength(3));
+      // 按输入顺序，startTime 升序
+      expect(result[0].startTime, 12500);
+      expect(result[1].startTime, 16700);
+      expect(result[2].startTime, 20500);
+      // 每行都有逐字数据
+      expect(result[0].words, hasLength(4));
+      expect(result[1].words, hasLength(2));
+      expect(result[2].words, hasLength(2));
+      // 文本拼接正确
+      expect(result[0].text, '運命の華');
+      expect(result[1].text, '泣き');
+      expect(result[2].text, '新しい');
+    });
+
+    test('3. 元数据过滤：仅产出歌词行', () {
+      const input = '''
+[id:\$00000000]
+[ar:トゲナシトゲアリ]
+[ti:運命の華]
+[by:]
+[hash:0dc65949d510244b1ade85a97602649c]
+[al:]
+[sign:]
+[qq:]
+[total:195735]
+[offset:0]
+[language: ShoreiGo]
+[12500,4200]<0,300,0>運<300,400,0>命
+''';
+      final result = KrcParser.parse(input);
+
+      // 只有一行歌词
+      expect(result, hasLength(1));
+      expect(result.first.startTime, 12500);
+      expect(result.first.text, '運命');
+    });
+
+    test('4. 空输入：返回空列表', () {
+      expect(KrcParser.parse(''), isEmpty);
+    });
+
+    test('5. 仅元数据无歌词：返回空列表', () {
+      const input = '''
+[id:\$00000000]
+[ar:トゲナシトゲアリ]
+[ti:運命の華]
+[total:195735]
+[offset:0]
+[language:ShoreiGo]
+''';
+      expect(KrcParser.parse(input), isEmpty);
+    });
+
+    test('6. 损坏行跳过：不影响其他正常行', () {
+      const input = '''
+[12500,4200]<0,300,0>運<300,400,0>命
+[abc,def]garbage
+random text
+[16700,3800]<0,350,0>泣<350,450,0>き
+''';
+      final result = KrcParser.parse(input);
+
+      // 仅解析出两行正常歌词，损坏行被跳过
+      expect(result, hasLength(2));
+      expect(result[0].startTime, 12500);
+      expect(result[0].text, '運命');
+      expect(result[1].startTime, 16700);
+      expect(result[1].text, '泣き');
+    });
+
+    test('7. 字标签 property 非 0：property 字段被忽略', () {
+      const input = '[1000,2000]<0,300,5>字<300,400,9>文';
+      final result = KrcParser.parse(input);
+
+      expect(result, hasLength(1));
+      final line = result.first;
+      expect(line.words, hasLength(2));
+      // 第一个字 property=5，被忽略
+      expect(line.words[0].startTime, 1000);
+      expect(line.words[0].duration, 300);
+      expect(line.words[0].text, '字');
+      // 第二个字 property=9，被忽略
+      expect(line.words[1].startTime, 1300);
+      expect(line.words[1].duration, 400);
+      expect(line.words[1].text, '文');
+    });
+
+    test('8. 整行文本拼接：LyricLine.text 等于所有字文本拼接', () {
+      const input = '[0,5000]<0,500,0>Hel<500,500,0>lo<1000,1000,0>, <2000,2000,0>World!';
+      final result = KrcParser.parse(input);
+
+      expect(result, hasLength(1));
+      final line = result.first;
+      expect(line.text, 'Hello, World!');
+      // 验证拼接 = 所有字 text 顺序连接
+      final concat = line.words.map((w) => w.text).join();
+      expect(line.text, concat);
+    });
+
+    test('9. UTF-8 中日字符：「運命の華」完整解析', () {
+      const input =
+          '[12500,4200]<0,300,0>運<300,400,0>命<700,500,0>の<1200,600,0>華';
+      final result = KrcParser.parse(input);
+
+      expect(result, hasLength(1));
+      final line = result.first;
+      expect(line.text, '運命の華');
+      expect(line.words, hasLength(4));
+      expect(line.words[0].text, '運');
+      expect(line.words[1].text, '命');
+      expect(line.words[2].text, 'の');
+      expect(line.words[3].text, '華');
+      // 时间戳正确：行 start 12500 + 字 offset
+      expect(line.words[0].startTime, 12500);
+      expect(line.words[1].startTime, 12800);
+      expect(line.words[2].startTime, 13200);
+      expect(line.words[3].startTime, 13700);
+    });
+
+    test('10. 多字标签紧密相连无文本间隙：产出 2 个 word', () {
+      const input = '[0,200]<0,100,0>A<100,100,0>B';
+      final result = KrcParser.parse(input);
+
+      expect(result, hasLength(1));
+      final line = result.first;
+      expect(line.words, hasLength(2));
+      expect(line.words[0].text, 'A');
+      expect(line.words[1].text, 'B');
+      expect(line.text, 'AB');
+    });
+
+    test('完整真实样本：運命の華首行 + 元数据头', () {
+      // 模拟 spec.md 附录 B 真实样本前几行
+      const input = '''
+[id:\$00000000]
+[ar:トゲナシトゲアリ]
+[ti:運命の華]
+[by:]
+[hash:0dc65949d510244b1ade85a97602649c]
+[al:]
+[sign:]
+[qq:]
+[total:195735]
+[offset:0]
+[language:ShoreiGo]
+[12500,4200]<0,300,0>運<300,400,0>命<700,500,0>の<1200,600,0>華
+[16700,3800]<0,350,0>泣<350,450,0>き<800,500,0>出<1300,500,0>し<1800,500,0>た<2300,500,0>ま<2800,500,0>い
+''';
+      final result = KrcParser.parse(input);
+
+      // 元数据全部过滤，只保留 2 行歌词
+      expect(result, hasLength(2));
+      expect(result[0].startTime, 12500);
+      expect(result[0].duration, 4200);
+      expect(result[0].text, '運命の華');
+      expect(result[0].words, hasLength(4));
+      expect(result[1].startTime, 16700);
+      expect(result[1].duration, 3800);
+      expect(result[1].text, '泣き出したまい');
+      // 输入字符串含 7 个字标签：泣/き/出/し/た/ま/い
+      expect(result[1].words, hasLength(7));
+    });
+
+    test('字标签无 property 字段（仅 offset,duration）：能正确解析', () {
+      // 部分变体 KRC 格式省略 property
+      const input = '[0,500]<0,250>A<250,250>B';
+      final result = KrcParser.parse(input);
+
+      expect(result, hasLength(1));
+      final line = result.first;
+      expect(line.words, hasLength(2));
+      expect(line.words[0].startTime, 0);
+      expect(line.words[0].duration, 250);
+      expect(line.words[0].text, 'A');
+      expect(line.words[1].startTime, 250);
+      expect(line.words[1].duration, 250);
+      expect(line.words[1].text, 'B');
+    });
+
+    test('只有行首时间戳但无字标签：跳过此行（无逐字信息）', () {
+      const input = '[0,1000]no word tags here';
+      final result = KrcParser.parse(input);
+      expect(result, isEmpty);
+    });
+
+    test('\\r\\n 行尾：trim 后正确解析', () {
+      const input = '[0,500]<0,250,0>A<250,250,0>B\r\n[500,500]<0,250,0>C<250,250,0>D';
+      final result = KrcParser.parse(input);
+
+      expect(result, hasLength(2));
+      expect(result[0].text, 'AB');
+      expect(result[1].text, 'CD');
+    });
+  });
+}

--- a/test/widgets/apple_lyrics/parsers/lrc_parser_test.dart
+++ b/test/widgets/apple_lyrics/parsers/lrc_parser_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:md3music/widgets/apple_lyrics/models/lyric_line.dart';
+import 'package:md3music/widgets/apple_lyrics/parsers/lrc_parser.dart';
+
+/// LrcParser 单元测试
+/// 覆盖：标准行、两位/三位毫秒、一行多时间戳、元数据过滤、空输入、
+/// 仅元数据、纯文本跳过、UTF-8 中文、多行混合排序、duration 字段
+void main() {
+  group('LrcParser.parse', () {
+    test('标准单行：[01:23.45]Hello → 1 行，startTime=83450', () {
+      final result = LrcParser.parse('[01:23.45]Hello');
+      expect(result, hasLength(1));
+      final line = result.first;
+      expect(line.startTime, 83450);
+      expect(line.text, 'Hello');
+      expect(line.words, isEmpty);
+      expect(line.hasWordTiming, isFalse);
+    });
+
+    test('两位毫秒：[00:05.45]World → startTime=5450', () {
+      final result = LrcParser.parse('[00:05.45]World');
+      expect(result, hasLength(1));
+      expect(result.first.startTime, 5450);
+      expect(result.first.text, 'World');
+    });
+
+    test('三位毫秒：[00:05.456]World → startTime=5456', () {
+      final result = LrcParser.parse('[00:05.456]World');
+      expect(result, hasLength(1));
+      expect(result.first.startTime, 5456);
+      expect(result.first.text, 'World');
+    });
+
+    test('一行多时间戳：[00:10.00][00:30.00]Chorus → 2 行按 startTime 升序', () {
+      final result = LrcParser.parse('[00:10.00][00:30.00]Chorus');
+      expect(result, hasLength(2));
+      expect(result[0].startTime, 10000);
+      expect(result[0].text, 'Chorus');
+      expect(result[1].startTime, 30000);
+      expect(result[1].text, 'Chorus');
+      // 确认升序
+      expect(result[0].startTime <= result[1].startTime, isTrue);
+    });
+
+    test('元数据过滤：[ar:]/[ti:] 跳过，仅保留歌词行', () {
+      final result =
+          LrcParser.parse('[ar:Artist]\n[ti:Title]\n[00:01.00]Lyric');
+      expect(result, hasLength(1));
+      expect(result.first.startTime, 1000);
+      expect(result.first.text, 'Lyric');
+    });
+
+    test('空输入返回空列表', () {
+      expect(LrcParser.parse(''), isEmpty);
+    });
+
+    test('仅元数据返回空列表', () {
+      final result = LrcParser.parse(
+        '[ar:Artist]\n[ti:Title]\n[al:Album]\n[by:Author]',
+      );
+      expect(result, isEmpty);
+    });
+
+    test('无时间戳的纯文本跳过，返回空列表', () {
+      expect(LrcParser.parse('just text'), isEmpty);
+    });
+
+    test('UTF-8 中文正确解析', () {
+      final result = LrcParser.parse('[00:30.00]你好世界');
+      expect(result, hasLength(1));
+      expect(result.first.startTime, 30000);
+      expect(result.first.text, '你好世界');
+    });
+
+    test('多行混合：3 行歌词 + 2 行元数据 → 3 行按时间排序', () {
+      final lrc = '''
+[ar:Artist]
+[ti:Title]
+[00:20.00]Third
+[00:05.00]First
+[00:10.00]Second
+''';
+      final result = LrcParser.parse(lrc);
+      expect(result, hasLength(3));
+      expect(result[0].startTime, 5000);
+      expect(result[0].text, 'First');
+      expect(result[1].startTime, 10000);
+      expect(result[1].text, 'Second');
+      expect(result[2].startTime, 20000);
+      expect(result[2].text, 'Third');
+    });
+
+    test('duration 字段为 0（所有 LyricLine）', () {
+      final result = LrcParser.parse('[00:01.00]A\n[00:02.00]B');
+      expect(result, hasLength(2));
+      for (final line in result) {
+        expect(line.duration, 0);
+      }
+    });
+
+    test('translation 字段为 null', () {
+      final result = LrcParser.parse('[00:01.00]Hello');
+      expect(result, hasLength(1));
+      expect(result.first.translation, isNull);
+    });
+
+    test('空行跳过', () {
+      final result = LrcParser.parse('\n\n[00:01.00]Hello\n\n');
+      expect(result, hasLength(1));
+      expect(result.first.text, 'Hello');
+    });
+
+    test('全部元数据标签均被过滤', () {
+      final lrc = '''
+[offset:+100]
+[id:123]
+[hash:abc]
+[total:180]
+[language:zh]
+[sign:署名]
+[qq:123456]
+[00:01.00]Lyric
+''';
+      final result = LrcParser.parse(lrc);
+      expect(result, hasLength(1));
+      expect(result.first.text, 'Lyric');
+    });
+
+    test('损坏输入不抛异常，返回空列表', () {
+      expect(LrcParser.parse('[[[broken'), isEmpty);
+    });
+
+    test('无时间戳但有方括号的行跳过', () {
+      expect(LrcParser.parse('[not a timestamp]text'), isEmpty);
+    });
+
+    test('一行多时间戳乱序输入也会按 startTime 升序输出', () {
+      final result = LrcParser.parse('[00:30.00][00:10.00]Chorus');
+      expect(result, hasLength(2));
+      expect(result[0].startTime, 10000);
+      expect(result[1].startTime, 30000);
+    });
+
+    test('LyricLine 相等性：相同时间戳与文本相等', () {
+      final a = LrcParser.parse('[00:01.00]Hello');
+      const b = LyricLine(startTime: 1000, duration: 0, text: 'Hello');
+      expect(a.first, equals(b));
+    });
+  });
+}

--- a/test/widgets/apple_lyrics/parsers/lyric_parser_chain_test.dart
+++ b/test/widgets/apple_lyrics/parsers/lyric_parser_chain_test.dart
@@ -1,0 +1,269 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:md3music/widgets/apple_lyrics/parsers/lyric_parser_chain.dart';
+
+/// LyricParserChain 单元测试
+///
+/// 覆盖：KRC/LRC/纯文本自动检测、空输入、仅元数据降级、
+/// KRC 元数据头不影响检测、parseAs 显式调用、混合格式边界等场景。
+/// 参照 spec.md "Requirement: 统一歌词模型" 与 tasks.md Task 5.4。
+void main() {
+  group('LyricParserChain.parse - 自动检测', () {
+    test('1. KRC 自动检测：含元数据头 + 歌词行 → hasWordTiming=true', () {
+      // KRC 真实样本片段（参照 spec.md 附录 B「運命の華」）
+      // 首行是元数据 [id:$...]，第二行才是 [12500,4200]<0,300,0>運...
+      const input = '''[id:\$00000000]
+[ar:トゲナシトゲアリ]
+[ti:運命の華]
+[by:foo]
+[hash:0DC65949D510244B1ADE85A97602649C]
+[al:傷つきつつも、美しく]
+[language:ja]
+[total:267000]
+[offset:0]
+[12500,4200]<0,300,0>運<300,400,0>命<700,500,0>の<1200,600,0>華
+[16700,3800]<0,350,0>泣<350,450,0>き
+[20500,4000]<0,400,0>新<400,500,0>しい
+''';
+      final result = LyricParserChain.parse(input);
+
+      expect(result, isNotEmpty);
+      // KRC 解析结果应携带逐字时间戳
+      expect(result.first.hasWordTiming, isTrue);
+      // 第一行歌词文本应为「運命の華」
+      expect(result.first.text, '運命の華');
+      expect(result.first.startTime, 12500);
+      expect(result.first.duration, 4200);
+      // 字数：運/命/の/華 = 4
+      expect(result.first.words, hasLength(4));
+    });
+
+    test('2. LRC 自动检测：返回非空列表且 hasWordTiming=false', () {
+      const input = '''[ti:Sample Song]
+[ar:Artist]
+[00:01.00]First line
+[00:05.50]Second line
+[00:10.00]Third line
+''';
+      final result = LyricParserChain.parse(input);
+
+      expect(result, isNotEmpty);
+      expect(result.length, 3);
+      // LRC 不携带逐字时间戳
+      for (final line in result) {
+        expect(line.hasWordTiming, isFalse);
+        expect(line.words, isEmpty);
+      }
+      // 时间戳解析正确：[00:01.00] → 1000ms
+      expect(result[0].startTime, 1000);
+      expect(result[0].text, 'First line');
+      // [00:05.50] → 5*1000 + 50*10 = 5500ms（2 位毫秒按厘秒处理）
+      expect(result[1].startTime, 5500);
+      // [00:10.00] → 10000ms
+      expect(result[2].startTime, 10000);
+    });
+
+    test('3. 纯文本自动检测：无时间戳纯文本 → 返回非空列表', () {
+      const input = '''Hello World
+This is a plain text lyric
+No timestamps here
+''';
+      final result = LyricParserChain.parse(input);
+
+      expect(result, isNotEmpty);
+      expect(result.length, 3);
+      // 纯文本所有行 startTime=0、duration=0、words=[]
+      for (final line in result) {
+        expect(line.startTime, 0);
+        expect(line.duration, 0);
+        expect(line.hasWordTiming, isFalse);
+      }
+      expect(result[0].text, 'Hello World');
+      expect(result[1].text, 'This is a plain text lyric');
+      expect(result[2].text, 'No timestamps here');
+    });
+
+    test('4. 空输入："" → []', () {
+      expect(LyricParserChain.parse(''), isEmpty);
+    });
+
+    test('5. 仅元数据无歌词：降级纯文本，元数据被当作普通文本行', () {
+      // 仅 KRC 元数据头，无任何歌词行
+      // 检测器找不到非空非元数据行 → 降级纯文本
+      // 纯文本解析器不识别 [id:...] 为时间戳，会当作普通文本行输出
+      const input = '''[id:\$00000000]
+[ar:Artist]
+[ti:Title]
+''';
+      final result = LyricParserChain.parse(input);
+
+      // 元数据行被 PlainTextParser 当作普通文本，所以非空
+      expect(result, hasLength(3));
+      expect(result[0].text, '[id:\$00000000]');
+      expect(result[1].text, '[ar:Artist]');
+      expect(result[2].text, '[ti:Title]');
+      for (final line in result) {
+        expect(line.hasWordTiming, isFalse);
+        expect(line.startTime, 0);
+      }
+    });
+
+    test('6. KRC 元数据头不影响检测：首行 [id:\$...] 仍走 KRC 路径', () {
+      // 首行是元数据 [id:$00000000]，第二行才是 KRC 歌词行
+      const input = '''[id:\$00000000]
+[12500,4200]<0,300,0>運<300,400,0>命
+''';
+      final result = LyricParserChain.parse(input);
+
+      // 必须走 KRC 路径（hasWordTiming=true），而非纯文本
+      expect(result, hasLength(1));
+      expect(result.first.hasWordTiming, isTrue);
+      expect(result.first.text, '運命');
+      expect(result.first.startTime, 12500);
+      expect(result.first.words, hasLength(2));
+    });
+  });
+
+  group('LyricParserChain.parseAs - 显式调用', () {
+    test('7. parseAs(krc) 强制走 KRC，即使内容是 LRC', () {
+      // 内容实际是 LRC，但强制指定为 KRC
+      // KrcParser 解析 LRC 文本时，找不到 [start_ms,duration_ms] 行格式，
+      // 会返回空列表（不抛异常）
+      const lrcInput = '''[00:01.00]First line
+[00:05.50]Second line
+''';
+      final result =
+          LyricParserChain.parseAs(lrcInput, LyricFormat.krc);
+
+      // KRC 解析器无法识别 LRC 时间戳格式，返回空列表
+      expect(result, isEmpty);
+    });
+
+    test('7b. parseAs(lrc) 强制走 LRC，即使内容是 KRC', () {
+      // 内容实际是 KRC，但强制指定为 LRC
+      // LrcParser 不识别 [12500,4200] 格式，会返回空列表
+      const krcInput = '[12500,4200]<0,300,0>運<300,400,0>命';
+      final result =
+          LyricParserChain.parseAs(krcInput, LyricFormat.lrc);
+
+      expect(result, isEmpty);
+    });
+
+    test('7c. parseAs(plaintext) 强制走纯文本，即使内容是 KRC', () {
+      // 内容是 KRC，但强制按纯文本解析
+      const krcInput = '[12500,4200]<0,300,0>運<300,400,0>命';
+      final result =
+          LyricParserChain.parseAs(krcInput, LyricFormat.plaintext);
+
+      // 纯文本解析器把整行当作一个 LyricLine，不做时间戳解析
+      expect(result, hasLength(1));
+      expect(result.first.text, '[12500,4200]<0,300,0>運<300,400,0>命');
+      expect(result.first.startTime, 0);
+      expect(result.first.hasWordTiming, isFalse);
+    });
+  });
+
+  group('LyricParserChain.parse - 混合格式边界', () {
+    test('8. 混合格式边界：首行 KRC + 后续 LRC 行 → 整体走 KRC 路径', () {
+      // 首行是 KRC 格式，后续插入一行 LRC 格式
+      // 调度器按首行格式判断 → 整体走 KRC，不混搭
+      const input = '''[12500,4200]<0,300,0>運<300,400,0>命
+[00:01.00]LRC行不应被识别
+[16700,3800]<0,350,0>泣<350,450,0>き
+''';
+      final result = LyricParserChain.parse(input);
+
+      // 整体走 KRC 路径：LRC 行 `[00:01.00]...` 不匹配 KRC 行格式被跳过
+      // 结果应包含 2 个 KRC LyricLine（運命 / 泣き），LRC 行被丢弃
+      expect(result, hasLength(2));
+      expect(result[0].hasWordTiming, isTrue);
+      expect(result[0].text, '運命');
+      expect(result[1].hasWordTiming, isTrue);
+      expect(result[1].text, '泣き');
+      // 确认没有 LRC 解析出的 startTime=1000 行混入
+      for (final line in result) {
+        expect(line.startTime, isNot(1000));
+      }
+    });
+
+    test('8b. 首行 LRC + 后续 KRC 行 → 整体走 LRC 路径', () {
+      // 首行是 LRC，后续插入 KRC 行
+      // 调度器按首行判断 → 整体走 LRC，KRC 行被 LRC 解析器跳过
+      const input = '''[00:01.00]LRC line
+[12500,4200]<0,300,0>運<300,400,0>命
+[00:05.00]Another LRC
+''';
+      final result = LyricParserChain.parse(input);
+
+      // 整体走 LRC：KRC 行 `[12500,4200]...` 不匹配 LRC 时间戳，被跳过
+      expect(result, hasLength(2));
+      for (final line in result) {
+        expect(line.hasWordTiming, isFalse);
+      }
+      expect(result[0].text, 'LRC line');
+      expect(result[0].startTime, 1000);
+      expect(result[1].text, 'Another LRC');
+      expect(result[1].startTime, 5000);
+    });
+
+    test('8c. 首行纯文本 + 后续 LRC 行 → 整体走纯文本路径', () {
+      // 首行是无时间戳文本，后续插入 LRC 行
+      // 调度器按首行判断 → 整体走纯文本，所有行被当作普通文本
+      const input = '''This is plain
+[00:01.00]Not parsed as LRC
+Plain again
+''';
+      final result = LyricParserChain.parse(input);
+
+      // 纯文本解析器把每行当作普通文本，不做时间戳解析
+      expect(result, hasLength(3));
+      for (final line in result) {
+        expect(line.hasWordTiming, isFalse);
+        expect(line.startTime, 0);
+      }
+      expect(result[0].text, 'This is plain');
+      expect(result[1].text, '[00:01.00]Not parsed as LRC');
+      expect(result[2].text, 'Plain again');
+    });
+  });
+
+  group('LyricParserChain.parse - 边界场景补充', () {
+    test('9. 仅空行与空白 → 降级纯文本，返回空列表', () {
+      const input = '   \n\n\t\n  ';
+      final result = LyricParserChain.parse(input);
+
+      // 纯文本解析器跳过所有空行 → 空列表
+      expect(result, isEmpty);
+    });
+
+    test('10. 单行 KRC 无元数据头 → 直接走 KRC', () {
+      const input = '[12500,4200]<0,300,0>運<300,400,0>命';
+      final result = LyricParserChain.parse(input);
+
+      expect(result, hasLength(1));
+      expect(result.first.hasWordTiming, isTrue);
+      expect(result.first.text, '運命');
+    });
+
+    test('11. 单行 LRC 无元数据头 → 直接走 LRC', () {
+      const input = '[00:01.50]Hello';
+      final result = LyricParserChain.parse(input);
+
+      expect(result, hasLength(1));
+      expect(result.first.hasWordTiming, isFalse);
+      expect(result.first.startTime, 1500);
+      expect(result.first.text, 'Hello');
+    });
+
+    test('12. KRC 元数据前缀与时间戳行混合：3 位毫秒 LRC 也能正确识别', () {
+      // 验证 LRC 3 位毫秒格式 [mm:ss.xxx] 也能被正确识别为 LRC
+      const input = '''[ti:Test]
+[00:01.500]Three digit ms
+''';
+      final result = LyricParserChain.parse(input);
+
+      expect(result, hasLength(1));
+      expect(result.first.hasWordTiming, isFalse);
+      expect(result.first.startTime, 1500);
+    });
+  });
+}

--- a/test/widgets/apple_lyrics/parsers/plaintext_parser_test.dart
+++ b/test/widgets/apple_lyrics/parsers/plaintext_parser_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:md3music/widgets/apple_lyrics/models/lyric_line.dart';
+import 'package:md3music/widgets/apple_lyrics/parsers/plaintext_parser.dart';
+
+/// PlainTextParser 单元测试
+/// 覆盖：单行、多行、空输入、仅空白行、trim、UTF-8 中文、
+/// words 为空、duration 为 0、混合空行
+void main() {
+  group('PlainTextParser.parse', () {
+    test('1. 单行：Hello → 1 个 LyricLine，text="Hello"，startTime=0', () {
+      final result = PlainTextParser.parse('Hello');
+      expect(result.length, 1);
+      expect(result.first.text, 'Hello');
+      expect(result.first.startTime, 0);
+    });
+
+    test('2. 多行：Hello\\nWorld\\nFoo → 3 个 LyricLine，按顺序', () {
+      final result = PlainTextParser.parse('Hello\nWorld\nFoo');
+      expect(result.length, 3);
+      expect(result[0].text, 'Hello');
+      expect(result[1].text, 'World');
+      expect(result[2].text, 'Foo');
+    });
+
+    test('3. 空字符串："" → []', () {
+      final result = PlainTextParser.parse('');
+      expect(result, isEmpty);
+    });
+
+    test('4. 仅空白行："  \\n\\n  " → []', () {
+      final result = PlainTextParser.parse('  \n\n  ');
+      expect(result, isEmpty);
+    });
+
+    test('5. 行首尾空格 trim："  Hello  \\n  World  " → 2 个 LyricLine', () {
+      final result = PlainTextParser.parse('  Hello  \n  World  ');
+      expect(result.length, 2);
+      expect(result[0].text, 'Hello');
+      expect(result[1].text, 'World');
+    });
+
+    test('6. UTF-8 中文：你好\\n世界 → 2 个 LyricLine', () {
+      final result = PlainTextParser.parse('你好\n世界');
+      expect(result.length, 2);
+      expect(result[0].text, '你好');
+      expect(result[1].text, '世界');
+    });
+
+    test('7. words 为空：所有 LyricLine.words == const []，hasWordTiming == false', () {
+      final result = PlainTextParser.parse('Hello\nWorld');
+      expect(result.length, 2);
+      for (final line in result) {
+        expect(line.words, isEmpty);
+        // 引用相等进行 const <LyricWord>[]（类型必须一致才能 identical）
+        expect(identical(line.words, const <LyricWord>[]), isTrue);
+        expect(line.hasWordTiming, isFalse);
+      }
+    });
+
+    test('8. duration 为 0：所有 LyricLine.duration == 0', () {
+      final result = PlainTextParser.parse('Hello\nWorld\nFoo');
+      expect(result.length, 3);
+      for (final line in result) {
+        expect(line.duration, 0);
+      }
+    });
+
+    test('9. 混合空行与非空行：Hello\\n\\n\\nWorld → 2 个 LyricLine（空行被跳过）', () {
+      final result = PlainTextParser.parse('Hello\n\n\nWorld');
+      expect(result.length, 2);
+      expect(result[0].text, 'Hello');
+      expect(result[1].text, 'World');
+    });
+  });
+
+  group('PlainTextParser.parse 附加验证', () {
+    test('所有 LyricLine 的 translation 为 null', () {
+      final result = PlainTextParser.parse('Hello\nWorld');
+      for (final line in result) {
+        expect(line.translation, isNull);
+      }
+    });
+
+    test('所有 LyricLine 的 startTime 为 0', () {
+      final result = PlainTextParser.parse('A\nB\nC\nD');
+      for (final line in result) {
+        expect(line.startTime, 0);
+      }
+    });
+
+    test('CRLF 换行兼容性："Hello\\r\\nWorld" → 2 个 LyricLine', () {
+      final result = PlainTextParser.parse('Hello\r\nWorld');
+      expect(result.length, 2);
+      expect(result[0].text, 'Hello');
+      expect(result[1].text, 'World');
+    });
+
+    test('tab 与全角空格 trim', () {
+      // 制表符与全角空格（U+3000）也应在 trim 后被去除
+      final result = PlainTextParser.parse('\tHello\t\n\u3000World\u3000');
+      expect(result.length, 2);
+      expect(result[0].text, 'Hello');
+      expect(result[1].text, 'World');
+    });
+  });
+
+  // 验证 PlainTextParser.parse 输出的 LyricLine 与模型构造器一致
+  test('LyricLine 模型一致性：与手动构造的 LyricLine 相等', () {
+    final result = PlainTextParser.parse('Hello');
+    const expected = LyricLine(
+      startTime: 0,
+      duration: 0,
+      text: 'Hello',
+      words: [],
+      translation: null,
+    );
+    expect(result.first, equals(expected));
+  });
+}

--- a/test/widgets/apple_lyrics/renderers/emphasize_effect_test.dart
+++ b/test/widgets/apple_lyrics/renderers/emphasize_effect_test.dart
@@ -1,0 +1,444 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:md3music/widgets/apple_lyrics/models/lyric_line.dart';
+import 'package:md3music/widgets/apple_lyrics/renderers/emphasize_effect.dart';
+
+/// EmphasizeEffect 单元测试
+///
+/// 覆盖（对应任务说明 1~10）：
+/// 1. shouldEmphasize 触发条件（CJK / 非 CJK / 时长 / 长度）
+/// 2. computeState 在 t=0 时接近 idle
+/// 3. computeState 在 t=0.5 时 scale 接近最大值（约 1.12）
+/// 4. computeState 在 t=1 时 scale 回到 1.0
+/// 5. computeState 在 t<0 时返回 idle
+/// 6. computeState 在 t>1 时返回 idle
+/// 7. 末尾字加强：isLastWord=true 时 scale 更大
+/// 8. 字符错位 delay：wordIndex=2 活跃时刻晚于 wordIndex=0
+/// 9. cubicBezier 函数端点与中点
+/// 10. blur 封顶 0.8、amount 封顶 1.2
+void main() {
+  late EmphasizeEffect effect;
+
+  setUp(() {
+    effect = EmphasizeEffect();
+  });
+
+  /// 构造默认测试 word：startTime=0, duration=1000ms, text='运'（CJK 单字）。
+  LyricWord makeWord({
+    int startTime = 0,
+    int duration = 1000,
+    String text = '运',
+  }) {
+    return LyricWord(
+      startTime: startTime,
+      duration: duration,
+      text: text,
+    );
+  }
+
+  group('shouldEmphasize', () {
+    test('CJK 字时长 1000ms → true', () {
+      final word = makeWord(duration: 1000, text: '运');
+      expect(EmphasizeEffect.shouldEmphasize(word), isTrue);
+    });
+
+    test('CJK 字时长 500ms → false（duration < 1000）', () {
+      final word = makeWord(duration: 500, text: '运');
+      expect(EmphasizeEffect.shouldEmphasize(word), isFalse);
+    });
+
+    test('CJK 字时长刚好 999ms → false（边界）', () {
+      final word = makeWord(duration: 999, text: '运');
+      expect(EmphasizeEffect.shouldEmphasize(word), isFalse);
+    });
+
+    test('非 CJK 字 7 字符 1500ms → true', () {
+      final word = makeWord(duration: 1500, text: 'abcdefg');
+      expect(EmphasizeEffect.shouldEmphasize(word), isTrue);
+    });
+
+    test('非 CJK 字 8 字符 1500ms → false（长度 > 7）', () {
+      final word = makeWord(duration: 1500, text: 'abcdefgh');
+      expect(EmphasizeEffect.shouldEmphasize(word), isFalse);
+    });
+
+    test('非 CJK 字 1 字符 1000ms → true（长度下界）', () {
+      final word = makeWord(duration: 1000, text: 'a');
+      expect(EmphasizeEffect.shouldEmphasize(word), isTrue);
+    });
+
+    test('非 CJK 字 7 字符 500ms → false（duration 不够）', () {
+      final word = makeWord(duration: 500, text: 'abcdefg');
+      expect(EmphasizeEffect.shouldEmphasize(word), isFalse);
+    });
+
+    test('CJK 多字符 2000ms → true（任意长度）', () {
+      final word = makeWord(duration: 2000, text: '運命の華');
+      expect(EmphasizeEffect.shouldEmphasize(word), isTrue);
+    });
+
+    test('平假名字 1200ms → true', () {
+      final word = makeWord(duration: 1200, text: 'は');
+      expect(EmphasizeEffect.shouldEmphasize(word), isTrue);
+    });
+
+    test('片假名字 1200ms → true', () {
+      final word = makeWord(duration: 1200, text: 'カ');
+      expect(EmphasizeEffect.shouldEmphasize(word), isTrue);
+    });
+
+    test('韩文字 1200ms → true', () {
+      final word = makeWord(duration: 1200, text: '한');
+      expect(EmphasizeEffect.shouldEmphasize(word), isTrue);
+    });
+
+    test('空文本 → false', () {
+      const word = LyricWord(startTime: 0, duration: 1000, text: '');
+      expect(EmphasizeEffect.shouldEmphasize(word), isFalse);
+    });
+  });
+
+  group('computeState - 字内进度 t', () {
+    test('t=0 时 scale=1.0, glowLevel≈0, shadowBlur≈0（接近 idle）', () {
+      // duration=1000ms：
+      //   amount = (1000/2000)^3 * 0.6 = 0.125 * 0.6 = 0.075
+      //   blur  = (1000/3000) * 0.5 = 0.16667
+      //   transX = bezIn(0) = 0
+      //   scale = 1 + 0 * 0.1 * 0.075 = 1.0
+      //   glowLevel = 0 * 0.075 = 0
+      //   shadowBlurEm = min(0.3, 0.16667 * 0.3) = 0.05
+      final word = makeWord(duration: 1000, text: '运');
+      final state = effect.computeState(
+        word: word,
+        currentTimeMs: 0,
+        isLastWord: false,
+        wordIndex: 0,
+        anchorCharCount: 1,
+      );
+      expect(state.scale, closeTo(1.0, 1e-9));
+      expect(state.glowLevel, closeTo(0.0, 1e-9));
+      expect(state.shadowBlurEm, closeTo(0.05, 1e-9));
+    });
+
+    test('t=0.5 时 scale 接近最大值 1.12（duration=10000ms 触发 amount 封顶）', () {
+      // duration=10000ms：
+      //   amount = sqrt(10000/2000) * 0.6 = sqrt(5) * 0.6 ≈ 1.3416，封顶 1.2
+      //   blur  = (10000/3000) * 0.5 ≈ 1.6667，封顶 0.8
+      //   transX = bezOut((1-0.5)*2) = bezOut(1) = 1.0
+      //   scale = 1 + 1.0 * 0.1 * 1.2 = 1.12
+      //   glowLevel = 1.0 * 1.2 = 1.2
+      //   shadowBlurEm = min(0.3, 0.8 * 0.3) = 0.24
+      final word = makeWord(duration: 10000, text: '运');
+      final state = effect.computeState(
+        word: word,
+        currentTimeMs: 5000,
+        isLastWord: false,
+        wordIndex: 0,
+        anchorCharCount: 1,
+      );
+      expect(state.scale, closeTo(1.12, 1e-9));
+      expect(state.glowLevel, closeTo(1.2, 1e-9));
+      expect(state.shadowBlurEm, closeTo(0.24, 1e-9));
+    });
+
+    test('t=1 时 scale 回到 1.0', () {
+      // t=1.0：transX = bezOut((1-1)*2) = bezOut(0) = 0
+      // scale = 1 + 0 * 0.1 * amount = 1.0
+      final word = makeWord(duration: 1000, text: '运');
+      final state = effect.computeState(
+        word: word,
+        currentTimeMs: 1000,
+        isLastWord: false,
+        wordIndex: 0,
+        anchorCharCount: 1,
+      );
+      expect(state.scale, closeTo(1.0, 1e-9));
+      expect(state.glowLevel, closeTo(0.0, 1e-9));
+    });
+
+    test('t<0 时返回 idle（字未激活）', () {
+      // startTime=1000, currentTimeMs=500：t = (500-1000)/1000 = -0.5
+      final word = makeWord(startTime: 1000, duration: 1000, text: '运');
+      final state = effect.computeState(
+        word: word,
+        currentTimeMs: 500,
+        isLastWord: false,
+        wordIndex: 0,
+        anchorCharCount: 1,
+      );
+      expect(state, equals(EmphasizeState.idle));
+      expect(state.scale, 1.0);
+      expect(state.glowLevel, 0.0);
+      expect(state.shadowBlurEm, 0.0);
+    });
+
+    test('t>1 时返回 idle（字已结束）', () {
+      // startTime=0, duration=1000, currentTimeMs=2000：t = (2000-0)/1000 = 2.0
+      final word = makeWord(duration: 1000, text: '运');
+      final state = effect.computeState(
+        word: word,
+        currentTimeMs: 2000,
+        isLastWord: false,
+        wordIndex: 0,
+        anchorCharCount: 1,
+      );
+      expect(state, equals(EmphasizeState.idle));
+    });
+  });
+
+  group('computeState - 末尾字加强', () {
+    test('isLastWord=true 时 scale 大于 isLastWord=false 时', () {
+      // duration=1000ms, t=0.5：
+      //   isLastWord=false：amount=0.075, scale=1+1*0.1*0.075=1.0075
+      //   isLastWord=true ：amount=0.075*1.6=0.12, scale=1+1*0.1*0.12=1.012
+      final word = makeWord(duration: 1000, text: '运');
+      final stateFalse = effect.computeState(
+        word: word,
+        currentTimeMs: 500,
+        isLastWord: false,
+        wordIndex: 0,
+        anchorCharCount: 1,
+      );
+      final stateTrue = effect.computeState(
+        word: word,
+        currentTimeMs: 500,
+        isLastWord: true,
+        wordIndex: 0,
+        anchorCharCount: 1,
+      );
+      expect(stateTrue.scale, greaterThan(stateFalse.scale));
+      // 同时验证 glowLevel 也加强
+      expect(stateTrue.glowLevel, greaterThan(stateFalse.glowLevel));
+    });
+  });
+
+  group('computeState - 字符错位 delay', () {
+    test('wordIndex=2 的字活跃时刻晚于 wordIndex=0 的字', () {
+      // duration=1000ms, anchorCharCount=1：
+      //   wordIndex=0：wordDe = 0 + (1000/2.5/1)*0 = 0
+      //     → currentTimeMs=0 时 t=0（激活）
+      //   wordIndex=2：wordDe = 0 + (1000/2.5/1)*2 = 800
+      //     → currentTimeMs=0 时 t=(0-800)/1000=-0.8（未激活，idle）
+      final word = makeWord(duration: 1000, text: '运');
+      final state0 = effect.computeState(
+        word: word,
+        currentTimeMs: 0,
+        isLastWord: false,
+        wordIndex: 0,
+        anchorCharCount: 1,
+      );
+      final state2 = effect.computeState(
+        word: word,
+        currentTimeMs: 0,
+        isLastWord: false,
+        wordIndex: 2,
+        anchorCharCount: 1,
+      );
+      // wordIndex=0 已激活，wordIndex=2 仍为 idle
+      expect(state0, isNot(equals(EmphasizeState.idle)));
+      expect(state2, equals(EmphasizeState.idle));
+    });
+
+    test('wordIndex=2 在 wordDe+duration 时刻激活（验证 delay 计算正确）', () {
+      // wordIndex=2：wordDe = 800, 字内 t=0 应在 currentTimeMs=800
+      final word = makeWord(duration: 1000, text: '运');
+      final state = effect.computeState(
+        word: word,
+        currentTimeMs: 800,
+        isLastWord: false,
+        wordIndex: 2,
+        anchorCharCount: 1,
+      );
+      // t=0，transX=0，scale=1.0 但非 idle
+      expect(state, isNot(equals(EmphasizeState.idle)));
+      expect(state.scale, closeTo(1.0, 1e-9));
+    });
+
+    test('anchorCharCount 越大 delay 越小（相邻字激活间隔更短）', () {
+      // duration=1000ms, wordIndex=1：
+      //   anchorCharCount=1：wordDe = 0 + (1000/2.5/1)*1 = 400
+      //   anchorCharCount=4：wordDe = 0 + (1000/2.5/4)*1 = 100
+      // anchorCharCount=4 时字更早激活
+      final word = makeWord(duration: 1000, text: '运');
+      // 在 currentTimeMs=200：
+      //   anchorCharCount=1：t = (200-400)/1000 = -0.2（idle）
+      //   anchorCharCount=4：t = (200-100)/1000 = 0.1（激活）
+      final state1 = effect.computeState(
+        word: word,
+        currentTimeMs: 200,
+        isLastWord: false,
+        wordIndex: 1,
+        anchorCharCount: 1,
+      );
+      final state4 = effect.computeState(
+        word: word,
+        currentTimeMs: 200,
+        isLastWord: false,
+        wordIndex: 1,
+        anchorCharCount: 4,
+      );
+      expect(state1, equals(EmphasizeState.idle));
+      expect(state4, isNot(equals(EmphasizeState.idle)));
+    });
+  });
+
+  group('cubicBezier', () {
+    test('t=0 返回 0', () {
+      expect(EmphasizeEffect.cubicBezier(0, 0.2, 0.4, 0.58, 1.0), closeTo(0.0, 1e-9));
+    });
+
+    test('t=1 返回 1', () {
+      expect(EmphasizeEffect.cubicBezier(1, 0.2, 0.4, 0.58, 1.0), closeTo(1.0, 1e-9));
+    });
+
+    test('t=0.5 返回值在 (0, 1) 之间', () {
+      final v = EmphasizeEffect.cubicBezier(0.5, 0.2, 0.4, 0.58, 1.0);
+      expect(v, greaterThan(0.0));
+      expect(v, lessThan(1.0));
+      // 验证精确值：3*0.25*0.5*0.2 + 3*0.5*0.25*0.4 + 0.125 = 0.075+0.15+0.125 = 0.35
+      expect(v, closeTo(0.35, 1e-9));
+    });
+
+    test('bezIn 与 bezOut 在 t=0/1 端点一致（均为 0 或 1）', () {
+      // bezIn(0) = 0, bezIn(1) = 1
+      expect(EmphasizeEffect.cubicBezier(0, 0.2, 0.4, 0.58, 1.0), closeTo(0.0, 1e-9));
+      expect(EmphasizeEffect.cubicBezier(1, 0.2, 0.4, 0.58, 1.0), closeTo(1.0, 1e-9));
+      // bezOut(0) = 0, bezOut(1) = 1
+      expect(EmphasizeEffect.cubicBezier(0, 0.3, 0.0, 0.58, 1.0), closeTo(0.0, 1e-9));
+      expect(EmphasizeEffect.cubicBezier(1, 0.3, 0.0, 0.58, 1.0), closeTo(1.0, 1e-9));
+    });
+
+    test('bezier 单调递增（p1/p2 均在 [0,1] 且 p1<=p2 时）', () {
+      // 在 [0,1] 上取 21 个点，验证后一个值 >= 前一个值
+      double prev = 0;
+      for (int i = 0; i <= 20; i++) {
+        final t = i / 20;
+        final v = EmphasizeEffect.cubicBezier(t, 0.2, 0.4, 0.58, 1.0);
+        expect(v, greaterThanOrEqualTo(prev));
+        prev = v;
+      }
+    });
+  });
+
+  group('blur 与 amount 封顶', () {
+    test('amount 封顶 1.2：duration=10000ms 时 scale=1.12（非 1.134）', () {
+      // duration=10000ms：amount 原始 = sqrt(5)*0.6 ≈ 1.3416，封顶 1.2
+      // 若未封顶：scale = 1 + 1*0.1*1.3416 = 1.13416
+      // 封顶后 ：scale = 1 + 1*0.1*1.2 = 1.12
+      // 验证 scale=1.12 证明 amount 被封顶为 1.2
+      final word = makeWord(duration: 10000, text: '运');
+      final state = effect.computeState(
+        word: word,
+        currentTimeMs: 5000,
+        isLastWord: false,
+        wordIndex: 0,
+        anchorCharCount: 1,
+      );
+      expect(state.scale, closeTo(1.12, 1e-9));
+      // glowLevel = transX * amount = 1.0 * 1.2 = 1.2（也证明 amount 封顶）
+      expect(state.glowLevel, closeTo(1.2, 1e-9));
+    });
+
+    test('blur 封顶 0.8：duration=6000ms 时 shadowBlurEm=0.24（非 0.3）', () {
+      // duration=6000ms：blur 原始 = (6000/3000)*0.5 = 1.0，封顶 0.8
+      // 若未封顶：shadowBlurEm = min(0.3, 1.0*0.3) = 0.3
+      // 封顶后 ：shadowBlurEm = min(0.3, 0.8*0.3) = 0.24
+      // 验证 shadowBlurEm=0.24（< 0.3）证明 blur 被封顶为 0.8
+      final word = makeWord(duration: 6000, text: '运');
+      final state = effect.computeState(
+        word: word,
+        currentTimeMs: 3000,
+        isLastWord: false,
+        wordIndex: 0,
+        anchorCharCount: 1,
+      );
+      expect(state.shadowBlurEm, closeTo(0.24, 1e-9));
+      expect(state.shadowBlurEm, lessThan(0.3));
+    });
+
+    test('blur 未封顶时（duration=3000ms）shadowBlurEm=0.15', () {
+      // duration=3000ms：blur = (3000/3000)*0.5 = 0.5（未封顶）
+      // shadowBlurEm = min(0.3, 0.5*0.3) = 0.15
+      final word = makeWord(duration: 3000, text: '运');
+      final state = effect.computeState(
+        word: word,
+        currentTimeMs: 1500,
+        isLastWord: false,
+        wordIndex: 0,
+        anchorCharCount: 1,
+      );
+      expect(state.shadowBlurEm, closeTo(0.15, 1e-9));
+    });
+  });
+
+  group('reset', () {
+    test('reset 不崩溃且为空实现', () {
+      // 无状态类，reset 仅作 API 占位
+      effect.reset();
+      // 验证 computeState 仍可正常工作
+      final word = makeWord(duration: 1000, text: '运');
+      final state = effect.computeState(
+        word: word,
+        currentTimeMs: 500,
+        isLastWord: false,
+        wordIndex: 0,
+        anchorCharCount: 1,
+      );
+      expect(state, isNot(equals(EmphasizeState.idle)));
+    });
+  });
+
+  group('边界保护', () {
+    test('duration=0 返回 idle（避免除零）', () {
+      const word = LyricWord(startTime: 0, duration: 0, text: '运');
+      final state = effect.computeState(
+        word: word,
+        currentTimeMs: 0,
+        isLastWord: false,
+        wordIndex: 0,
+        anchorCharCount: 1,
+      );
+      expect(state, equals(EmphasizeState.idle));
+    });
+
+    test('anchorCharCount=0 返回 idle（避免除零）', () {
+      final word = makeWord(duration: 1000, text: '运');
+      final state = effect.computeState(
+        word: word,
+        currentTimeMs: 500,
+        isLastWord: false,
+        wordIndex: 0,
+        anchorCharCount: 0,
+      );
+      expect(state, equals(EmphasizeState.idle));
+    });
+  });
+
+  group('EmphasizeState 值对象', () {
+    test('idle 常量正确', () {
+      expect(EmphasizeState.idle.scale, 1.0);
+      expect(EmphasizeState.idle.glowLevel, 0.0);
+      expect(EmphasizeState.idle.shadowBlurEm, 0.0);
+    });
+
+    test('相等性：相同字段相等', () {
+      const a = EmphasizeState(scale: 1.1, glowLevel: 0.5, shadowBlurEm: 0.2);
+      const b = EmphasizeState(scale: 1.1, glowLevel: 0.5, shadowBlurEm: 0.2);
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('不等性：任一字段不同则不等', () {
+      const a = EmphasizeState(scale: 1.1, glowLevel: 0.5, shadowBlurEm: 0.2);
+      const b = EmphasizeState(scale: 1.2, glowLevel: 0.5, shadowBlurEm: 0.2);
+      expect(a, isNot(equals(b)));
+    });
+
+    test('toString 包含三字段', () {
+      const s = EmphasizeState(scale: 1.1, glowLevel: 0.5, shadowBlurEm: 0.2);
+      final str = s.toString();
+      expect(str.contains('1.1'), isTrue);
+      expect(str.contains('0.5'), isTrue);
+      expect(str.contains('0.2'), isTrue);
+    });
+  });
+}

--- a/test/widgets/apple_lyrics/renderers/interlude_dots_test.dart
+++ b/test/widgets/apple_lyrics/renderers/interlude_dots_test.dart
@@ -1,0 +1,136 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:md3music/widgets/apple_lyrics/layout/lyric_layout.dart';
+import 'package:md3music/widgets/apple_lyrics/renderers/interlude_dots.dart';
+
+void main() {
+  group('InterludeDots', () {
+    test('初始状态：无间奏，isInterlude 返回 false，shouldRender=false', () {
+      final dots = InterludeDots();
+      expect(dots.startTime, isNull);
+      expect(dots.endTime, isNull);
+      expect(dots.isInterlude(0), isFalse);
+      expect(dots.isInterlude(5000), isFalse);
+      expect(dots.shouldRender, isFalse);
+      // tick 不抛异常即可（返回 void）
+      dots.tick(0.016);
+      dots.tick(0.1);
+    });
+
+    group('设置间奏后 (start=1000, end=7000)', () {
+      // 注意：按 API 约定，endTime 是调用方已减去 interludeEarlyEndMs(250ms) 的值。
+      // 这里模拟"下一行 startTime=7250ms"的场景，传入 endTime=7250-250=7000。
+      const start = 1000;
+      const end = 7000;
+      late InterludeDots dots;
+
+      setUp(() {
+        dots = InterludeDots();
+        dots.setInterlude(start, end);
+        // 推进 1 帧（16ms）使动画时钟启动
+        dots.tick(0.016);
+      });
+
+      test('setInterlude 后 shouldRender=true', () {
+        expect(dots.shouldRender, isTrue);
+      });
+
+      test('间奏时段内 isInterlude 返回 true（基于 currentTimeMs 判定）', () {
+        expect(dots.isInterlude(1000), isTrue);
+        expect(dots.isInterlude(3000), isTrue);
+        expect(dots.isInterlude(6999), isTrue);
+      });
+
+      test('间奏边界：startTime 处 isInterlude=true，endTime 处 isInterlude=false', () {
+        expect(dots.isInterlude(start), isTrue);
+        expect(dots.isInterlude(end), isFalse);
+      });
+
+      test('间奏外时刻 isInterlude 返回 false', () {
+        expect(dots.isInterlude(start - 1), isFalse);
+        expect(dots.isInterlude(end), isFalse);
+        expect(dots.isInterlude(end + 1000), isFalse);
+      });
+    });
+
+    group('clear()', () {
+      test('clear 后 isInterlude 返回 false，shouldRender=false', () {
+        final dots = InterludeDots();
+        dots.setInterlude(1000, 7000);
+        dots.tick(0.016);
+        expect(dots.isInterlude(3000), isTrue);
+        expect(dots.shouldRender, isTrue);
+
+        dots.clear();
+        expect(dots.startTime, isNull);
+        expect(dots.endTime, isNull);
+        expect(dots.isInterlude(3000), isFalse);
+        expect(dots.isInterlude(1000), isFalse);
+        expect(dots.shouldRender, isFalse);
+      });
+    });
+
+    group('setInterlude 重新设置', () {
+      test('重新设置后旧时段失效，新时段生效', () {
+        final dots = InterludeDots();
+        dots.setInterlude(1000, 7000);
+        dots.tick(0.016);
+        expect(dots.isInterlude(3000), isTrue);
+
+        dots.setInterlude(10000, 20000);
+        dots.tick(0.016);
+        expect(dots.isInterlude(3000), isFalse);
+        expect(dots.isInterlude(15000), isTrue);
+      });
+
+      test('相同间奏重复调用 setInterlude 不重置（幂等）', () {
+        final dots = InterludeDots();
+        dots.setInterlude(1000, 7000);
+        dots.tick(0.016);
+        // 推进一段时间
+        dots.tick(0.5);
+        // 再次设置相同间奏，shouldRender 仍为 true，且动画时钟不重置
+        dots.setInterlude(1000, 7000);
+        expect(dots.shouldRender, isTrue);
+        expect(dots.isInterlude(3000), isTrue);
+      });
+
+      test('setInterlude(null, null) 清除间奏', () {
+        final dots = InterludeDots();
+        dots.setInterlude(1000, 7000);
+        dots.tick(0.016);
+        expect(dots.shouldRender, isTrue);
+
+        dots.setInterlude(null, null);
+        expect(dots.shouldRender, isFalse);
+        expect(dots.startTime, isNull);
+      });
+    });
+
+    group('间奏检测规则集成（参照 spec.md）', () {
+      test('相邻行间隔 >= 4000ms 应触发间奏（由调用方判定，本类只接收时段）', () {
+        final dots = InterludeDots();
+        const currentEnd = 1000;
+        const nextStart = 6000;
+        const gap = nextStart - currentEnd;
+        expect(gap, greaterThanOrEqualTo(LyricLayout.interludeThresholdMs));
+
+        dots.setInterlude(currentEnd, nextStart - LyricLayout.interludeEarlyEndMs);
+        dots.tick(0.016);
+        expect(dots.isInterlude(currentEnd), isTrue);
+        expect(dots.isInterlude(nextStart - LyricLayout.interludeEarlyEndMs - 1), isTrue);
+        expect(dots.isInterlude(nextStart - LyricLayout.interludeEarlyEndMs), isFalse);
+      });
+
+      test('相邻行间隔 < 4000ms 不应触发间奏（调用方不调用 setInterlude）', () {
+        final dots = InterludeDots();
+        const currentEnd = 1000;
+        const nextStart = 4000;
+        const gap = nextStart - currentEnd;
+        expect(gap, lessThan(LyricLayout.interludeThresholdMs));
+
+        expect(dots.isInterlude(currentEnd), isFalse);
+        expect(dots.shouldRender, isFalse);
+      });
+    });
+  });
+}

--- a/test/widgets/apple_lyrics/renderers/line_renderer_test.dart
+++ b/test/widgets/apple_lyrics/renderers/line_renderer_test.dart
@@ -1,0 +1,337 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:md3music/widgets/apple_lyrics/layout/lyric_layout.dart';
+import 'package:md3music/widgets/apple_lyrics/models/lyric_line.dart';
+import 'package:md3music/widgets/apple_lyrics/renderers/line_renderer.dart';
+
+/// LineRenderer 单元测试
+///
+/// 覆盖：初始状态、setLineState、tick 指数衰减、变亮比变暗快、reset、paintLine 不崩溃、
+/// 整行模式无 mask 渐变（与 WordRenderer 区分）。
+///
+/// 主要验证状态逻辑（alpha 计算与 tick 推进），不验证绘制像素。
+/// paintLine 涉及 Canvas 绘制，构造一个写入 PictureRecorder 的 canvas
+/// 以触发内部 TextPainter 调用，但不验证像素。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late LineRenderer renderer;
+  late LyricLine line;
+
+  setUp(() {
+    renderer = LineRenderer();
+    line = const LyricLine(
+      startTime: 0,
+      duration: 4000,
+      text: '这是一行 LRC 歌词',
+      words: [], // 整行模式：无 word 时间戳
+    );
+  });
+
+  /// 构造一个可绘制的 Canvas（写入 PictureRecorder，不实际显示）。
+  /// 用 ui 前缀访问 dart:ui 的 Canvas / PictureRecorder / Offset，
+  /// 避免与 flutter/widgets.dart 重导出的同名类冲突。
+  ui.Canvas makeCanvas() {
+    final recorder = ui.PictureRecorder();
+    return ui.Canvas(recorder);
+  }
+
+  // ==================== 1. 初始状态 ====================
+  group('初始状态', () {
+    test('currentAlpha 初始值为 0.2（SOLID 非当前行暗态）', () {
+      expect(renderer.currentAlpha, closeTo(0.2, 1e-9));
+    });
+
+    test('isActive 初始为 false', () {
+      expect(renderer.isActive, isFalse);
+    });
+
+    test('targetAlpha 初始为 0.2', () {
+      expect(renderer.targetAlpha, closeTo(0.2, 1e-9));
+    });
+
+    test('hasWordTiming=false 的行确实没有逐字时间戳', () {
+      expect(line.hasWordTiming, isFalse);
+    });
+  });
+
+  // ==================== 2. setLineState(isActive=true) ====================
+  group('setLineState(isActive=true)', () {
+    test('targetAlpha 变为 1.0', () {
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      expect(renderer.targetAlpha, closeTo(1.0, 1e-9));
+      expect(renderer.isActive, isTrue);
+    });
+
+    test('tick 后 currentAlpha 趋向 1.0', () {
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      for (int i = 0; i < 100; i++) {
+        renderer.tick(0.016);
+      }
+      expect(renderer.currentAlpha, closeTo(1.0, 0.01));
+    });
+  });
+
+  // ==================== 3. setLineState(isActive=false) ====================
+  group('setLineState(isActive=false)', () {
+    test('targetAlpha 变为 0.2', () {
+      // 先设为 active 让 targetAlpha=1.0
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      // 再切回 inactive
+      renderer.setLineState(
+          isActive: false, scale: LyricLayout.inactiveScale);
+      expect(renderer.targetAlpha, closeTo(0.2, 1e-9));
+      expect(renderer.isActive, isFalse);
+    });
+
+    test('tick 后 currentAlpha 趋向 0.2', () {
+      // 先 active 并 tick 让 currentAlpha 接近 1.0
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      for (int i = 0; i < 100; i++) {
+        renderer.tick(0.016);
+      }
+      // 切回 inactive 并 tick（RELEASE 速度较慢，多 tick 一些）
+      renderer.setLineState(
+          isActive: false, scale: LyricLayout.inactiveScale);
+      for (int i = 0; i < 300; i++) {
+        renderer.tick(0.016);
+      }
+      expect(renderer.currentAlpha, closeTo(0.2, 0.01));
+    });
+  });
+
+  // ==================== 4. 指数衰减 ====================
+  group('指数衰减', () {
+    test('连续 tick 后 currentAlpha 接近目标值（误差 < 0.01）', () {
+      // 变亮到 1.0
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      for (int i = 0; i < 200; i++) {
+        renderer.tick(0.016);
+      }
+      expect(renderer.currentAlpha, closeTo(1.0, 0.01));
+
+      // 变暗到 0.2
+      renderer.setLineState(
+          isActive: false, scale: LyricLayout.inactiveScale);
+      for (int i = 0; i < 500; i++) {
+        renderer.tick(0.016);
+      }
+      expect(renderer.currentAlpha, closeTo(0.2, 0.01));
+    });
+
+    test('阈值收敛：alphaEpsilon=0.001 内直接吸附到目标', () {
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      // 大量 tick 让 alpha 充分收敛
+      for (int i = 0; i < 500; i++) {
+        renderer.tick(0.016);
+      }
+      // 应完全等于目标 1.0（无残差）
+      expect(renderer.currentAlpha, equals(1.0));
+    });
+
+    test('tick(0) 不推进', () {
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      final alphaBefore = renderer.currentAlpha;
+      renderer.tick(0);
+      expect(renderer.currentAlpha, equals(alphaBefore));
+    });
+
+    test('tick(负值) 不推进', () {
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      final alphaBefore = renderer.currentAlpha;
+      renderer.tick(-0.1);
+      expect(renderer.currentAlpha, equals(alphaBefore));
+    });
+
+    test('单次大 dt 推进也能逼近目标', () {
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      // 一次大步长 tick（模拟长时间未刷新），decay 趋近 1，alpha 几乎到目标
+      renderer.tick(1.0);
+      expect(renderer.currentAlpha, closeTo(1.0, 0.01));
+    });
+  });
+
+  // ==================== 5. 变亮比变暗快 ====================
+  group('变亮比变暗快', () {
+    test('从 0.2 到 1.0 的过渡时间 < 从 1.0 到 0.2 的过渡时间', () {
+      // 测量变亮所需 tick 数：从初始 0.2 到 closeTo(1.0, 0.01)
+      final upRenderer = LineRenderer();
+      upRenderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      int upTicks = 0;
+      while ((upRenderer.currentAlpha - 1.0).abs() >= 0.01) {
+        upRenderer.tick(0.016);
+        upTicks++;
+        if (upTicks > 10000) break; // 安全保护
+      }
+
+      // 测量变暗所需 tick 数：从 1.0 到 closeTo(0.2, 0.01)
+      final downRenderer = LineRenderer();
+      downRenderer.setLineState(
+          isActive: true, scale: LyricLayout.activeScale);
+      // 先让 alpha 充分变亮到 1.0
+      for (int i = 0; i < 500; i++) {
+        downRenderer.tick(0.016);
+      }
+      // 切到 inactive 开始计时
+      downRenderer.setLineState(
+          isActive: false, scale: LyricLayout.inactiveScale);
+      int downTicks = 0;
+      while ((downRenderer.currentAlpha - 0.2).abs() >= 0.01) {
+        downRenderer.tick(0.016);
+        downTicks++;
+        if (downTicks > 10000) break; // 安全保护
+      }
+
+      // 变亮 tick 数应远小于变暗 tick 数（ATTACK=50 vs RELEASE=7）
+      expect(upTicks, lessThan(downTicks));
+    });
+
+    test('相同帧数下变亮残差小于变暗残差', () {
+      // 变亮：5 帧
+      final upRenderer = LineRenderer();
+      upRenderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      for (int i = 0; i < 5; i++) {
+        upRenderer.tick(0.016);
+      }
+      final double upAlpha = upRenderer.currentAlpha;
+      // 变亮残差：距 1.0 的差
+      final double upResidual = 1.0 - upAlpha;
+
+      // 变暗：5 帧（从充分变亮的 1.0 开始）
+      final downRenderer = LineRenderer();
+      downRenderer.setLineState(
+          isActive: true, scale: LyricLayout.activeScale);
+      for (int i = 0; i < 500; i++) {
+        downRenderer.tick(0.016);
+      }
+      downRenderer.setLineState(
+          isActive: false, scale: LyricLayout.inactiveScale);
+      for (int i = 0; i < 5; i++) {
+        downRenderer.tick(0.016);
+      }
+      final double downAlpha = downRenderer.currentAlpha;
+      // 变暗残差：距 0.2 的差
+      final double downResidual = downAlpha - 0.2;
+
+      // 5 帧内变亮残差应小于变暗残差（ATTACK 比 RELEASE 快）
+      expect(upResidual, lessThan(downResidual));
+    });
+  });
+
+  // ==================== 6. reset ====================
+  group('reset', () {
+    test('reset 后 currentAlpha 回到初始值 0.2', () {
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      for (int i = 0; i < 100; i++) {
+        renderer.tick(0.016);
+      }
+      // 确认 alpha 已偏离初始值
+      expect(renderer.currentAlpha, closeTo(1.0, 0.01));
+
+      renderer.reset();
+      expect(renderer.currentAlpha, closeTo(0.2, 1e-9));
+      expect(renderer.isActive, isFalse);
+      expect(renderer.targetAlpha, closeTo(0.2, 1e-9));
+    });
+
+    test('reset 后重新 setLineState 与 tick 仍正常工作', () {
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      for (int i = 0; i < 50; i++) {
+        renderer.tick(0.016);
+      }
+      renderer.reset();
+
+      // 重新激活
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      for (int i = 0; i < 100; i++) {
+        renderer.tick(0.016);
+      }
+      expect(renderer.currentAlpha, closeTo(1.0, 0.01));
+    });
+  });
+
+  // ==================== 7. paintLine 不崩溃 ====================
+  group('paintLine', () {
+    test('正常整行绘制不崩溃', () {
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      renderer.paintLine(makeCanvas(), ui.Offset.zero, line, 24);
+    });
+
+    test('非当前行绘制不崩溃', () {
+      renderer.setLineState(
+          isActive: false, scale: LyricLayout.inactiveScale);
+      renderer.paintLine(makeCanvas(), ui.Offset.zero, line, 24);
+    });
+
+    test('空文本不崩溃', () {
+      const emptyLine = LyricLine(
+        startTime: 0,
+        duration: 1000,
+        text: '',
+        words: [],
+      );
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      renderer.paintLine(makeCanvas(), ui.Offset.zero, emptyLine, 24);
+    });
+
+    test('tick 推进后再绘制不崩溃', () {
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      for (int i = 0; i < 50; i++) {
+        renderer.tick(0.016);
+      }
+      renderer.paintLine(makeCanvas(), ui.Offset.zero, line, 24);
+    });
+
+    test('使用非零 offset 绘制不崩溃', () {
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      renderer.paintLine(makeCanvas(), const ui.Offset(100, 200), line, 24);
+    });
+  });
+
+  // ==================== 附加：整行模式无 mask 渐变 ====================
+  group('整行模式无 mask 渐变（与 WordRenderer 区分）', () {
+    test('整行 alpha 在 active 时趋向 1.0（高亮）', () {
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      for (int i = 0; i < 200; i++) {
+        renderer.tick(0.016);
+      }
+      // 整行模式 active 目标是 1.0，不是 WordRenderer 的 dynamicBrightAlpha=0.4~1.0
+      expect(renderer.currentAlpha, closeTo(1.0, 0.01));
+    });
+
+    test('整行 alpha 在 inactive 时保持 0.2（SOLID 暗态）', () {
+      renderer.setLineState(
+          isActive: false, scale: LyricLayout.inactiveScale);
+      // 即使 tick，alpha 仍保持 0.2（目标也是 0.2，无变化）
+      for (int i = 0; i < 100; i++) {
+        renderer.tick(0.016);
+      }
+      expect(renderer.currentAlpha, closeTo(0.2, 1e-9));
+    });
+
+    test('scale 参数影响 alpha 计算（与 WordRenderer 公式一致）', () {
+      // isActive=true，scale 不同 → dynamicBrightAlpha 不同
+      // factor = clamp01((scale - 0.97) / 0.03)
+      // dynamicBrightAlpha = factor * 0.8 + 0.2
+      final r1 = LineRenderer()
+        ..setLineState(isActive: true, scale: LyricLayout.activeScale); // factor=1 → 1.0
+      final r2 = LineRenderer()
+        ..setLineState(isActive: true, scale: LyricLayout.inactiveScale); // factor=0 → 0.2
+      final r3 = LineRenderer()
+        ..setLineState(isActive: true, scale: 0.985); // factor=0.5 → 0.6
+
+      for (int i = 0; i < 100; i++) {
+        r1.tick(0.016);
+        r2.tick(0.016);
+        r3.tick(0.016);
+      }
+      // r1: scale=1.0 → dynamicBright=1.0
+      expect(r1.currentAlpha, closeTo(1.0, 0.01));
+      // r2: scale=0.97 → dynamicBright=0.2
+      expect(r2.currentAlpha, closeTo(0.2, 0.01));
+      // r3: scale=0.985 → dynamicBright=0.6
+      expect(r3.currentAlpha, closeTo(0.6, 0.01));
+    });
+  });
+}

--- a/test/widgets/apple_lyrics/renderers/word_renderer_test.dart
+++ b/test/widgets/apple_lyrics/renderers/word_renderer_test.dart
@@ -1,0 +1,356 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:md3music/widgets/apple_lyrics/layout/lyric_layout.dart';
+import 'package:md3music/widgets/apple_lyrics/models/lyric_line.dart';
+import 'package:md3music/widgets/apple_lyrics/renderers/word_renderer.dart';
+
+/// WordRenderer 单元测试
+///
+/// 覆盖：初始状态、tick 推进、isActive 切换、scale 联动、
+/// 指数衰减、reset、空 words 不崩溃。
+///
+/// 主要验证状态逻辑（alpha 计算与 tick 推进），不验证绘制像素。
+/// paintLine 涉及 Canvas 绘制，构造一个写入 PictureRecorder 的 canvas
+/// 以触发内部绑定逻辑与 TextPainter 调用，但不验证像素。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late WordRenderer renderer;
+  late LyricLine line;
+
+  setUp(() {
+    renderer = WordRenderer();
+    line = const LyricLine(
+      startTime: 0,
+      duration: 4000,
+      text: '运命的华',
+      words: [
+        LyricWord(startTime: 0, duration: 1000, text: '运'),
+        LyricWord(startTime: 1000, duration: 1000, text: '命'),
+        LyricWord(startTime: 2000, duration: 1000, text: '的'),
+        LyricWord(startTime: 3000, duration: 1000, text: '华'),
+      ],
+    );
+  });
+
+  /// 构造一个可绘制的 Canvas（写入 PictureRecorder，不实际显示）。
+  /// 用 ui 前缀访问 dart:ui 的 Canvas / PictureRecorder / Offset，
+  /// 避免与 flutter/widgets.dart 重导出的同名类冲突。
+  ui.Canvas makeCanvas() {
+    final recorder = ui.PictureRecorder();
+    return ui.Canvas(recorder);
+  }
+
+  group('初始状态', () {
+    test('非当前行（scale=0.97）：所有 word alpha 初始为 dynamicDarkAlpha=0.2', () {
+      renderer.setLineState(
+          isActive: false, scale: LyricLayout.inactiveScale);
+      renderer.paintLine(makeCanvas(), ui.Offset.zero, line, 24);
+      final alphas = renderer.wordAlphas;
+      expect(alphas.length, 4);
+      for (final a in alphas.values) {
+        expect(a, closeTo(0.2, 1e-9));
+      }
+    });
+
+    test('当前行（scale=1.0）：所有 word alpha 初始为 dynamicDarkAlpha=0.4', () {
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      renderer.paintLine(makeCanvas(), ui.Offset.zero, line, 24);
+      final alphas = renderer.wordAlphas;
+      expect(alphas.length, 4);
+      for (final a in alphas.values) {
+        expect(a, closeTo(0.4, 1e-9));
+      }
+    });
+  });
+
+  group('tick 后状态推进', () {
+    test('progress=0.25：word 0 已播趋向 1.0，word 1/2/3 未播趋向 0.4', () {
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      renderer.paintLine(makeCanvas(), ui.Offset.zero, line, 24);
+
+      // progress=0.25 时：wordPos = 0.25 * 4 = 1.0，currentIdx = 1
+      // word 0: index=0 < 1 → 已播 → bright=1.0
+      // word 1: index=1 == 1, wp=0 → 当前字起点 → dark=0.4
+      // word 2,3: 未播 → dark=0.4
+      for (int i = 0; i < 100; i++) {
+        renderer.tick(0.016, 0.25);
+      }
+      expect(renderer.wordAlphas[0]!, closeTo(1.0, 0.01));
+      expect(renderer.wordAlphas[1]!, closeTo(0.4, 0.01));
+      expect(renderer.wordAlphas[2]!, closeTo(0.4, 0.01));
+      expect(renderer.wordAlphas[3]!, closeTo(0.4, 0.01));
+    });
+
+    test('progress 推进到 1.0：所有 word 已播，alpha 趋向 1.0', () {
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      renderer.paintLine(makeCanvas(), ui.Offset.zero, line, 24);
+
+      // 先到 progress=0.5 让前两字变亮
+      for (int i = 0; i < 100; i++) {
+        renderer.tick(0.016, 0.5);
+      }
+      // 再推进到 1.0：wordPos=4.0, currentIdx=4，所有字已播 → bright=1.0
+      for (int i = 0; i < 200; i++) {
+        renderer.tick(0.016, 1.0);
+      }
+      for (int i = 0; i < 4; i++) {
+        expect(renderer.wordAlphas[i]!, closeTo(1.0, 0.01),
+            reason: 'word $i 应趋向 brightAlpha=1.0');
+      }
+    });
+  });
+
+  group('isActive 切换', () {
+    test('从非当前行切到当前行，alpha 从 0.2 渐变到 0.4', () {
+      // 初始非当前行：scale=0.97, factor=0, dynamicDarkAlpha=0.2
+      renderer.setLineState(
+          isActive: false, scale: LyricLayout.inactiveScale);
+      renderer.paintLine(makeCanvas(), ui.Offset.zero, line, 24);
+      for (final a in renderer.wordAlphas.values) {
+        expect(a, closeTo(0.2, 1e-9));
+      }
+
+      // 切到当前行：scale=1.0, factor=1, dynamicDarkAlpha=0.4
+      // progress=0 时所有字未播，目标 = dynamicDarkAlpha = 0.4
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      for (int i = 0; i < 100; i++) {
+        renderer.tick(0.016, 0.0);
+      }
+      for (final a in renderer.wordAlphas.values) {
+        expect(a, closeTo(0.4, 0.01));
+      }
+    });
+
+    test('从当前行切到非当前行，alpha 从 0.4 渐变回 0.2', () {
+      // 初始当前行：所有字 alpha=0.4
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      renderer.paintLine(makeCanvas(), ui.Offset.zero, line, 24);
+      for (final a in renderer.wordAlphas.values) {
+        expect(a, closeTo(0.4, 1e-9));
+      }
+
+      // 切到非当前行：scale=0.97, factor=0, dynamicDarkAlpha=0.2
+      // 非当前行 SOLID 模式，所有字目标 = 0.2
+      renderer.setLineState(
+          isActive: false, scale: LyricLayout.inactiveScale);
+      for (int i = 0; i < 200; i++) {
+        renderer.tick(0.016, 0.5);
+      }
+      for (final a in renderer.wordAlphas.values) {
+        expect(a, closeTo(0.2, 0.01));
+      }
+    });
+  });
+
+  group('scale 联动', () {
+    test('scale=0.97 时 factor=0，dynamicDarkAlpha=0.2，dynamicBrightAlpha=0.2', () {
+      renderer.setLineState(
+          isActive: false, scale: LyricLayout.inactiveScale);
+      expect(renderer.factor, closeTo(0.0, 1e-9));
+      expect(renderer.dynamicDarkAlpha, closeTo(0.2, 1e-9));
+      expect(renderer.dynamicBrightAlpha, closeTo(0.2, 1e-9));
+    });
+
+    test('scale=1.0 时 factor=1，dynamicDarkAlpha=0.4，dynamicBrightAlpha=1.0', () {
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      expect(renderer.factor, closeTo(1.0, 1e-9));
+      expect(renderer.dynamicDarkAlpha, closeTo(0.4, 1e-9));
+      expect(renderer.dynamicBrightAlpha, closeTo(1.0, 1e-9));
+    });
+
+    test('scale=0.985 时 factor=0.5，dynamicDarkAlpha=0.3，dynamicBrightAlpha=0.6', () {
+      renderer.setLineState(isActive: true, scale: 0.985);
+      expect(renderer.factor, closeTo(0.5, 1e-9));
+      expect(renderer.dynamicDarkAlpha, closeTo(0.3, 1e-9));
+      expect(renderer.dynamicBrightAlpha, closeTo(0.6, 1e-9));
+    });
+
+    test('scale 越界保护：< 0.97 时 factor 钳制为 0', () {
+      renderer.setLineState(isActive: false, scale: 0.5);
+      expect(renderer.factor, closeTo(0.0, 1e-9));
+    });
+
+    test('scale 越界保护：> 1.0 时 factor 钳制为 1', () {
+      renderer.setLineState(isActive: true, scale: 1.5);
+      expect(renderer.factor, closeTo(1.0, 1e-9));
+    });
+  });
+
+  group('指数衰减', () {
+    test('连续 tick 多次后，alpha 接近目标值（误差 < 0.01）', () {
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      renderer.paintLine(makeCanvas(), ui.Offset.zero, line, 24);
+
+      // progress=0.5: wordPos=2.0, currentIdx=2
+      // word 0,1: 已播 → bright=1.0
+      // word 2: 当前 wp=0 → dark=0.4
+      // word 3: 未播 → dark=0.4
+      for (int i = 0; i < 200; i++) {
+        renderer.tick(0.016, 0.5);
+      }
+      expect(renderer.wordAlphas[0]!, closeTo(1.0, 0.01));
+      expect(renderer.wordAlphas[1]!, closeTo(1.0, 0.01));
+      expect(renderer.wordAlphas[2]!, closeTo(0.4, 0.01));
+      expect(renderer.wordAlphas[3]!, closeTo(0.4, 0.01));
+    });
+
+    test('ATTACK 速度比 RELEASE 快：相同帧数下变亮幅度大于变暗幅度', () {
+      // 变亮：从 dark(0.4) 到 bright(1.0)
+      final upRenderer = WordRenderer()
+        ..setLineState(isActive: true, scale: LyricLayout.activeScale);
+      upRenderer.paintLine(makeCanvas(), ui.Offset.zero, line, 24);
+      for (int i = 0; i < 5; i++) {
+        upRenderer.tick(0.016, 1.0); // progress=1.0：所有字已播，目标=1.0
+      }
+      final double upAlpha = upRenderer.wordAlphas[0]!;
+
+      // 变暗：从 bright(1.0) 到 dark(0.4)
+      final downRenderer = WordRenderer()
+        ..setLineState(isActive: true, scale: LyricLayout.activeScale);
+      downRenderer.paintLine(makeCanvas(), ui.Offset.zero, line, 24);
+      // 先把 alpha 推到接近 1.0
+      for (int i = 0; i < 200; i++) {
+        downRenderer.tick(0.016, 1.0);
+      }
+      // 然后切到 progress=0（目标 0.4）tick 5 次
+      for (int i = 0; i < 5; i++) {
+        downRenderer.tick(0.016, 0.0);
+      }
+      final double downAlpha = downRenderer.wordAlphas[0]!;
+
+      // 5 帧内：变亮残差（距 1.0 的差）应小于变暗残差（距 0.4 的差）
+      // 即 ATTACK 比 RELEASE 快
+      expect(1.0 - upAlpha, lessThan(downAlpha - 0.4));
+    });
+
+    test('阈值收敛：alphaEpsilon=0.001 内的差值直接吸附到目标', () {
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      renderer.paintLine(makeCanvas(), ui.Offset.zero, line, 24);
+      // 大量 tick 让 alpha 充分收敛
+      for (int i = 0; i < 500; i++) {
+        renderer.tick(0.016, 1.0);
+      }
+      // 应完全等于目标 1.0（无残差）
+      expect(renderer.wordAlphas[0]!, equals(1.0));
+    });
+  });
+
+  group('reset', () {
+    test('reset 后 alpha map 清空，状态归零', () {
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      renderer.paintLine(makeCanvas(), ui.Offset.zero, line, 24);
+      for (int i = 0; i < 50; i++) {
+        renderer.tick(0.016, 0.5);
+      }
+      expect(renderer.wordAlphas, isNotEmpty);
+
+      renderer.reset();
+      expect(renderer.wordAlphas, isEmpty);
+      expect(renderer.isActive, isFalse);
+      expect(renderer.currentLineProgress, 0.0);
+      // factor 也应回到 inactive (0)
+      expect(renderer.factor, closeTo(0.0, 1e-9));
+    });
+
+    test('reset 后重新 paintLine 应重新绑定并初始化', () {
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      renderer.paintLine(makeCanvas(), ui.Offset.zero, line, 24);
+      for (int i = 0; i < 50; i++) {
+        renderer.tick(0.016, 0.5);
+      }
+      renderer.reset();
+
+      // 重新设置并绑定
+      renderer.setLineState(
+          isActive: false, scale: LyricLayout.inactiveScale);
+      renderer.paintLine(makeCanvas(), ui.Offset.zero, line, 24);
+      for (final a in renderer.wordAlphas.values) {
+        expect(a, closeTo(0.2, 1e-9));
+      }
+    });
+  });
+
+  group('空 words 列表', () {
+    test('paintLine 不崩溃，alpha map 为空', () {
+      const emptyLine = LyricLine(
+        startTime: 0,
+        duration: 1000,
+        text: '空行',
+        words: [],
+      );
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      renderer.paintLine(makeCanvas(), ui.Offset.zero, emptyLine, 24);
+      expect(renderer.wordAlphas, isEmpty);
+    });
+
+    test('tick 在空 words 时不崩溃', () {
+      const emptyLine = LyricLine(
+        startTime: 0,
+        duration: 1000,
+        text: '空行',
+        words: [],
+      );
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      renderer.paintLine(makeCanvas(), ui.Offset.zero, emptyLine, 24);
+      renderer.tick(0.016, 0.5);
+      expect(renderer.wordAlphas, isEmpty);
+    });
+
+    test('空 text + 空 words 也不崩溃', () {
+      const emptyLine = LyricLine(
+        startTime: 0,
+        duration: 1000,
+        text: '',
+        words: [],
+      );
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      renderer.paintLine(makeCanvas(), ui.Offset.zero, emptyLine, 24);
+      expect(renderer.wordAlphas, isEmpty);
+    });
+
+    test('hasWordTiming=false 的行触发 SOLID 降级绘制不崩溃', () {
+      const lrcLine = LyricLine(
+        startTime: 0,
+        duration: 1000,
+        text: '这是一行 LRC 歌词',
+        words: [],
+      );
+      expect(lrcLine.hasWordTiming, isFalse);
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      renderer.paintLine(makeCanvas(), ui.Offset.zero, lrcLine, 24);
+      // 降级绘制不写入 _wordAlphas（无 word index）
+      expect(renderer.wordAlphas, isEmpty);
+    });
+  });
+
+  group('line 切换重置 alpha map', () {
+    test('切换到不同 line 时 alpha map 重新初始化', () {
+      renderer.setLineState(isActive: true, scale: LyricLayout.activeScale);
+      renderer.paintLine(makeCanvas(), ui.Offset.zero, line, 24);
+      // 推进动画让 alpha 偏离初始值
+      for (int i = 0; i < 50; i++) {
+        renderer.tick(0.016, 1.0);
+      }
+      expect(renderer.wordAlphas[0]!, closeTo(1.0, 0.01));
+
+      // 切换到新 line（不同引用）
+      const newLine = LyricLine(
+        startTime: 1000,
+        duration: 2000,
+        text: '新行',
+        words: [
+          LyricWord(startTime: 1000, duration: 500, text: '新'),
+          LyricWord(startTime: 1500, duration: 500, text: '行'),
+        ],
+      );
+      renderer.paintLine(makeCanvas(), ui.Offset.zero, newLine, 24);
+      // alpha map 应重新初始化为新 line 的 word 数量，值为 dynamicDarkAlpha=0.4
+      expect(renderer.wordAlphas.length, 2);
+      for (final a in renderer.wordAlphas.values) {
+        expect(a, closeTo(0.4, 1e-9));
+      }
+    });
+  });
+}


### PR DESCRIPTION
### 新增

- 🎵 **Apple Music 风格逐字歌词** — 逐字 mask alpha 渲染、弹簧物理动画、间奏点呼吸动画，参照 AMLL 设计规范
- 📱 **Apple Music 风格播放页** — 模糊封面背景 + 沉浸式布局，设置中可切换（默认关闭）
- 🎨 **莫奈取色 + 8 色预设 + OLED 纯黑模式** — 主题系统增强
- 📡 **Lyricon 桌面词幕推送** — 集成 Lyricon Provider SDK，把歌词推送到 Lyricon 应用（默认关闭）
- ✨ **UI/UX 改进** — AppBar 标题常驻、频谱暂停指示器、mini player 全面屏适配、评论智能反色、歌曲标题自动剥离文件扩展名、收藏夹折叠动画

### 修复

- 修复 mini player 与全面屏手势条冲突
- 修复悬浮窗歌词卡顿

### 升级说明

所有新功能默认关闭，升级后 App 行为与原 md3Music 一致。可在设置中按需开启：
- Apple Music 风格播放器
- OLED 纯黑模式
- Lyricon 词幕推送
