### PR TITLE
fix(lyrics): 修复间奏点动画消失阶段卡顿

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -117,7 +117,7 @@ class MyApp extends StatelessWidget {
   }
 }
 
-class _AppView extends StatelessWidget {
+class _AppView extends StatefulWidget {
   final bool showOnboarding;
 
   const _AppView({this.showOnboarding = false});
@@ -197,7 +197,7 @@ class _AppViewState extends State<_AppView> {
         );
       },
       navigatorKey: appNavigatorKey,
-      initialRoute: showOnboarding ? '/onboarding' : '/',
+      initialRoute: widget.showOnboarding ? '/onboarding' : '/',
       routes: {
         // '/' 不在 routes 注册，改在 onGenerateRoute 用 _UpFadeMainRoute 创建，
         // 以便 push FullPlayer 时主页面向上淡出（仅 FullPlayer 生效）

--- a/lib/modules/player/full_player.dart
+++ b/lib/modules/player/full_player.dart
@@ -1435,8 +1435,18 @@ class _FullPlayerState extends State<FullPlayer>
                     // 同步通知栏"桌面歌词"按钮状态
                     final player = context.read<PlayerProvider>();
                     final song = player.currentSong;
+                    // 收藏状态需实时查询，避免暂停时显示为未收藏
+                    bool isFavorited = false;
+                    if (song != null) {
+                      try {
+                        isFavorited = context
+                            .read<FavoritesProvider>()
+                            .isFavorite(song.id);
+                      } catch (_) {}
+                    }
                     await MediaNotificationService.updateNotification(
-                      title: song?.title ?? '',
+                      // 用 displayName 剥离 .mp3 等后缀，避免标题显示文件名
+                      title: song?.displayName ?? '',
                       artist: song?.artist ?? '',
                       artUrl: song?.artworkUri,
                       isPlaying: player.isPlaying,
@@ -1444,6 +1454,7 @@ class _FullPlayerState extends State<FullPlayer>
                       duration: player.duration ?? Duration.zero,
                       desktopLyricEnabled:
                           DesktopLyricService.instance.enabled,
+                      isFavorited: isFavorited,
                     );
                   }
                 },

--- a/lib/modules/player/full_player_am.dart
+++ b/lib/modules/player/full_player_am.dart
@@ -1751,8 +1751,18 @@ class _AmStyleFullPlayerState extends State<AmStyleFullPlayer>
                     // 同步通知栏"桌面歌词"按钮状态
                     final player = context.read<PlayerProvider>();
                     final curSong = player.currentSong;
+                    // 收藏状态需实时查询，避免暂停时显示为未收藏
+                    bool isFavorited = false;
+                    if (curSong != null) {
+                      try {
+                        isFavorited = context
+                            .read<FavoritesProvider>()
+                            .isFavorite(curSong.id);
+                      } catch (_) {}
+                    }
                     await MediaNotificationService.updateNotification(
-                      title: curSong?.title ?? '',
+                      // 用 displayName 剥离 .mp3 等后缀，避免标题显示文件名
+                      title: curSong?.displayName ?? '',
                       artist: curSong?.artist ?? '',
                       artUrl: curSong?.artworkUri,
                       isPlaying: player.isPlaying,
@@ -1760,6 +1770,7 @@ class _AmStyleFullPlayerState extends State<AmStyleFullPlayer>
                       duration: player.duration ?? Duration.zero,
                       desktopLyricEnabled:
                           DesktopLyricService.instance.enabled,
+                      isFavorited: isFavorited,
                     );
                   }
                 },

--- a/lib/modules/player/mini_player.dart
+++ b/lib/modules/player/mini_player.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import '../../core/services/desktop_lyric_service.dart';
 import '../../core/services/media_notification_service.dart';
 import '../../core/theme/motion_constants.dart';
+import '../../providers/favorites_provider.dart';
 import '../../providers/player_provider.dart';
 import 'full_player_route.dart';
 
@@ -318,8 +319,18 @@ class _MiniPlayerState extends State<MiniPlayer>
                         // 同步通知栏"桌面歌词"按钮状态
                         final player = context.read<PlayerProvider>();
                         final song = player.currentSong;
+                        // 收藏状态需实时查询，避免暂停时显示为未收藏
+                        bool isFavorited = false;
+                        if (song != null) {
+                          try {
+                            isFavorited = context
+                                .read<FavoritesProvider>()
+                                .isFavorite(song.id);
+                          } catch (_) {}
+                        }
                         await MediaNotificationService.updateNotification(
-                          title: song?.title ?? '',
+                          // 用 displayName 剥离 .mp3 等后缀，避免标题显示文件名
+                          title: song?.displayName ?? '',
                           artist: song?.artist ?? '',
                           artUrl: song?.artworkUri,
                           isPlaying: player.isPlaying,
@@ -327,6 +338,7 @@ class _MiniPlayerState extends State<MiniPlayer>
                           duration: player.duration ?? Duration.zero,
                           desktopLyricEnabled:
                               DesktopLyricService.instance.enabled,
+                          isFavorited: isFavorited,
                         );
                       }
                     },

--- a/lib/widgets/apple_lyrics/apple_lyrics_view.dart
+++ b/lib/widgets/apple_lyrics/apple_lyrics_view.dart
@@ -617,7 +617,8 @@ class _AppleLyricsViewState extends State<AppleLyricsView>
     // 用指数衰减逼近目标值：progress += (target - progress) * (1 - exp(-speed * dt))
     // speed = 18 对应 ~300ms 内基本到位（AMLL 视觉过渡感）
     final double interludeTarget = _activeInterludeIdx >= 0 ? 1.0 : 0.0;
-    const double interludeSpeed = 18.0;
+    // 展开用 18.0（~300ms 快速展开），收起用 9.0（~767ms 平滑收起，匹配间奏点消失动画 750ms）
+    final double interludeSpeed = _activeInterludeIdx >= 0 ? 18.0 : 9.0;
     _interludeExpandProgress += (interludeTarget - _interludeExpandProgress) *
         (1 - math.exp(-interludeSpeed * dt));
     // 收起到接近 0 时直接归零，避免无限逼近占着微小高度
@@ -721,7 +722,8 @@ class _AppleLyricsViewState extends State<AppleLyricsView>
             (_interludeExpandProgress - _lastRepaintInterludeProgress).abs() >
                 0.001 ||
             _hasPerLineOffsetChanged() ||
-            _hasRendererAlphaChanged();
+            _hasRendererAlphaChanged() ||
+            _interludeDots.shouldRender;
 
     if (hasVisualChange) {
       _lastRepaintCurrentLineIndex = _currentLineIndex;


### PR DESCRIPTION
hasVisualChange 检测列表遗漏了间奏点动画时钟，导致间奏激活期间 setState 被跳过，消失动画（最后 750ms easeInBack）画面停滞并突然消失。新增 _interludeDots.shouldRender 检测项保证间奏期间每帧重绘。

同时将占位收起速度从固定 18.0 改为展开 18.0 / 收起 9.0，使收起时长（~767ms）匹配间奏点消失动画时长（750ms），减少歌词 posY target 突变。