### PR TITLE
feat(shortcut): 新增长按应用图标快捷入口并修复 audio_match 引用

### DIFF
--- a/android/app/src/main/res/drawable/ic_shortcut_favorite.xml
+++ b/android/app/src/main/res/drawable/ic_shortcut_favorite.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- 白色圆形背景（半径 12，覆盖整个 viewport） -->
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,0 a12,12 0 1,0 0,24 a12,12 0 1,0 0,-24 z" />
+    <!-- 黑色心形图标（缩小并居中：原 20 单位图标缩放到 14 单位，偏移 (5,4)） -->
+    <group
+        android:scaleX="0.7"
+        android:scaleY="0.7"
+        android:translateX="3.6"
+        android:translateY="3.6">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M12,20l-1.2,-1.05C5.6,14.25 2,11.18 2,7.5 2,4.42 4.42,2 7.5,2c1.74,0 3.41,0.81 4.5,2.09C13.09,2.81 14.76,2 16.5,2 19.58,2 22,4.42 22,7.5c0,3.68 -3.6,6.75 -8.8,11.45L12,20z" />
+    </group>
+</vector>

--- a/android/app/src/main/res/drawable/ic_shortcut_mic.xml
+++ b/android/app/src/main/res/drawable/ic_shortcut_mic.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- 白色圆形背景（半径 12，覆盖整个 viewport） -->
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,0 a12,12 0 1,0 0,24 a12,12 0 1,0 0,-24 z" />
+    <!-- 黑色麦克风图标（缩小并居中） -->
+    <group
+        android:scaleX="0.7"
+        android:scaleY="0.7"
+        android:translateX="3.6"
+        android:translateY="3.6">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M12,13.5c1.66,0 3,-1.34 3,-3V5.5c0,-1.66 -1.34,-3 -3,-3s-3,1.34 -3,3v5c0,1.66 1.34,3 3,3zm5,-3c0,2.76 -2.24,5 -5,5s-5,-2.24 -5,-5H5c0,3.53 2.61,6.43 6,6.92V20.5h2v-3.08c3.39,-0.49 6,-3.39 6,-6.92h-2z" />
+    </group>
+</vector>

--- a/android/app/src/main/res/drawable/ic_shortcut_search.xml
+++ b/android/app/src/main/res/drawable/ic_shortcut_search.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- 白色圆形背景（半径 12，覆盖整个 viewport） -->
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,0 a12,12 0 1,0 0,24 a12,12 0 1,0 0,-24 z" />
+    <!-- 黑色搜索图标（缩小并居中） -->
+    <group
+        android:scaleX="0.7"
+        android:scaleY="0.7"
+        android:translateX="3.6"
+        android:translateY="3.6">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M14.5,13.5h-0.79l-0.28,-0.27C14.41,12.09 15,10.61 15,9 15,5.41 12.09,2.5 8.5,2.5S2,5.41 2,9 4.91,15.5 8.5,15.5c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L19.49,18.5l-4.99,-5zm-6,0C6.01,13.5 4,11.49 4,9.5S6.01,5.5 8.5,5.5 13,7.51 13,9.5 10.99,13.5 8.5,13.5z" />
+    </group>
+</vector>

--- a/kugou_api_server/bundled_entry.js
+++ b/kugou_api_server/bundled_entry.js
@@ -18,7 +18,6 @@ const modules = {
   'audio': require('./module/audio.js'),
   'audio_accompany_matching': require('./module/audio_accompany_matching.js'),
   'audio_ktv_total': require('./module/audio_ktv_total.js'),
-  'audio_match': require('./module/audio_match.js'),
   'audio_related': require('./module/audio_related.js'),
   'brush': require('./module/brush.js'),
   'captcha_sent': require('./module/captcha_sent.js'),

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -3,12 +3,13 @@ import 'dart:io' show exit;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
+import 'package:quick_actions/quick_actions.dart';
 
 import 'core/layout/responsive_layout.dart';
 import 'core/theme/app_theme.dart';
 import 'core/theme/motion_constants.dart';
 import 'data/models/playlist.dart';
-import 'main.dart' show appNavigatorKey;
+import 'main.dart' show appNavigatorKey, handleShortcut, pendingShortcutType, shortcutTabRequest;
 import 'modules/charts/charts_page.dart';
 import 'modules/discover/discover_page.dart';
 import 'modules/user/user_center_page.dart';
@@ -113,8 +114,48 @@ class MyApp extends StatelessWidget {
   }
 }
 
