### PR TITLE
Fix media session artwork update and enhance DLNA casting features

### DIFF
--- a/lib/core/services/dlna_service.dart
+++ b/lib/core/services/dlna_service.dart
@@ -63,16 +63,19 @@ class DlnaService {
 
   /// 投屏：设置媒体 URL 并播放。
   /// [mediaType] 决定 DLNA 的 MIME 类型（音频/视频）。
+  /// [overrideType] 可选，本地文件按扩展名映射的具体 PlayType；
+  ///   传 null 时按 [mediaType] 兜底用 mpeg/mp4（保持向后兼容）。
   Future<bool> cast(
     String url, {
     String? title,
     required DlnaMediaType mediaType,
+    PlayType? overrideType,
   }) async {
     final device = _connectedDevice;
     if (device == null) return false;
 
     // 显式声明为 PlayType，避免 switch 推断为 Object
-    final PlayType playType = switch (mediaType) {
+    final PlayType playType = overrideType ?? switch (mediaType) {
       DlnaMediaType.audio => AudioMime.mpeg,
       DlnaMediaType.video => VideoMime.mp4,
     };

--- a/lib/core/services/local_http_server.dart
+++ b/lib/core/services/local_http_server.dart
@@ -1,0 +1,187 @@
+import 'dart:io';
+
+/// 把本地音频文件通过 HTTP 暴露到局域网，供 DLNA 渲染设备拉流。
+///
+/// 单例服务，仅在 Android 平台启用（由 main.dart 控制）。
+/// 监听 `0.0.0.0:<port>`，路由 `GET /local?path=<url-encoded-absolute-path>`。
+/// 支持 Range 请求（DLNA 设备 seek 必需），按文件扩展名映射 Content-Type。
+class LocalHttpServer {
+  static final LocalHttpServer instance = LocalHttpServer._();
+  LocalHttpServer._();
+
+  HttpServer? _server;
+  String? _lanIp;
+  int? _port;
+
+  /// 候选端口：8888 优先，被占用依次尝试到 8898。
+  static const List<int> _candidatePorts = [
+    8888, 8889, 8890, 8891, 8892, 8893, 8894, 8895, 8896, 8897, 8898,
+  ];
+
+  bool get isRunning => _server != null;
+  int? get port => _port;
+
+  /// 启动服务器。端口冲突时自动尝试下一个候选端口；
+  /// 全部失败则静默返回（UI 层会在投屏时给出错误提示）。
+  Future<void> start() async {
+    if (_server != null) return;
+    for (final port in _candidatePorts) {
+      try {
+        _server = await HttpServer.bind('0.0.0.0', port);
+        _port = port;
+        _lanIp = await _resolveLanIp();
+        _server!.listen(_handleRequest);
+        // ignore: avoid_print
+        print('LocalHttpServer started on $_lanIp:$_port');
+        return;
+      } catch (_) {
+        // 端口被占用，尝试下一个
+      }
+    }
+    // ignore: avoid_print
+    print('LocalHttpServer failed to bind any port in $_candidatePorts');
+  }
+
+  /// 停止服务器。
+  Future<void> stop() async {
+    await _server?.close(force: true);
+    _server = null;
+    _port = null;
+    _lanIp = null;
+  }
+
+  /// 获取本地文件的局域网 HTTP URL。
+  /// 返回 `http://<lan-ip>:<port>/local?path=<url-encoded>`。
+  /// 服务器未启动或无可用局域网 IP 时返回 null。
+  /// 自动剥离 `file://` 前缀，并对路径做完全 decode 后再统一编码，
+  /// 避免 song.localPath 已被 percent-encode（如 MediaStore 返回的 file:// URI）
+  /// 导致二次编码后服务器端 File() 无法识别路径。
+  String? getUrlForPath(String path) {
+    if (_server == null || _port == null) return null;
+    if (_lanIp == null) return null;
+    // 先完全解码（处理已 percent-encode 的 file:// URI），再剥离 file:// 前缀
+    String normalized = Uri.decodeFull(path);
+    if (normalized.startsWith('file://')) {
+      normalized = normalized.substring(7);
+    }
+    final encoded = Uri.encodeComponent(normalized);
+    return 'http://$_lanIp:$_port/local?path=$encoded';
+  }
+
+  /// 解析局域网 IPv4 地址。
+  /// 优先返回 WiFi/以太网接口（wlan0/eth0）的 IP，
+  /// 跳过蜂窝数据接口（rmnet/pdp）和 VPN 接口（tun），
+  /// 否则 DLNA 设备会拿到蜂窝 CGNAT 段 IP（如 10.x.x.x）而无法访问。
+  Future<String?> _resolveLanIp() async {
+    try {
+      final interfaces = await NetworkInterface.list(
+        type: InternetAddressType.IPv4,
+        includeLoopback: false,
+        includeLinkLocal: false,
+      );
+      String? fallbackIp;
+      for (final iface in interfaces) {
+        final name = iface.name.toLowerCase();
+        // 蜂窝数据接口 / VPN 接口，直接跳过
+        if (name.startsWith('rmnet') ||
+            name.startsWith('pdp') ||
+            name.startsWith('tun') ||
+            name.startsWith('ppp')) {
+          continue;
+        }
+        for (final addr in iface.addresses) {
+          if (addr.isLoopback || addr.isLinkLocal) continue;
+          // 优先返回 WiFi/以太网接口
+          if (name.startsWith('wlan') ||
+              name.startsWith('eth') ||
+              name.startsWith('wifi') ||
+              name.startsWith('ap')) {
+            return addr.address;
+          }
+          // 其他接口（如 dummy0）作为回退
+          fallbackIp ??= addr.address;
+        }
+      }
+      return fallbackIp;
+    } catch (_) {}
+    return null;
+  }
+
+  /// 处理 HTTP 请求：仅响应 `GET /local?path=<absolute-path>`。
+  Future<void> _handleRequest(HttpRequest request) async {
+    try {
+      if (request.method != 'GET' || request.uri.path != '/local') {
+        request.response.statusCode = HttpStatus.notFound;
+        await request.response.close();
+        return;
+      }
+      final path = request.uri.queryParameters['path'];
+      if (path == null || path.isEmpty) {
+        request.response.statusCode = HttpStatus.badRequest;
+        await request.response.close();
+        return;
+      }
+      final file = File(path);
+      if (!await file.exists()) {
+        request.response.statusCode = HttpStatus.notFound;
+        await request.response.close();
+        return;
+      }
+      final mime = _mimeForPath(path);
+      final length = await file.length();
+
+      // Range 请求支持（DLNA 设备 seek 必需）
+      final rangeHeader = request.headers.value('range');
+      if (rangeHeader != null) {
+        final match = RegExp(r'bytes=(\d+)-(\d*)').firstMatch(rangeHeader);
+        if (match != null) {
+          final start = int.parse(match.group(1)!);
+          final endStr = match.group(2)!;
+          final end = endStr.isEmpty ? length - 1 : int.parse(endStr);
+          if (start >= length || end >= length || start > end) {
+            request.response.statusCode =
+                HttpStatus.requestedRangeNotSatisfiable;
+            request.response.headers
+                .set('Content-Range', 'bytes */$length');
+            await request.response.close();
+            return;
+          }
+          request.response.statusCode = HttpStatus.partialContent;
+          request.response.headers.set('Content-Type', mime);
+          request.response.headers.set('Content-Length', end - start + 1);
+          request.response.headers
+              .set('Content-Range', 'bytes $start-$end/$length');
+          request.response.headers.set('Accept-Ranges', 'bytes');
+          await file.openRead(start, end + 1).pipe(request.response);
+          return;
+        }
+      }
+
+      // 完整文件响应
+      request.response.statusCode = HttpStatus.ok;
+      request.response.headers.set('Content-Type', mime);
+      request.response.headers.set('Content-Length', length);
+      request.response.headers.set('Accept-Ranges', 'bytes');
+      await file.openRead().pipe(request.response);
+    } catch (_) {
+      try {
+        await request.response.close();
+      } catch (_) {}
+    }
+  }
+
+  /// 按文件扩展名映射 HTTP Content-Type。
+  String _mimeForPath(String path) {
+    final lower = path.toLowerCase();
+    if (lower.endsWith('.mp3')) return 'audio/mpeg';
+    if (lower.endsWith('.flac')) return 'audio/x-flac';
+    if (lower.endsWith('.wav')) return 'audio/wav';
+    if (lower.endsWith('.m4a')) return 'audio/mp4';
+    if (lower.endsWith('.aac')) return 'audio/aac';
+    if (lower.endsWith('.ogg')) return 'audio/ogg';
+    if (lower.endsWith('.opus')) return 'audio/opus';
+    if (lower.endsWith('.ape')) return 'audio/x-ape';
+    if (lower.endsWith('.wma')) return 'audio/wma';
+    return 'application/octet-stream';
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'app.dart';
 import 'core/services/desktop_lyric_service.dart';
 import 'core/services/equalizer_service.dart';
+import 'core/services/local_http_server.dart';
 import 'core/services/lyricon_provider_service.dart';
 import 'core/services/media_notification_service.dart';
 import 'core/services/wakelock_service.dart';
@@ -75,6 +76,13 @@ Future<void> main() async {
       await NodeJsServer.start();
     } catch (e) {
       print('Node.js server start error: $e');
+    }
+    // 启动本地 HTTP 服务器，供 DLNA 投屏本地音乐
+    // 失败不阻塞启动流程，投屏时若未启动会提示用户重启 App
+    try {
+      await LocalHttpServer.instance.start();
+    } catch (e) {
+      print('Local HTTP server start error: $e');
     }
   }
 

--- a/lib/modules/player/full_player.dart
+++ b/lib/modules/player/full_player.dart
@@ -53,6 +53,16 @@ const List<AudioQuality> _audioQualities = [
   AudioQuality.hires,
 ];
 
+/// 定时关闭预定义档位（分钟）。
+const List<Duration> _sleepTimerPresets = [
+  Duration(minutes: 5),
+  Duration(minutes: 10),
+  Duration(minutes: 15),
+  Duration(minutes: 30),
+  Duration(minutes: 60),
+  Duration(minutes: 90),
+];
+
 class FullPlayer extends StatefulWidget {
   const FullPlayer({super.key});
 
@@ -1268,6 +1278,16 @@ class _FullPlayerState extends State<FullPlayer>
           const Spacer(),
           // MD3E v2: 顶部栏右侧 FLAC 质量徽章，点击复用 _showQualityDialog
           _buildQualityPill(playerProvider),
+          // 睡眠药丸：用 ListenableBuilder 独立监听，确保每秒走字
+          ListenableBuilder(
+            listenable: playerProvider,
+            builder: (context, _) {
+              if (!playerProvider.isSleepTimerActive) {
+                return const SizedBox.shrink();
+              }
+              return _buildSleepTimerPill(playerProvider);
+            },
+          ),
           if (playerProvider.currentSong?.isOnline == true)
             IconButton(
               icon: const Icon(Icons.music_video_outlined),
@@ -2282,7 +2302,7 @@ class _FullPlayerState extends State<FullPlayer>
     );
   }
 
-  void _showMoreMenu(BuildContext context) {
+  void _showMoreMenu(BuildContext rootContext) {
     final song = context.read<PlayerProvider>().currentSong;
     if (song == null) return;
 
@@ -2291,9 +2311,9 @@ class _FullPlayerState extends State<FullPlayer>
     final artistTitle = song.artist.isEmpty ? '查看歌手' : '查看歌手：${song.artist}';
 
     showModalBottomSheet(
-      context: context,
+      context: rootContext,
       isScrollControlled: true,
-      builder: (context) {
+      builder: (sheetContext) {
         return SafeArea(
           child: SingleChildScrollView(
             child: Column(
@@ -2303,8 +2323,8 @@ class _FullPlayerState extends State<FullPlayer>
                   leading: const Icon(Icons.lyrics),
                   title: const Text('歌词显示设置'),
                   onTap: () {
-                    Navigator.pop(context);
-                    _showLyricPreferencesSheet(context);
+                    Navigator.pop(sheetContext);
+                    _showLyricPreferencesSheet(rootContext);
                   },
                 ),
                 ListenableBuilder(
@@ -2323,9 +2343,9 @@ class _FullPlayerState extends State<FullPlayer>
                         eq.enabled ? '已开启 · ${eq.currentPreset}' : '未开启',
                       ),
                       onTap: () {
-                        Navigator.pop(context);
+                        Navigator.pop(sheetContext);
                         Navigator.push(
-                          context,
+                          rootContext,
                           MaterialPageRoute(
                             builder: (_) => const EqualizerSettingsPage(),
                           ),
@@ -2334,12 +2354,32 @@ class _FullPlayerState extends State<FullPlayer>
                     );
                   },
                 ),
+                ListenableBuilder(
+                  listenable: context.read<PlayerProvider>(),
+                  builder: (context, _) {
+                    final player = context.read<PlayerProvider>();
+                    final remaining = player.sleepTimerRemaining;
+                    return ListTile(
+                      leading: const Icon(Icons.timer_outlined),
+                      title: const Text('定时关闭'),
+                      subtitle: Text(
+                        remaining == null
+                            ? '未设置'
+                            : '还剩 ${_formatSleepTime(remaining)}',
+                      ),
+                      onTap: () {
+                        Navigator.pop(sheetContext);
+                        _showSleepTimerSheet(rootContext, player);
+                      },
+                    );
+                  },
+                ),
                 ListTile(
                   leading: const Icon(Icons.cast),
                   title: const Text('投屏'),
                   onTap: () {
-                    Navigator.pop(context);
-                    _showDlnaCastSheet(context);
+                    Navigator.pop(sheetContext);
+                    _showDlnaCastSheet(rootContext);
                   },
                 ),
                 ListTile(
@@ -2350,7 +2390,7 @@ class _FullPlayerState extends State<FullPlayer>
                     overflow: TextOverflow.ellipsis,
                   ),
                   onTap: () {
-                    Navigator.pop(context);
+                    Navigator.pop(sheetContext);
                     _navigateToAlbum(song);
                   },
                 ),
@@ -2362,7 +2402,7 @@ class _FullPlayerState extends State<FullPlayer>
                     overflow: TextOverflow.ellipsis,
                   ),
                   onTap: () {
-                    Navigator.pop(context);
+                    Navigator.pop(sheetContext);
                     _navigateToArtist(song);
                   },
                 ),
@@ -2370,18 +2410,18 @@ class _FullPlayerState extends State<FullPlayer>
                   leading: const Icon(Icons.playlist_add),
                   title: const Text('添加到歌单'),
                   onTap: () {
-                    Navigator.pop(context);
-                    _showAddToPlaylistDialog(context, song);
+                    Navigator.pop(sheetContext);
+                    _showAddToPlaylistDialog(rootContext, song);
                   },
                 ),
                 ListTile(
                   leading: const Icon(Icons.share),
                   title: const Text('分享'),
                   onTap: () {
-                    Navigator.pop(context);
+                    Navigator.pop(sheetContext);
                     // TODO: 实现分享功能
                     ScaffoldMessenger.of(
-                      context,
+                      rootContext,
                     ).showSnackBar(const SnackBar(content: Text('分享功能开发中')));
                   },
                 ),
@@ -2392,7 +2432,7 @@ class _FullPlayerState extends State<FullPlayer>
                     context.read<ThemeProvider>().setUseArtistPhotoBackground(
                       v,
                     );
-                    Navigator.pop(context);
+                    Navigator.pop(sheetContext);
                   },
                 ),
               ],
@@ -2401,6 +2441,200 @@ class _FullPlayerState extends State<FullPlayer>
         );
       },
     );
