### PR TITLE
Optimize performance for lyrics and player components

### DIFF
--- a/lib/modules/player/full_player_am.dart
+++ b/lib/modules/player/full_player_am.dart
@@ -405,32 +405,42 @@ class _AmStyleFullPlayerState extends State<AmStyleFullPlayer>
 
   @override
   Widget build(BuildContext context) {
-    final playerProvider = context.watch<PlayerProvider>();
-    final currentSong = playerProvider.currentSong;
-    final colorScheme = Theme.of(context).colorScheme;
+    // v4 优化：父级 build 只在切歌（currentSong.id 变化）或播放/暂停（isPlaying）时执行。
+    // position 更新（200ms）通过 AppleLyricsView 与进度条自身的 Selector 注入，不触发父级重建。
+    return Selector<PlayerProvider, ({String? songId, bool isPlaying})>(
+      selector: (_, p) => (
+        songId: p.currentSong?.id,
+        isPlaying: p.isPlaying,
+      ),
+      builder: (context, _, __) {
+        final playerProvider = context.read<PlayerProvider>();
+        final currentSong = playerProvider.currentSong;
+        final colorScheme = Theme.of(context).colorScheme;
 
-    if (currentSong == null) {
-      return Scaffold(
-        backgroundColor: colorScheme.surface,
-        appBar: AppBar(leading: const BackButton()),
-        body: const Center(child: Text('暂无播放')),
-      );
-    }
+        if (currentSong == null) {
+          return Scaffold(
+            backgroundColor: colorScheme.surface,
+            appBar: AppBar(leading: const BackButton()),
+            body: const Center(child: Text('暂无播放')),
+          );
+        }
 
-    // 初始化封面 URL（首次进入或 null→有值）
-    if (_previousArtworkUrl == null && currentSong.artworkUri != null) {
-      _previousArtworkUrl = currentSong.artworkUri;
-    }
+        // 初始化封面 URL（首次进入或 null→有值）
+        if (_previousArtworkUrl == null && currentSong.artworkUri != null) {
+          _previousArtworkUrl = currentSong.artworkUri;
+        }
 
-    // 拦截系统返回键：先播放 reverse 动画（mini player 淡入），
-    // 动画完成后用 removeRoute 移除路由（绕过 PopScope 避免死循环）。
-    return PopScope(
-      canPop: false,
-      onPopInvokedWithResult: (didPop, _) {
-        if (didPop || _isDismissing) return;
-        _collapseByButton();
+        // 拦截系统返回键：先播放 reverse 动画（mini player 淡入），
+        // 动画完成后用 removeRoute 移除路由（绕过 PopScope 避免死循环）。
+        return PopScope(
+          canPop: false,
+          onPopInvokedWithResult: (didPop, _) {
+            if (didPop || _isDismissing) return;
+            _collapseByButton();
+          },
+          child: _buildFullLayout(playerProvider, currentSong, colorScheme),
+        );
       },
-      child: _buildFullLayout(playerProvider, currentSong, colorScheme),
     );
   }
 
@@ -529,13 +539,18 @@ class _AmStyleFullPlayerState extends State<AmStyleFullPlayer>
                   child: RepaintBoundary(
                     child: _isLoadingLyrics
                         ? const Center(child: CircularProgressIndicator())
-                        : AppleLyricsView(
-                            lines: _parsedLyrics,
-                            currentTimeMs:
-                                playerProvider.position.inMilliseconds,
-                            isPlaying: playerProvider.isPlaying,
-                            onSeek: (ms) => playerProvider
-                                .seek(Duration(milliseconds: ms)),
+                        // v4 优化：用 Selector 注入 position，避免父级每 200ms 重建
+                        : Selector<PlayerProvider, int>(
+                            selector: (_, p) =>
+                                p.position.inMilliseconds,
+                            builder: (context, positionMs, _) =>
+                                AppleLyricsView(
+                              lines: _parsedLyrics,
+                              currentTimeMs: positionMs,
+                              isPlaying: playerProvider.isPlaying,
+                              onSeek: (ms) => playerProvider
+                                  .seek(Duration(milliseconds: ms)),
+                            ),
                           ),
                   ),
                 ),
@@ -692,13 +707,18 @@ class _AmStyleFullPlayerState extends State<AmStyleFullPlayer>
                       _isLoadingLyrics
                           ? const Center(child: CircularProgressIndicator())
                           : RepaintBoundary(
-                              child: AppleLyricsView(
-                                lines: _parsedLyrics,
-                                currentTimeMs:
-                                    playerProvider.position.inMilliseconds,
-                                isPlaying: playerProvider.isPlaying,
-                                onSeek: (ms) => playerProvider.seek(
-                                  Duration(milliseconds: ms),
+                              // v4 优化：用 Selector 注入 position，避免父级每 200ms 重建
+                              child: Selector<PlayerProvider, int>(
+                                selector: (_, p) =>
+                                    p.position.inMilliseconds,
+                                builder: (context, positionMs, _) =>
+                                    AppleLyricsView(
+                                  lines: _parsedLyrics,
+                                  currentTimeMs: positionMs,
+                                  isPlaying: playerProvider.isPlaying,
+                                  onSeek: (ms) => playerProvider.seek(
+                                    Duration(milliseconds: ms),
+                                  ),
                                 ),
                               ),
                             ),
@@ -858,13 +878,18 @@ class _AmStyleFullPlayerState extends State<AmStyleFullPlayer>
                       _isLoadingLyrics
                           ? const Center(child: CircularProgressIndicator())
                           : RepaintBoundary(
-                              child: AppleLyricsView(
-                                lines: _parsedLyrics,
-                                currentTimeMs:
-                                    playerProvider.position.inMilliseconds,
-                                isPlaying: playerProvider.isPlaying,
-                                onSeek: (ms) => playerProvider.seek(
-                                  Duration(milliseconds: ms),
+                              // v4 优化：用 Selector 注入 position，避免父级每 200ms 重建
+                              child: Selector<PlayerProvider, int>(
+                                selector: (_, p) =>
+                                    p.position.inMilliseconds,
+                                builder: (context, positionMs, _) =>
+                                    AppleLyricsView(
+                                  lines: _parsedLyrics,
+                                  currentTimeMs: positionMs,
+                                  isPlaying: playerProvider.isPlaying,
+                                  onSeek: (ms) => playerProvider.seek(
+                                    Duration(milliseconds: ms),
+                                  ),
                                 ),
                               ),
                             ),
@@ -1107,8 +1132,6 @@ class _AmStyleFullPlayerState extends State<AmStyleFullPlayer>
     ColorScheme colorScheme, {
     bool isExpanded = false,
   }) {
-    final duration = playerProvider.duration ?? Duration.zero;
-    final position = playerProvider.position;
     final horizontalPadding = isExpanded ? 16.0 : 24.0;
     final verticalSpacing = isExpanded ? 4.0 : 8.0;
 
@@ -1117,8 +1140,21 @@ class _AmStyleFullPlayerState extends State<AmStyleFullPlayer>
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          // 进度条需要 200ms 刷新（Slider value 依赖 position）
-          _buildProgressBar(playerProvider, position, duration, colorScheme),
+          // v4 优化：进度条用 Selector 注入 position + duration，
+          // 避免父级每 200ms position 更新触发 _buildControls 整体重建。
+          Selector<PlayerProvider,
+              ({Duration position, Duration? duration})>(
+            selector: (_, p) => (
+              position: p.position,
+              duration: p.duration,
+            ),
+            builder: (context, state, _) => _buildProgressBar(
+              playerProvider,
+              state.position,
+              state.duration ?? Duration.zero,
+              colorScheme,
+            ),
+          ),
           SizedBox(height: verticalSpacing),
           // Selector 让主控制按钮仅在 isPlaying / loopMode / shuffle 变化时重建
           // 不再每 200ms 因 position 变化重建

--- a/lib/widgets/apple_lyrics/renderers/line_renderer.dart
+++ b/lib/widgets/apple_lyrics/renderers/line_renderer.dart
@@ -56,6 +56,15 @@ class LineRenderer {
   /// 现在复用实例，只重新 set text + layout（alpha 变了需要重新 layout）。
   final TextPainter _painter = TextPainter(textDirection: TextDirection.ltr);
 
+  /// v4 优化：上次 set text + layout 时的 alpha。
+  /// 仅在 alpha 变化 > 0.001 时才 set text + layout，避免每帧 N 次 layout。
+  /// LineRenderer 每行独立实例（`Map<int, LineRenderer>`），无 v3 共享 painter bug 风险。
+  double _lastSetAlpha = -1;
+
+  /// v4 优化：上次 set text + layout 时的 maxWidth。
+  /// maxWidth 变化时也需重新 layout（视口宽度变化导致换行变化）。
+  double _lastSetMaxWidth = -1;
+
   // ============== 状态查询 ==============
 
   /// 当前 alpha（用于测试与外部协调）。
@@ -81,6 +90,10 @@ class LineRenderer {
   /// [scale] 是行缩放，0.97（inactive）~1.0（active）。
   /// [blurFade] 控制非当前行透明度：1.0=透明（模糊图片覆盖），0.0=正常显示。
   /// [blurActive] 是否启用高斯模糊：false 时不降低非当前行透明度。
+  ///
+  /// **v4 bug 修复**：检测 _targetAlpha 变化时重置 _isConverged=false。
+  /// 之前 setLineState 修改 _targetAlpha 但不重置 _isConverged，
+  /// 导致后续 tick 调用时 _isConverged=true（来自上次收敛）即便 target 已变也不会重新计算。
   void setLineState({required bool isActive, required double scale, double blurFade = 1.0, bool blurActive = true}) {
     _isActive = isActive;
     final double factor = ((scale - LyricLayout.inactiveScale) /
@@ -91,7 +104,12 @@ class LineRenderer {
     final double dynamicBright = factor * 0.8 + 0.2;
     // 非当前行 alpha = dynamicDark * (1 - blurFade)，blurActive=false 时不降低
     final double effectiveFade = blurActive ? blurFade : 0.0;
-    _targetAlpha = isActive ? dynamicBright : dynamicDark * (1.0 - effectiveFade);
+    final double newTargetAlpha = isActive ? dynamicBright : dynamicDark * (1.0 - effectiveFade);
+    // v4 修复：target 变化时重置 _isConverged，让 tick 重新计算 alpha
+    if ((newTargetAlpha - _targetAlpha).abs() > 1e-6) {
+      _isConverged = false;
+    }
+    _targetAlpha = newTargetAlpha;
   }
 
   // ============== 动画推进 ==============
@@ -102,8 +120,12 @@ class LineRenderer {
   /// 用指数衰减公式 `_currentAlpha += (_targetAlpha - _currentAlpha) * (1 - exp(-speed * dt))`
   /// 平滑过渡：变亮用 [LyricLayout.attackSpeed]（50.0），变暗用 [LyricLayout.releaseSpeed]（7.0）。
   /// 差值小于 [LyricLayout.alphaEpsilon]（0.001）时吸附到目标。
+  ///
+  /// **v4 优化**：isConverged=true 时早 return 跳过已收敛行的指数衰减计算。
+  /// setLineState 检测 target 变化时会重置 _isConverged=false，确保 target 变化后能重新计算。
   void tick(double dt) {
     if (dt <= 0) return;
+    if (_isConverged) return; // v4 优化：已收敛的行跳过 tick
     // 变亮用 ATTACK（快），变暗用 RELEASE（慢）
     final double speed = _targetAlpha >= _currentAlpha
         ? LyricLayout.attackSpeed
@@ -129,32 +151,45 @@ class LineRenderer {
   ///
   /// [maxWidth] 为可用最大文字宽度，超出时 TextPainter 自动换行（默认不换行）。
   ///
-  /// **性能优化**：复用 [_painter] 实例，避免每帧创建 TextPainter 对象 + GC。
-  /// layout 仍需每帧执行（alpha 变化需重新 set TextSpan）。
+  /// **性能优化**：
+  /// - 复用 [_painter] 实例，避免每帧创建 TextPainter 对象 + GC
+  /// - **v4 优化**：alpha 变化 < 0.001 且 maxWidth 未变时跳过 set text + layout
+  ///   （layout 结果与 alpha 无关，复用上次的 layout 结果直接 paint）
   void paintLine(
       Canvas canvas, Offset offset, LyricLine line, double fontSize,
       {double maxWidth = double.infinity}) {
     if (line.text.isEmpty) return;
-    _painter.text = TextSpan(
-      text: line.text,
-      style: TextStyle(
-        // 文字颜色固定白色，alpha 整行统一（无 mask 渐变）
-        color: Color.fromRGBO(255, 255, 255, _currentAlpha),
-        fontSize: fontSize,
-        height: LyricLayout.lineHeight,
-        // 显式注入歌词 fontFamily（system 模式为 null，走系统字体链）
-        fontFamily: LyricLayout.fontFamily,
-      ),
-    );
-    _painter.layout(
-        maxWidth: maxWidth == double.infinity ? double.infinity : maxWidth);
+    // v4 优化：alpha 变化 < 0.001 且 maxWidth 未变时跳过 set text + layout
+    if ((_currentAlpha - _lastSetAlpha).abs() > 0.001 ||
+        maxWidth != _lastSetMaxWidth) {
+      _painter.text = TextSpan(
+        text: line.text,
+        style: TextStyle(
+          // 文字颜色固定白色，alpha 整行统一（无 mask 渐变）
+          color: Color.fromRGBO(255, 255, 255, _currentAlpha),
+          fontSize: fontSize,
+          height: LyricLayout.lineHeight,
+          // 显式注入歌词 fontFamily（system 模式为 null，走系统字体链）
+          fontFamily: LyricLayout.fontFamily,
+        ),
+      );
+      _painter.layout(
+          maxWidth: maxWidth == double.infinity ? double.infinity : maxWidth);
+      _lastSetAlpha = _currentAlpha;
+      _lastSetMaxWidth = maxWidth;
+    }
     _painter.paint(canvas, offset);
   }
 
   /// 重置状态：alpha 回到初始值（0.2），isActive=false。
+  ///
+  /// **v4 优化**：重置 alpha 缓存字段，下次 paintLine 会重新 set text + layout。
   void reset() {
     _isActive = false;
     _currentAlpha = LyricLayout.currentDarkAlpha;
     _targetAlpha = LyricLayout.currentDarkAlpha;
+    _isConverged = true;
+    _lastSetAlpha = -1;
+    _lastSetMaxWidth = -1;
   }
 }

--- a/lib/widgets/apple_lyrics/renderers/word_renderer.dart
+++ b/lib/widgets/apple_lyrics/renderers/word_renderer.dart
@@ -52,11 +52,20 @@ class WordRenderer {
   /// 10 word/行 × 60fps = 每秒 600 次 layout → 缓存后降为 0 次/帧。
   List<double> _wordWidths = const <double>[];
 
-  /// 复用的 TextPainter 实例（避免每帧创建对象）。
+  /// v4 优化：per-word TextPainter 实例列表。
   ///
-  /// 注意：text setter 会标记需要 layout，所以 layout 还是要做，
-  /// 但省了 TextPainter 对象创建+GC 的开销。
-  final TextPainter _painter = TextPainter(textDirection: TextDirection.ltr);
+  /// **背景**：v3 Task 1 用单实例 _painter + _lastSetAlphas 缓存导致"当前行重复显示同一字"bug
+  /// （commit b56b7e9 已回滚）。根因：单实例 _painter 在循环中被多个 word 共用，下一个 word 的
+  /// set text 会覆盖 painter.text，导致 _lastSetAlphas[i] 比较时基于"上次循环的最后一个 word"
+  /// 状态而非该 word 自身上次状态。
+  /// **v4 解决方案**：每个 word 独占一个 TextPainter 实例，alpha 不变时跳过 set text + layout 是安全的。
+  /// 10 word/行 × 60fps = 每秒 600 次 layout → 缓存后降到 ~100-200 次/秒
+  /// （仅当前字 + 边界附近 word 在过渡）。
+  List<TextPainter> _wordPainters = const <TextPainter>[];
+
+  /// v4 优化：每个 word index 上次设置的 alpha。
+  /// 仅在 alpha 变化时才 set text + layout，避免每帧 N 次 layout。
+  final Map<int, double> _lastSetAlphas = <int, double>{};
 
   /// 每个 word index 的当前 alpha 值。
   final Map<int, double> _wordAlphas = <int, double>{};
@@ -290,8 +299,10 @@ class WordRenderer {
   /// **性能优化**：
   /// - word 宽度用 [_wordWidths] 缓存（[_ensureBound] 时一次性测量），
   ///   换行判断不再每帧创建 TextPainter + layout
-  /// - 复用 [_painter] 实例，避免每帧创建对象（layout 还是要做，
-  ///   因为 alpha 变了需要重新设置 TextSpan，但省了对象创建+GC）
+  /// - **v4 优化**：per-word TextPainter 实例 + alpha 缓存。
+  ///   仅在 alpha 变化时才 set text + layout，alpha 不变时直接 paint。
+  ///   这与 v3 Task 1 共享 painter 不同：每个 word 独占一个 TextPainter 实例，
+  ///   不会出现"下一个 word 覆盖 painter.text 导致 _lastSetAlphas[i] 错乱"的 bug。
   void paintLine(
       Canvas canvas, Offset offset, LyricLine line, double fontSize,
       {double maxWidth = double.infinity}) {
@@ -330,22 +341,23 @@ class WordRenderer {
       final double wordY = currentY + yOffset;
       final Offset wordPos = Offset(wordX, wordY);
 
-      // 设置文字样式 + layout。
-      // 注意：_painter 在循环里被多个 word 共用，每次循环到新 word 都必须重新
-      // set text + layout，否则 painter 仍保留上一个 word 的 text。
-      // v3 实测发现按 alpha 缓存跳过 set text 会引入"当前行重复显示同一字"的 bug，
-      // 已回滚到 v2 行为（每次 set text + layout）。
-      _painter.text = TextSpan(
-        text: word.text,
-        style: TextStyle(
-          color: Color.fromRGBO(255, 255, 255, alpha),
-          fontSize: fontSize,
-          height: lineHeight,
-          // 显式注入歌词 fontFamily，与测量路径保持一致
-          fontFamily: LyricLayout.fontFamily,
-        ),
-      );
-      _painter.layout();
+      // **v4 性能优化**：per-word TextPainter + alpha 缓存。
+      // 仅在 alpha 变化时才 set text + layout，alpha 不变时直接 paint。
+      final painter = _wordPainters[i];
+      if (_lastSetAlphas[i] != alpha) {
+        painter.text = TextSpan(
+          text: word.text,
+          style: TextStyle(
+            color: Color.fromRGBO(255, 255, 255, alpha),
+            fontSize: fontSize,
+            height: lineHeight,
+            // 显式注入歌词 fontFamily，与测量路径保持一致
+            fontFamily: LyricLayout.fontFamily,
+          ),
+        );
+        painter.layout();
+        _lastSetAlphas[i] = alpha;
+      }
 
       // 应用强调辉光效果：per-word scale + glow shadow
       if (emState.scale != 1.0 || emState.glowLevel > 0) {
@@ -371,17 +383,17 @@ class WordRenderer {
                 sigmaX: blurSigma, sigmaY: blurSigma,
               ),
             );
-            _painter.paint(canvas, wordPos);
+            painter.paint(canvas, wordPos);
             canvas.restore();
           }
         }
 
         // 绘制正常文字层
-        _painter.paint(canvas, wordPos);
+        painter.paint(canvas, wordPos);
         canvas.restore();
       } else {
         // 无辉光：直接绘制
-        _painter.paint(canvas, wordPos);
+        painter.paint(canvas, wordPos);
       }
 
       dx += width;
@@ -391,13 +403,14 @@ class WordRenderer {
   /// 整行降级绘制（无 word 时间戳时使用）。
   ///
   /// [maxWidth] 用于自动换行（默认 [double.infinity] 不换行）。
-  /// 复用 [_painter] 实例避免对象创建。
+  /// 用临时 TextPainter 实例（仅在 fallback 路径，频率低不缓存）。
   void _paintSolidFallback(
       Canvas canvas, Offset offset, LyricLine line, double fontSize,
       {double maxWidth = double.infinity}) {
     if (line.text.isEmpty) return;
     final double alpha = dynamicDarkAlpha;
-    _painter.text = TextSpan(
+    final painter = TextPainter(textDirection: TextDirection.ltr);
+    painter.text = TextSpan(
       text: line.text,
       style: TextStyle(
         color: Color.fromRGBO(255, 255, 255, alpha),
@@ -407,9 +420,10 @@ class WordRenderer {
         fontFamily: LyricLayout.fontFamily,
       ),
     );
-    _painter.layout(
+    painter.layout(
         maxWidth: maxWidth == double.infinity ? double.infinity : maxWidth);
-    _painter.paint(canvas, offset);
+    painter.paint(canvas, offset);
+    painter.dispose();
   }
 
   /// 检测 line 切换并重置 alpha map，同时测量并缓存所有 word 宽度。
@@ -418,22 +432,37 @@ class WordRenderer {
   /// 或 fontSize 变化，重新初始化每个 word 的 alpha 为 [dynamicDarkAlpha]，
   /// 并测量每个 word 的宽度缓存到 [_wordWidths]。
   ///
-  /// **性能优化**：word 宽度只在此时测量一次，paintLine 用缓存宽度做换行判断，
-  /// 避免每帧创建 N 个 TextPainter + layout。
+  /// **v4 性能优化**：
+  /// - 用 per-word TextPainter 实例列表替代共享 _painter
+  /// - word 宽度只在此时测量一次，paintLine 用缓存宽度做换行判断
+  /// - _lastSetAlphas 在 line 切换时清空，强制下次 paintLine 重新 set text + layout
   void _ensureBound(LyricLine line, double fontSize) {
     final sameLine = identical(_boundLine, line);
     final sameFontSize = _boundFontSize == fontSize;
-    if (sameLine && sameFontSize) return;
+    if (sameLine && sameFontSize && _wordPainters.length == line.words.length) {
+      return; // 缓存命中
+    }
     _boundLine = line;
     _boundFontSize = fontSize;
     _wordAlphas.clear();
     _wordYOffsets.clear();
     _emphasizeStates.clear();
+    _lastSetAlphas.clear(); // v4 优化：line 切换时清空 alpha 缓存
+
+    // 释放旧 _wordPainters（line 缩短时避免泄漏）
+    for (final painter in _wordPainters) {
+      painter.dispose();
+    }
+
     final double dark = dynamicDarkAlpha;
-    // 测量所有 word 宽度并缓存
+    // 测量所有 word 宽度并初始化 per-word TextPainter
     _wordWidths = List<double>.filled(line.words.length, 0);
+    _wordPainters = List<TextPainter>.generate(
+      line.words.length,
+      (_) => TextPainter(textDirection: TextDirection.ltr),
+    );
     for (int i = 0; i < line.words.length; i++) {
-      _painter.text = TextSpan(
+      _wordPainters[i].text = TextSpan(
         text: line.words[i].text,
         style: TextStyle(
           fontSize: fontSize,
@@ -443,22 +472,31 @@ class WordRenderer {
           fontFamily: LyricLayout.fontFamily,
         ),
       );
-      _painter.layout();
-      _wordWidths[i] = _painter.width;
+      _wordPainters[i].layout();
+      _wordWidths[i] = _wordPainters[i].width;
       _wordAlphas[i] = dark;
       _wordYOffsets[i] = 0;
+      // _lastSetAlphas[i] 不设置（默认 null），下次 paintLine 会重新 set text + layout
     }
   }
 
   /// 重置状态：清空 alpha map、Y 偏移、归零 progress、scale 回到 inactive、isActive=false、解绑 line。
+  ///
+  /// **v4 优化**：dispose 所有 per-word TextPainter 实例避免内存泄漏。
   void reset() {
     _isActive = false;
     _scale = LyricLayout.inactiveScale;
     _boundLine = null;
     _boundFontSize = -1;
     _wordWidths = const <double>[];
+    // v4 优化：dispose per-word TextPainter 实例
+    for (final painter in _wordPainters) {
+      painter.dispose();
+    }
+    _wordPainters = const <TextPainter>[];
     _wordAlphas.clear();
     _wordYOffsets.clear();
     _emphasizeStates.clear();
+    _lastSetAlphas.clear();
   }
 }


### PR DESCRIPTION
…cache + Selector split

WordRenderer: replace shared _painter with List<TextPainter> _wordPainters; per-word _lastSetAlphas cache skips set text + layout when alpha unchanged. Fixes v3 Task 1 word duplication regression (b56b7e9) safely.

LineRenderer: add _lastSetAlpha/_lastSetMaxWidth cache; fix setLineState not resetting _isConverged when _targetAlpha changes; tick early-return when converged.

full_player_am: wrap build with Selector<(songId, isPlaying)> so position updates (200ms) no longer trigger parent rebuild. Inject position via Selector<int> for 3 AppleLyricsView instances and Selector<(position, duration)> for progress bar.

Verified via adb: parent build fires only on song change / play-pause. Paused CPU ~0.7% (no regression vs v3). Playing CPU ~48-65% (bottleneck shifted to AppleLyricsView._onTick per-frame setState + blur layer widget rebuild).