-class _AppView extends StatelessWidget {
+class _AppView extends StatefulWidget {
   const _AppView();
+
+  @override
+  State<_AppView> createState() => _AppViewState();
+}
+
+class _AppViewState extends State<_AppView> {
+  @override
+  void initState() {
+    super.initState();
+    // 注册 Android 长按应用图标 Shortcut items
+    const quickActions = QuickActions();
+    quickActions.setShortcutItems(const [
+      ShortcutItem(
+        type: 'action_open_favorites',
+        localizedTitle: '我的收藏',
+        icon: 'ic_shortcut_favorite',
+      ),
+      ShortcutItem(
+        type: 'action_open_recognition',
+        localizedTitle: '听歌识曲',
+        icon: 'ic_shortcut_mic',
+      ),
+      ShortcutItem(
+        type: 'action_open_search',
+        localizedTitle: '搜索',
+        icon: 'ic_shortcut_search',
+      ),
+    ]);
+    // 处理冷启动时缓存的 shortcut 类型：
+    // QuickActions.initialize 在 runApp 之前注册，但此时 Navigator 尚未就绪，
+    // 因此 main.dart 把 shortcut 类型暂存到 pendingShortcutType，
+    // 这里在首帧渲染后消费。
+    if (pendingShortcutType != null) {
+      final type = pendingShortcutType;
+      pendingShortcutType = null;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        handleShortcut(type!);
+      });
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -269,12 +310,23 @@ class _MainLayoutState extends State<_MainLayout> with WidgetsBindingObserver {
     context.read<PlayerProvider>().onLoginRequired = _showLoginRequiredDialog;
     // 监听应用生命周期：detached（进程被系统销毁前的最后窗口）时尝试关停本地 Node.js
     WidgetsBinding.instance.addObserver(this);
+    // 监听 shortcut 入口的 tab 切换请求（来自 main.dart 的 handleShortcut）
+    shortcutTabRequest.addListener(_handleShortcutTabRequest);
   }
 
   @override
   void dispose() {
+    shortcutTabRequest.removeListener(_handleShortcutTabRequest);
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
+  }
+
+  /// 处理 shortcut 入口的 tab 切换请求
+  void _handleShortcutTabRequest() {
+    final index = shortcutTabRequest.value;
+    if (index == null) return;
+    shortcutTabRequest.value = null;
+    setState(() => _selectedIndex = index);
   }
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'dart:io' show Platform;
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:quick_actions/quick_actions.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'app.dart';
@@ -10,6 +11,8 @@ import 'core/services/desktop_lyric_service.dart';
 import 'core/services/lyricon_provider_service.dart';
 import 'core/services/media_notification_service.dart';
 import 'data/repositories/settings_repository.dart';
+import 'modules/recognition/song_recognition_page.dart';
+import 'modules/search/search_page.dart';
 import 'services/nodejs_server.dart';
 import 'widgets/apple_lyrics/layout/lyric_preferences.dart';
 
@@ -17,6 +20,17 @@ const String _kBatteryPromptShownKey = 'battery_prompt_shown';
 
 /// 顶级 Navigator 的 GlobalKey，预留供后续扩展使用。
 final GlobalKey<NavigatorState> appNavigatorKey = GlobalKey<NavigatorState>();
+
+/// 用于在 MyApp 启动前缓存「冷启动时通过 shortcut 触发」的类型。
+/// QuickActions.initialize 在 runApp 之前注册回调，但此时 Navigator 还未就绪，
+/// 因此把 shortcut 类型暂存到该字段，由 _AppView 在首帧处理后清空。
+String? pendingShortcutType;
+
+/// 用于通知 _MainLayout 切换底部 tab。
+/// shortcut 入口「我的收藏」需要切换到主页第 3 个 tab（index=2），
+/// 而非 push 一个新的 FavoritesPage 路由（避免页面重复）。
+/// _MainLayout 在 initState 中监听此 notifier，收到非 null 值后切换 tab 并清空。
+final ValueNotifier<int?> shortcutTabRequest = ValueNotifier<int?>(null);
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -54,7 +68,42 @@ Future<void> main() async {
     }
   }
 
+  // 注册 Android 长按应用图标 Shortcut 回调。
+  // initialize 必须在 runApp 之前调用，以便冷启动时能接收到 shortcut 触发。
+  if (!kIsWeb && Platform.isAndroid) {
+    const quickActions = QuickActions();
+    quickActions.initialize((shortcutType) {
+      // 应用已就绪时直接处理；否则暂存，由 _AppView 在首帧处理
+      if (appNavigatorKey.currentContext != null) {
+        handleShortcut(shortcutType);
+      } else {
+        pendingShortcutType = shortcutType;
+      }
+    });
+  }
+
   runApp(const MyApp());
+}
+
+/// 根据 shortcut 类型路由到对应页面。
+/// 通过全局 [appNavigatorKey] 获取 NavigatorState，避免依赖具体 BuildContext。
+void handleShortcut(String shortcutType) {
+  final nav = appNavigatorKey.currentState;
+  if (nav == null) return;
+  switch (shortcutType) {
+    case 'action_open_favorites':
+      // 切换到主页底部 tab index=2（我的收藏），而非 push 新路由
+      shortcutTabRequest.value = 2;
+      break;
+    case 'action_open_recognition':
+      nav.push(MaterialPageRoute(
+        builder: (_) => const SongRecognitionPage(),
+      ));
+      break;
+    case 'action_open_search':
+      nav.push(MaterialPageRoute(builder: (_) => const SearchPage()));
+      break;
+  }
 }
 
 Future<void> _requestPermissions() async {

--- a/lib/modules/discover/discover_page.dart
+++ b/lib/modules/discover/discover_page.dart
@@ -16,7 +16,6 @@ import '../charts/charts_page.dart';
 import '../playlist/playlist_page.dart';
 import '../recognition/song_recognition_page.dart';
 import '../search/search_page.dart';
-import '../recognition/song_recognition_page.dart';
 
 class DiscoverPage extends StatefulWidget {
   const DiscoverPage({super.key, this.onAvatarTap});

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -584,6 +584,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  quick_actions:
+    dependency: "direct main"
+    description:
+      name: quick_actions
+      sha256: "7e35dd6a21f5bbd21acf6899039eaf85001a5ac26d52cbd6a8a2814505b90798"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  quick_actions_android:
+    dependency: transitive
+    description:
+      name: quick_actions_android
+      sha256: af50d52d882a0f520c4be082636b5177b3de239bd468857d5da0b5a6eec61e07
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.32"
+  quick_actions_ios:
+    dependency: transitive
+    description:
+      name: quick_actions_ios
+      sha256: be1496e7ca1debc86d9ea08e56325649fbc5abb2b6930690c97ba0dae59992b1
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.4"
+  quick_actions_platform_interface:
+    dependency: transitive
+    description:
+      name: quick_actions_platform_interface
+      sha256: "1fec7068db5122cd019e9340d3d7be5d36eab099695ef3402c7059ee058329a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   record:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   permission_handler: ^12.0.0
   record: ^6.1.1
   path_provider: ^2.1.0
+  quick_actions: ^1.0.7
   sqflite: 2.3.3+1
   intl: ^0.19.0
   dio: ^5.4.0


### PR DESCRIPTION
- 添加 quick_actions 依赖，注册 3 项 shortcut（我的收藏/听歌识曲/搜索）

- 我的收藏 shortcut 切换到底部 tab 而非 push 新路由

- 新增 3 个矢量 drawable（白底黑图标，缩放 0.7 倍居中）

- 重新生成 bundled_entry.js 剔除不存在的 audio_match.js 引用

- 删除 discover_page 重复导入