+  }
+
+  /// MD3E v2 睡眠定时药丸 — 复用 _buildQualityPill 样式。
+  Widget _buildSleepTimerPill(PlayerProvider playerProvider) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    final remaining = playerProvider.sleepTimerRemaining ?? Duration.zero;
+    return Material(
+      color: colorScheme.primaryContainer,
+      shape: const StadiumBorder(),
+      child: InkWell(
+        onTap: () => _showSleepTimerSheet(context, playerProvider),
+        customBorder: const StadiumBorder(),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                Icons.timer_outlined,
+                size: 14,
+                color: colorScheme.onPrimaryContainer,
+              ),
+              const SizedBox(width: 4),
+              Text(
+                _formatSleepTime(remaining),
+                style: textTheme.labelMedium?.copyWith(
+                  color: colorScheme.onPrimaryContainer,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// MD3E v2 定时关闭选择面板。
+  void _showSleepTimerSheet(BuildContext rootContext, PlayerProvider player) {
+    showModalBottomSheet(
+      context: rootContext,
+      isScrollControlled: true,
+      builder: (sheetCtx) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Text(
+                  '定时关闭',
+                  style: Theme.of(rootContext).textTheme.titleMedium,
+                ),
+              ),
+              ..._sleepTimerPresets.map((d) {
+                final r = player.sleepTimerRemaining;
+                final active = r != null &&
+                    (r.inSeconds - d.inSeconds).abs() < 2;
+                return ListTile(
+                  leading: Icon(active
+                      ? Icons.radio_button_checked
+                      : Icons.radio_button_unchecked),
+                  title: Text('${d.inMinutes} 分钟'),
+                  onTap: () {
+                    player.setSleepTimer(d);
+                    Navigator.pop(sheetCtx);
+                    ScaffoldMessenger.of(rootContext).showSnackBar(
+                      SnackBar(
+                        content: Text('将在 ${d.inMinutes} 分钟后自动暂停'),
+                        behavior: SnackBarBehavior.floating,
+                      ),
+                    );
+                  },
+                );
+              }),
+              ListTile(
+                leading: const Icon(Icons.edit_outlined),
+                title: const Text('自定义…'),
+                onTap: () {
+                  Navigator.pop(sheetCtx);
+                  _showCustomSleepTimerDialog(rootContext, player);
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.cancel_outlined),
+                title: const Text('关闭定时'),
+                onTap: () {
+                  player.setSleepTimer(null);
+                  Navigator.pop(sheetCtx);
+                },
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  /// MD3E v2 自定义分钟数对话框。
+  void _showCustomSleepTimerDialog(
+    BuildContext rootContext,
+    PlayerProvider player,
+  ) {
+    final controller = TextEditingController();
+    showDialog(
+      context: rootContext,
+      builder: (dialogCtx) => Dialog(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(28),
+        ),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 320),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: 24,
+              vertical: 20,
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.timer_outlined, size: 32),
+                const SizedBox(height: 8),
+                const Text(
+                  '自定义定时关闭',
+                  style: TextStyle(fontSize: 16),
+                ),
+                const SizedBox(height: 16),
+                TextField(
+                  controller: controller,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(
+                    labelText: '分钟',
+                    hintText: '1-240',
+                    border: OutlineInputBorder(),
+                  ),
+                  autofocus: true,
+                ),
+                const SizedBox(height: 16),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    TextButton(
+                      onPressed: () {
+                        controller.dispose();
+                        Navigator.pop(dialogCtx);
+                      },
+                      child: const Text('取消'),
+                    ),
+                    FilledButton(
+                      onPressed: () {
+                        final n = int.tryParse(controller.text);
+                        controller.dispose();
+                        if (n == null || n < 1 || n > 240) {
+                          ScaffoldMessenger.of(rootContext).showSnackBar(
+                            const SnackBar(
+                              content: Text('请输入 1-240 之间的整数'),
+                              behavior: SnackBarBehavior.floating,
+                            ),
+                          );
+                          return;
+                        }
+                        final d = Duration(minutes: n);
+                        player.setSleepTimer(d);
+                        Navigator.pop(dialogCtx);
+                        ScaffoldMessenger.of(rootContext).showSnackBar(
+                          SnackBar(
+                            content: Text('将在 $n 分钟后自动暂停'),
+                            behavior: SnackBarBehavior.floating,
+                          ),
+                        );
+                      },
+                      child: const Text('确定'),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// MD3E v2 睡眠定时剩余时间格式：>=1h 显示 `XhYYm`，否则 `mm:ss`。
+  String _formatSleepTime(Duration d) {
+    if (d.inHours >= 1) {
+      final h = d.inHours;
+      final m = d.inMinutes.remainder(60);
+      return '${h}h${m.toString().padLeft(2, '0')}m';
+    }
+    final m = d.inMinutes;
+    final s = d.inSeconds.remainder(60);
+    return '${m.toString().padLeft(2, '0')}:${s.toString().padLeft(2, '0')}';
   }
 
   /// 弹出 DLNA 投屏二级菜单（设备选择 + 传输控制）。

--- a/lib/modules/player/full_player_am.dart
+++ b/lib/modules/player/full_player_am.dart
@@ -56,6 +56,16 @@ const List<AudioQuality> _audioQualities = [
   AudioQuality.hires,
 ];
 
+/// 定时关闭预定义档位（分钟）。
+const List<Duration> _sleepTimerPresets = [
+  Duration(minutes: 5),
+  Duration(minutes: 10),
+  Duration(minutes: 15),
+  Duration(minutes: 30),
+  Duration(minutes: 60),
+  Duration(minutes: 90),
+];
+
 class AmStyleFullPlayer extends StatefulWidget {
   const AmStyleFullPlayer({super.key});
 
@@ -1482,6 +1492,16 @@ class _AmStyleFullPlayerState extends State<AmStyleFullPlayer>
           // AM v2: 顶部栏右侧 FLAC 质量徽章，点击复用 _showQualityDialog，
           // 长按呼出 _showVolumeDialog（与 MD 风格统一）
           _buildQualityPill(playerProvider),
+          // 睡眠药丸：用 ListenableBuilder 独立监听，确保每秒走字
+          ListenableBuilder(
+            listenable: playerProvider,
+            builder: (context, _) {
+              if (!playerProvider.isSleepTimerActive) {
+                return const SizedBox.shrink();
+              }
+              return _buildSleepTimerPill(playerProvider);
+            },
+          ),
           if (playerProvider.currentSong?.isOnline == true)
             IconButton(
               icon: const Icon(Icons.music_video_outlined, color: Colors.white),
@@ -2564,7 +2584,7 @@ class _AmStyleFullPlayerState extends State<AmStyleFullPlayer>
     );
   }
 
-  void _showMoreMenu(BuildContext context) {
+  void _showMoreMenu(BuildContext rootContext) {
     final song = context.read<PlayerProvider>().currentSong;
     if (song == null) return;
 
@@ -2573,9 +2593,9 @@ class _AmStyleFullPlayerState extends State<AmStyleFullPlayer>
     final artistTitle = song.artist.isEmpty ? '查看歌手' : '查看歌手：${song.artist}';
 
     showModalBottomSheet(
-      context: context,
+      context: rootContext,
       isScrollControlled: true,
-      builder: (context) {
+      builder: (sheetContext) {
         // 歌词类型标签：KRC / LRC 逐字 / LRC 行级 / 静态 / 未加载
         // LRC 内部细分：任意一行含字级时间戳即视为"逐字"，否则为"行级"
         final hasWordTiming = _parsedLyrics.any((line) => line.hasWordTiming);
@@ -2596,8 +2616,8 @@ class _AmStyleFullPlayerState extends State<AmStyleFullPlayer>
                   title: const Text('歌词类型'),
                   trailing: Text(
                     lyricTypeLabel,
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: Theme.of(context).colorScheme.primary,
+                    style: Theme.of(sheetContext).textTheme.bodyMedium?.copyWith(
+                      color: Theme.of(sheetContext).colorScheme.primary,
                     ),
                   ),
                 ),
@@ -2605,8 +2625,8 @@ class _AmStyleFullPlayerState extends State<AmStyleFullPlayer>
                   leading: const Icon(Icons.lyrics),
                   title: const Text('歌词显示设置'),
                   onTap: () {
-                    Navigator.pop(context);
-                    _showLyricPreferencesSheet(context);
+                    Navigator.pop(sheetContext);
+                    _showLyricPreferencesSheet(rootContext);
                   },
                 ),
                 ListenableBuilder(
@@ -2625,9 +2645,9 @@ class _AmStyleFullPlayerState extends State<AmStyleFullPlayer>
                         eq.enabled ? '已开启 · ${eq.currentPreset}' : '未开启',
                       ),
                       onTap: () {
-                        Navigator.pop(context);
+                        Navigator.pop(sheetContext);
                         Navigator.push(
-                          context,
+                          rootContext,
                           MaterialPageRoute(
                             builder: (_) => const EqualizerSettingsPage(),
                           ),
@@ -2636,12 +2656,32 @@ class _AmStyleFullPlayerState extends State<AmStyleFullPlayer>
                     );
                   },
                 ),
+                ListenableBuilder(
+                  listenable: context.read<PlayerProvider>(),
+                  builder: (context, _) {
+                    final player = context.read<PlayerProvider>();
+                    final remaining = player.sleepTimerRemaining;
+                    return ListTile(
+                      leading: const Icon(Icons.timer_outlined),
+                      title: const Text('定时关闭'),
+                      subtitle: Text(
+                        remaining == null
+                            ? '未设置'
+                            : '还剩 ${_formatSleepTime(remaining)}',
+                      ),
+                      onTap: () {
+                        Navigator.pop(sheetContext);
+                        _showSleepTimerSheet(rootContext, player);
+                      },
+                    );
+                  },
+                ),
                 ListTile(
                   leading: const Icon(Icons.cast),
                   title: const Text('投屏'),
                   onTap: () {
-                    Navigator.pop(context);
-                    _showDlnaCastSheet(context);
+                    Navigator.pop(sheetContext);
+                    _showDlnaCastSheet(rootContext);
                   },
                 ),
                 ListTile(
@@ -2652,7 +2692,7 @@ class _AmStyleFullPlayerState extends State<AmStyleFullPlayer>
                     overflow: TextOverflow.ellipsis,
                   ),
                   onTap: () {
-                    Navigator.pop(context);
+                    Navigator.pop(sheetContext);
                     _navigateToAlbum(song);
                   },
                 ),
@@ -2664,7 +2704,7 @@ class _AmStyleFullPlayerState extends State<AmStyleFullPlayer>
                     overflow: TextOverflow.ellipsis,
                   ),
                   onTap: () {
-                    Navigator.pop(context);
+                    Navigator.pop(sheetContext);
                     _navigateToArtist(song);
                   },
                 ),
@@ -2672,18 +2712,18 @@ class _AmStyleFullPlayerState extends State<AmStyleFullPlayer>
                   leading: const Icon(Icons.playlist_add),
                   title: const Text('添加到歌单'),
                   onTap: () {
-                    Navigator.pop(context);
-                    _showAddToPlaylistDialog(context, song);
+                    Navigator.pop(sheetContext);
+                    _showAddToPlaylistDialog(rootContext, song);
                   },
                 ),
                 ListTile(
                   leading: const Icon(Icons.share),
                   title: const Text('分享'),
                   onTap: () {
-                    Navigator.pop(context);
+                    Navigator.pop(sheetContext);
                     // TODO: 实现分享功能
                     ScaffoldMessenger.of(
-                      context,
+                      rootContext,
                     ).showSnackBar(const SnackBar(content: Text('分享功能开发中')));
                   },
                 ),
@@ -2693,6 +2733,195 @@ class _AmStyleFullPlayerState extends State<AmStyleFullPlayer>
         );
       },
     );
+  }
+
+  /// AM v2 睡眠定时药丸 — 复用 _buildQualityPill 样式（白色 15% 背景）。
+  Widget _buildSleepTimerPill(PlayerProvider playerProvider) {
+    final textTheme = Theme.of(context).textTheme;
+    final remaining = playerProvider.sleepTimerRemaining ?? Duration.zero;
+    return Material(
+      color: Colors.white.withValues(alpha: 0.15),
+      shape: const StadiumBorder(),
+      child: InkWell(
+        onTap: () => _showSleepTimerSheet(context, playerProvider),
+        customBorder: const StadiumBorder(),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.timer_outlined, size: 14, color: Colors.white),
+              const SizedBox(width: 4),
+              Text(
+                _formatSleepTime(remaining),
+                style: textTheme.labelMedium?.copyWith(
+                  color: Colors.white,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// AM v2 定时关闭选择面板。
+  void _showSleepTimerSheet(BuildContext rootContext, PlayerProvider player) {
+    showModalBottomSheet(
+      context: rootContext,
+      isScrollControlled: true,
+      builder: (sheetCtx) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Text(
+                  '定时关闭',
+                  style: Theme.of(rootContext).textTheme.titleMedium,
+                ),
+              ),
+              ..._sleepTimerPresets.map((d) {
+                final r = player.sleepTimerRemaining;
+                final active = r != null &&
+                    (r.inSeconds - d.inSeconds).abs() < 2;
+                return ListTile(
+                  leading: Icon(active
+                      ? Icons.radio_button_checked
+                      : Icons.radio_button_unchecked),
+                  title: Text('${d.inMinutes} 分钟'),
+                  onTap: () {
+                    player.setSleepTimer(d);
+                    Navigator.pop(sheetCtx);
+                    ScaffoldMessenger.of(rootContext).showSnackBar(
+                      SnackBar(
+                        content: Text('将在 ${d.inMinutes} 分钟后自动暂停'),
+                        behavior: SnackBarBehavior.floating,
+                      ),
+                    );
+                  },
+                );
+              }),
+              ListTile(
+                leading: const Icon(Icons.edit_outlined),
+                title: const Text('自定义…'),
+                onTap: () {
+                  Navigator.pop(sheetCtx);
+                  _showCustomSleepTimerDialog(rootContext, player);
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.cancel_outlined),
+                title: const Text('关闭定时'),
+                onTap: () {
+                  player.setSleepTimer(null);
+                  Navigator.pop(sheetCtx);
+                },
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  /// AM v2 自定义分钟数对话框。
+  void _showCustomSleepTimerDialog(
+    BuildContext rootContext,
+    PlayerProvider player,
+  ) {
+    final controller = TextEditingController();
+    showDialog(
+      context: rootContext,
+      builder: (dialogCtx) => Dialog(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(28),
+        ),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 320),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: 24,
+              vertical: 20,
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.timer_outlined, size: 32),
+                const SizedBox(height: 8),
+                const Text(
+                  '自定义定时关闭',
+                  style: TextStyle(fontSize: 16),
+                ),
+                const SizedBox(height: 16),
+                TextField(
+                  controller: controller,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(
+                    labelText: '分钟',
+                    hintText: '1-240',
+                    border: OutlineInputBorder(),
+                  ),
+                  autofocus: true,
+                ),
+                const SizedBox(height: 16),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    TextButton(
+                      onPressed: () {
+                        controller.dispose();
+                        Navigator.pop(dialogCtx);
+                      },
+                      child: const Text('取消'),
+                    ),
+                    FilledButton(
+                      onPressed: () {
+                        final n = int.tryParse(controller.text);
+                        controller.dispose();
+                        if (n == null || n < 1 || n > 240) {
+                          ScaffoldMessenger.of(rootContext).showSnackBar(
+                            const SnackBar(
+                              content: Text('请输入 1-240 之间的整数'),
+                              behavior: SnackBarBehavior.floating,
+                            ),
+                          );
+                          return;
+                        }
+                        final d = Duration(minutes: n);
+                        player.setSleepTimer(d);
+                        Navigator.pop(dialogCtx);
+                        ScaffoldMessenger.of(rootContext).showSnackBar(
+                          SnackBar(
+                            content: Text('将在 $n 分钟后自动暂停'),
+                            behavior: SnackBarBehavior.floating,
+                          ),
+                        );
+                      },
+                      child: const Text('确定'),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// AM v2 睡眠定时剩余时间格式：>=1h 显示 `XhYYm`，否则 `mm:ss`。
+  String _formatSleepTime(Duration d) {
+    if (d.inHours >= 1) {
+      final h = d.inHours;
+      final m = d.inMinutes.remainder(60);
+      return '${h}h${m.toString().padLeft(2, '0')}m';
+    }
+    final m = d.inMinutes;
+    final s = d.inSeconds.remainder(60);
+    return '${m.toString().padLeft(2, '0')}:${s.toString().padLeft(2, '0')}';
   }
 
   /// 弹出 DLNA 投屏二级菜单（设备选择 + 传输控制）。

--- a/lib/providers/dlna_provider.dart
+++ b/lib/providers/dlna_provider.dart
@@ -1,9 +1,12 @@
 import 'dart:async';
 
+import 'package:dlna_dart/xmlParser.dart' show AudioMime, PlayType;
 import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 
 import '../core/services/dlna_service.dart';
+import '../core/services/local_http_server.dart';
+import '../core/services/media_store_service.dart';
 import '../data/models/song.dart';
 import 'player_provider.dart';
 import '../services/kugou_api/kugou_api_client.dart';
@@ -128,44 +131,75 @@ class DlnaProvider extends ChangeNotifier {
     }
   }
 
-  /// 投屏歌曲：获取在线播放 URL → cast → 暂停本地播放。
+  /// 投屏歌曲：在线歌曲走酷狗 URL，本地歌曲走 LocalHttpServer 暴露的 HTTP URL。
   /// [preserveWasPlaying] 为 true 时不覆盖 _wasPlayingBefore（切歌场景）。
   Future<void> castSong(BuildContext context, Song song,
       {bool preserveWasPlaying = false}) async {
-    if (!song.isOnline) {
-      _state = DlnaCastState.error;
-      _errorMessage = '本地歌曲不支持投屏';
-      notifyListeners();
-      return;
-    }
-
     _state = DlnaCastState.connecting;
     _castTitle = song.displayName;
     _castMediaType = DlnaMediaType.audio;
     notifyListeners();
 
     try {
-      // 获取新鲜的播放 URL
-      final apiClient = KugouApiClient();
       final playerProvider = context.read<PlayerProvider>();
-      final result = await apiClient.getSongUrlWithFallback(
-        song.id,
-        quality: playerProvider.audioQuality.value,
-        albumId: song.albumId,
-        albumAudioId: song.albumAudioId,
-      );
+      String url;
+      PlayType? overrideType;
 
-      if (result == null || result.url.isEmpty) {
-        _state = DlnaCastState.error;
-        _errorMessage = '无法获取播放地址';
-        notifyListeners();
-        return;
+      if (song.isOnline) {
+        // ── 在线歌曲：通过酷狗 API 获取新鲜播放 URL ──
+        final apiClient = KugouApiClient();
+        final result = await apiClient.getSongUrlWithFallback(
+          song.id,
+          quality: playerProvider.audioQuality.value,
+          albumId: song.albumId,
+          albumAudioId: song.albumAudioId,
+        );
+        if (result == null || result.url.isEmpty) {
+          _state = DlnaCastState.error;
+          _errorMessage = '无法获取播放地址';
+          notifyListeners();
+          return;
+        }
+        url = result.url;
+      } else {
+        // ── 本地歌曲：通过 LocalHttpServer 暴露到局域网 ──
+        final rawPath = song.localPath;
+        if (rawPath == null || rawPath.isEmpty) {
+          _state = DlnaCastState.error;
+          _errorMessage = '本地歌曲无文件路径';
+          notifyListeners();
+          return;
+        }
+        // content:// URI 走 MediaStoreService 重新解析为真实路径
+        String filePath = rawPath;
+        if (filePath.startsWith('content://')) {
+          final resolved = await MediaStoreService.resolveLocalPath(filePath);
+          if (resolved == null || resolved.isEmpty) {
+            _state = DlnaCastState.error;
+            _errorMessage = '无法解析本地文件路径';
+            notifyListeners();
+            return;
+          }
+          filePath = resolved;
+        }
+        final httpUrl = LocalHttpServer.instance.getUrlForPath(filePath);
+        if (httpUrl == null) {
+          _state = DlnaCastState.error;
+          _errorMessage = LocalHttpServer.instance.isRunning
+              ? '请确保手机已连接 WiFi'
+              : '本地服务器未启动，请重启 App';
+          notifyListeners();
+          return;
+        }
+        url = httpUrl;
+        overrideType = _audioPlayTypeForPath(filePath);
       }
 
       final success = await _service.cast(
-        result.url,
+        url,
         title: song.displayName,
         mediaType: DlnaMediaType.audio,
+        overrideType: overrideType,
       );
 
       if (success) {
@@ -190,6 +224,21 @@ class DlnaProvider extends ChangeNotifier {
       _errorMessage = '投屏出错：$e';
       notifyListeners();
     }
+  }
+
+  /// 本地文件按扩展名映射到 dlna_dart 的 AudioMime。
+  /// 仅常见格式有专用枚举；未识别格式返回 null，由 cast() 兜底用 AudioMime.mpeg。
+  static PlayType? _audioPlayTypeForPath(String path) {
+    final lower = path.toLowerCase();
+    if (lower.endsWith('.mp3')) return AudioMime.mp3;
+    if (lower.endsWith('.flac')) return AudioMime.xFlac;
+    if (lower.endsWith('.wav')) return AudioMime.wav;
+    if (lower.endsWith('.m4a') || lower.endsWith('.aac')) {
+      return AudioMime.mp4;
+    }
+    if (lower.endsWith('.ape')) return AudioMime.xApe;
+    if (lower.endsWith('.wma')) return AudioMime.wma;
+    return null; // ogg/opus 等无对应枚举，由 cast() 兜底用 mpeg
   }
 
   /// 投屏 MV：使用已解析的 MV URL。

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -58,6 +58,12 @@ class PlayerProvider extends ChangeNotifier with WidgetsBindingObserver {
   String? _cachedArtworkPath;
   AudioQuality _audioQuality = AudioQuality.standard;
 
+  // —— 睡眠定时（到点自动暂停） ——
+  // 用 wall clock（DateTime.now()）计算剩余时间，避免 Timer 漂移；
+  // App 被杀后失效（无后台服务），符合"不持久化"决策。
+  DateTime? _sleepTimerEndTime;
+  Timer? _sleepTimerTicker;
+
   // —— 在线歌曲异常结束重试限制 ——
   // 当在线歌曲播放不足 80% 就触发 completed 时（URL 过期 / 流中断），
   // 最多重试 _maxAbnormalRetries 次；超过后跳过该歌曲，避免死循环。
@@ -80,6 +86,17 @@ class PlayerProvider extends ChangeNotifier with WidgetsBindingObserver {
   String? get resolveError => _resolveError;
   AudioQuality get audioQuality => _audioQuality;
   String get audioQualityLabel => _audioQuality.label;
+
+  /// 睡眠定时剩余时间（null = 未启用）。
+  Duration? get sleepTimerRemaining {
+    final end = _sleepTimerEndTime;
+    if (end == null) return null;
+    final left = end.difference(DateTime.now());
+    return left.isNegative ? Duration.zero : left;
+  }
+
+  /// 是否启用了睡眠定时。
+  bool get isSleepTimerActive => _sleepTimerEndTime != null;
 
   /// 当前歌曲的实际音质标签。
   /// 本地歌曲优先使用 song.quality 推断的标签，在线歌曲始终使用全局音质偏好
@@ -1673,6 +1690,36 @@ class PlayerProvider extends ChangeNotifier with WidgetsBindingObserver {
     _applyQualityToCurrent();
   }
 
+  /// 设置 / 取消睡眠定时。
+  /// [duration] 为 null 表示取消；非 null 表示 duration 后自动暂停播放。
+  void setSleepTimer(Duration? duration) {
+    _sleepTimerTicker?.cancel();
+    _sleepTimerTicker = null;
+    if (duration == null) {
+      _sleepTimerEndTime = null;
+      notifyListeners();
+      return;
+    }
+    _sleepTimerEndTime = DateTime.now().add(duration);
+    _sleepTimerTicker = Timer.periodic(const Duration(seconds: 1), (_) {
+      final end = _sleepTimerEndTime;
+      if (end == null) return;
+      final left = end.difference(DateTime.now());
+      if (left <= Duration.zero) {
+        // 到点：暂停 + 清理
+        _sleepTimerTicker?.cancel();
+        _sleepTimerTicker = null;
+        _sleepTimerEndTime = null;
+        _audioService?.pause();
+        notifyListeners();
+      } else {
+        // 每秒刷新剩余时间，让 UI 药丸走字
+        notifyListeners();
+      }
+    });
+    notifyListeners();
+  }
+
   Future<void> _applyQualityToCurrent() async {
     final song = _currentSong;
     if (song == null || !song.isOnline) return;
@@ -2009,6 +2056,8 @@ class PlayerProvider extends ChangeNotifier with WidgetsBindingObserver {
     _playerStateSubscription?.cancel();
     _sequenceStateSubscription?.cancel();
     _speedSubscription?.cancel();
+    _sleepTimerTicker?.cancel();
+    _sleepTimerTicker = null;
     super.dispose();
   }
 }


### PR DESCRIPTION
DLNA 设备无法访问手机本地文件路径，新增 LocalHttpServer 在
0.0.0.0:8888 启动 HTTP 服务器把本地音频通过局域网 URL 暴露，
支持 Range 请求（DLNA seek 必需）和按扩展名映射 MIME。

- 新增 local_http_server.dart：单例 HttpServer，端口冲突自动 尝试 8889-8898，_resolveLanIp 优先 wlan0/eth0 跳过蜂窝和 VPN 接口，getUrlForPath 统一解码后再编码避免双重 percent-encode
- main.dart 在 NodeJsServer 启动后初始化 LocalHttpServer
- dlna_service.cast() 新增 overrideType 参数支持动态 MIME
- dlna_provider.castSong() 移除本地歌曲拒绝逻辑，本地分支处理 content:// 与 file:// 前缀，按扩展名映射 AudioMime