### PR TITLE
feat: 支持已收藏无版权歌曲播放及无法播放自动跳过

### DIFF
--- a/lib/modules/player/comments_view.dart
+++ b/lib/modules/player/comments_view.dart
@@ -2,9 +2,84 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../data/models/song.dart';
 import '../../providers/kugou_provider.dart';
+import '../../services/kugou_api/kugou_api_client.dart';
 import '../../services/kugou_api/kugou_models.dart';
 import '../../widgets/md3e_loading_indicator.dart';
+
+/// 统一的评论面板入口。
+///
+/// 将歌曲菜单「看评论」与「无法播放」弹窗中的评论入口合并为同一实现：
+/// 使用 [DraggableScrollableSheet] 可拖拽调整高度，顶部为标题栏（歌名 + 关闭按钮），
+/// 内容区为 [CommentsView]。
+void showSongCommentsSheet(BuildContext context, Song song) {
+  showModalBottomSheet(
+    context: context,
+    isScrollControlled: true,
+    useSafeArea: true,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+    ),
+    builder: (sheetCtx) => DraggableScrollableSheet(
+      initialChildSize: 0.8,
+      minChildSize: 0.4,
+      maxChildSize: 0.95,
+      expand: false,
+      builder: (innerCtx, scrollController) => Column(
+        children: [
+          Container(
+            width: 32,
+            height: 4,
+            margin: const EdgeInsets.only(top: 12, bottom: 8),
+            decoration: BoxDecoration(
+              color: Theme.of(innerCtx).colorScheme.outline,
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    '评论: ${song.displayName}',
+                    style: Theme.of(innerCtx).textTheme.titleSmall,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.close),
+                  onPressed: () => Navigator.of(innerCtx).pop(),
+                ),
+              ],
+            ),
+          ),
+          const Divider(height: 1),
+          Expanded(
+            child: CommentsView(
+              songHash: song.id,
+              albumAudioId: song.albumAudioId,
+              artworkUri: song.artworkUri,
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+/// 楼层评论状态
+class _FloorState {
+  bool expanded = false;
+  bool loading = false;
+  bool initialized = false;
+  List<KugouComment> replies = [];
+  int total = 0;
+  int page = 1;
+  bool hasMore = true;
+  String message = '';
+}
 
 /// 评论列表视图。
 ///
@@ -14,11 +89,12 @@ import '../../widgets/md3e_loading_indicator.dart';
 /// - MD3 风格（[isAmStyle] = false，默认）：跟随莫奈色主题，用户名用主色调，
 ///   评论正文和时间戳根据深浅色模式自动适配。
 ///
-/// **分页加载**：滚动到底部自动加载下一页评论。
-///
-/// **mask alpha 渐变**：列表顶部/底部各 24px 范围用 ShaderMask + BlendMode.dstIn
-/// 实现 alpha 渐变（比歌词页更窄），让滚动内容从背景柔和淡入、淡出到背景，
-/// 避免列表硬切边。
+/// **功能**：
+/// - 热门评论/歌手评论置顶展示，带徽章标识
+/// - 楼层评论（楼中楼），点击"查看N条回复"展开
+/// - 长评论展开/收起（超过 120 字或 3 行）
+/// - 点赞数格式化（10000+ → "1w"）
+/// - 滚动到底部自动加载下一页
 class CommentsView extends StatefulWidget {
   final String songHash;
   final String? albumAudioId;
@@ -44,11 +120,18 @@ class CommentsView extends StatefulWidget {
 class _CommentsViewState extends State<CommentsView> {
   final ScrollController _scrollController = ScrollController();
   List<KugouComment> _comments = [];
+  List<KugouComment> _hotComments = [];
   bool _isLoading = false;
   bool _isLoadingMore = false;
   String? _error;
   int _currentPage = 1;
   bool _hasMore = true;
+
+  /// 长评论展开状态
+  final Set<String> _expandedContents = {};
+
+  /// 楼层评论状态（按评论 ID 索引）
+  final Map<String, _FloorState> _floorStates = {};
 
   @override
   void initState() {
@@ -73,6 +156,9 @@ class _CommentsViewState extends State<CommentsView> {
       _currentPage = 1;
       _hasMore = true;
       _comments.clear();
+      _hotComments.clear();
+      _expandedContents.clear();
+      _floorStates.clear();
       WidgetsBinding.instance.addPostFrameCallback((_) {
         _fetchComments();
       });
@@ -104,12 +190,14 @@ class _CommentsViewState extends State<CommentsView> {
     if (mounted) {
       setState(() {
         _isLoading = false;
-        if (result != null && result.comments.isNotEmpty) {
+        if (result != null) {
           _comments = result.comments;
+          _hotComments = result.hotComments;
           _currentPage = 1;
           _hasMore = result.comments.length >= 20;
         } else {
           _comments = [];
+          _hotComments = [];
           _hasMore = false;
         }
         _error = kugouProvider.error;
@@ -143,262 +231,109 @@ class _CommentsViewState extends State<CommentsView> {
     }
   }
 
-  @override
-  Widget build(BuildContext context) {
-    // 根据风格和主题计算颜色
-    final Color primaryTextColor;
-    final Color secondaryTextColor;
-    final Color usernameColor;
+  // ---- 长评论展开/收起 ----
 
-    if (widget.isAmStyle) {
-      // AM 风格：固定白色文字
-      primaryTextColor = Colors.white;
-      secondaryTextColor = const Color(0xB3FFFFFF);
-      usernameColor = const Color(0xB3FFFFFF);
-    } else {
-      // MD3 风格：跟随莫奈色主题
-      final colorScheme = Theme.of(context).colorScheme;
-      primaryTextColor = colorScheme.onSurface;
-      secondaryTextColor = colorScheme.onSurfaceVariant;
-      usernameColor = colorScheme.primary;
-    }
-
-    if (_isLoading) {
-      return Center(
-        child: MD3ELoadingIndicator(color: primaryTextColor),
-      );
-    }
-
-    if (_error != null) {
-      return Center(
-        child: Padding(
-          padding: const EdgeInsets.all(32),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Icon(
-                Icons.error_outline,
-                size: 48,
-                color: secondaryTextColor,
-              ),
-              const SizedBox(height: 12),
-              Text(
-                '加载评论失败',
-                style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  color: secondaryTextColor,
-                ),
-              ),
-              const SizedBox(height: 16),
-              TextButton(
-                onPressed: _fetchComments,
-                style: TextButton.styleFrom(foregroundColor: primaryTextColor),
-                child: const Text('重试'),
-              ),
-            ],
-          ),
-        ),
-      );
-    }
-
-    if (_comments.isEmpty) {
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              Icons.comment_outlined,
-              size: 48,
-              color: secondaryTextColor,
-            ),
-            const SizedBox(height: 12),
-            Text(
-              '暂无评论',
-              style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                color: secondaryTextColor,
-              ),
-            ),
-          ],
-        ),
-      );
-    }
-
-    // 用 ShaderMask + BlendMode.dstIn 实现上下 alpha 渐变：
-    // 顶部 24px alpha 0→1，底部 24px alpha 1→0，
-    // 比 lyrics 视图更窄，让评论从背景柔和淡入、淡出到背景。
-    return ShaderMask(
-      shaderCallback: (Rect bounds) {
-        const double fadeHeight = 24.0;
-        final double fadeRatio = (fadeHeight / bounds.height).clamp(0.0, 0.5);
-        return LinearGradient(
-          begin: Alignment.topCenter,
-          end: Alignment.bottomCenter,
-          colors: const [
-            Colors.transparent,
-            Colors.black,
-            Colors.black,
-            Colors.transparent,
-          ],
-          stops: [
-            0.0,
-            fadeRatio,
-            1.0 - fadeRatio,
-            1.0,
-          ],
-        ).createShader(bounds);
-      },
-      blendMode: BlendMode.dstIn,
-      child: ListView.separated(
-        controller: _scrollController,
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        itemCount: _comments.length + (_hasMore ? 1 : 0),
-        separatorBuilder: (_, _) => Divider(
-          height: 1,
-          color: secondaryTextColor.withValues(alpha: 0.2),
-        ),
-        itemBuilder: (context, index) {
-          if (index == _comments.length) {
-            return Center(
-              child: Padding(
-                padding: const EdgeInsets.all(16),
-                child: _isLoadingMore
-                    ? MD3ELoadingIndicator(
-                        size: 24,
-                        color: primaryTextColor,
-                      )
-                    : TextButton(
-                        onPressed: _loadMore,
-                        style: TextButton.styleFrom(
-                          foregroundColor: primaryTextColor,
-                        ),
-                        child: const Text('加载更多'),
-                      ),
-              ),
-            );
-          }
-          final comment = _comments[index];
-          return _buildCommentItem(
-            comment,
-            primaryTextColor,
-            secondaryTextColor,
-            usernameColor,
-          );
-        },
-      ),
-    );
+  bool _needsTruncate(String content) {
+    return content.length > 120;
   }
 
-  Widget _buildCommentItem(
-    KugouComment comment,
-    Color primaryTextColor,
-    Color secondaryTextColor,
-    Color usernameColor,
-  ) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 12),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          _buildAvatar(comment, usernameColor),
-          const SizedBox(width: 12),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    Flexible(
-                      child: Text(
-                        comment.username,
-                        style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                          color: usernameColor,
-                          fontWeight: FontWeight.w500,
-                        ),
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                    const SizedBox(width: 8),
-                    Text(
-                      _formatTime(comment.time),
-                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                        color: secondaryTextColor.withValues(alpha: 0.6),
-                      ),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 4),
-                Text(
-                  comment.content,
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    color: primaryTextColor,
-                    height: 1.4,
-                  ),
-                ),
-                if (comment.likes > 0) ...[
-                  const SizedBox(height: 6),
-                  Row(
-                    children: [
-                      Icon(
-                        Icons.thumb_up_outlined,
-                        size: 12,
-                        color: secondaryTextColor.withValues(alpha: 0.5),
-                      ),
-                      const SizedBox(width: 4),
-                      Text(
-                        '${comment.likes}',
-                        style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                          color: secondaryTextColor.withValues(alpha: 0.5),
-                        ),
-                      ),
-                    ],
-                  ),
-                ],
-              ],
-            ),
-          ),
-        ],
-      ),
-    );
+  void _toggleContent(String id) {
+    setState(() {
+      if (_expandedContents.contains(id)) {
+        _expandedContents.remove(id);
+      } else {
+        _expandedContents.add(id);
+      }
+    });
   }
 
-  /// 构建评论用户头像。
-  /// 优先使用 API 返回的头像 URL，加载失败或无头像时回退到首字母圆形头像。
-  Widget _buildAvatar(KugouComment comment, Color usernameColor) {
-    final avatarUrl = _fixAvatarUrl(comment.avatar);
+  // ---- 楼层评论 ----
 
-    if (avatarUrl != null && avatarUrl.isNotEmpty) {
-      return CircleAvatar(
-        radius: 18,
-        backgroundColor: usernameColor.withValues(alpha: 0.15),
-        child: ClipOval(
-          child: CachedNetworkImage(
-            imageUrl: avatarUrl,
-            width: 36,
-            height: 36,
-            fit: BoxFit.cover,
-            placeholder: (_, _) => _buildTextAvatar(comment, usernameColor),
-            errorWidget: (_, _, _) => _buildTextAvatar(comment, usernameColor),
-          ),
-        ),
-      );
+  _FloorState _getFloorState(String commentId) {
+    return _floorStates.putIfAbsent(commentId, () => _FloorState());
+  }
+
+  Future<void> _fetchFloorReplies(KugouComment comment,
+      {bool reset = false}) async {
+    final state = _getFloorState(comment.id);
+    if (state.loading) return;
+    if (!state.hasMore && !reset) return;
+
+    if (reset) {
+      state.page = 1;
+      state.replies = [];
+      state.hasMore = true;
+      state.message = '';
     }
 
-    return _buildTextAvatar(comment, usernameColor);
+    setState(() => state.loading = true);
+
+    final specialId = comment.specialId ?? '';
+    final tid = comment.tid ?? comment.id;
+    final mixSongId = comment.mixSongId ?? widget.albumAudioId;
+
+    if (specialId.isEmpty || tid.isEmpty) {
+      state.message = '楼层评论暂不可用';
+      state.hasMore = false;
+      if (mounted) setState(() => state.loading = false);
+      return;
+    }
+
+    try {
+      final api = KugouApiClient();
+      final result = await api.getFloorComments(
+        specialId: specialId,
+        tid: tid,
+        mixSongId: mixSongId?.isNotEmpty == true ? mixSongId : null,
+        code: comment.code,
+        page: state.page,
+      );
+
+      if (result != null) {
+        final replies = result.comments;
+        state.replies = reset ? replies : [...state.replies, ...replies];
+        state.total = result.total;
+        state.hasMore = state.total > 0
+            ? state.replies.length < state.total
+            : replies.length >= 30;
+        if (state.hasMore) state.page++;
+        if (state.replies.isEmpty) {
+          state.message = '暂无回复';
+        }
+      } else {
+        state.message = '楼层评论暂不可用';
+        state.hasMore = false;
+      }
+    } catch (_) {
+      state.message = '加载失败，点击重试';
+    } finally {
+      state.initialized = true;
+      if (mounted) setState(() => state.loading = false);
+    }
   }
 
-  Widget _buildTextAvatar(KugouComment comment, Color usernameColor) {
-    return CircleAvatar(
-      radius: 18,
-      backgroundColor: usernameColor.withValues(alpha: 0.15),
-      child: Text(
-        comment.username.isNotEmpty ? comment.username[0] : '?',
-        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-          color: usernameColor,
-        ),
-      ),
-    );
+  void _toggleFloor(KugouComment comment) {
+    final state = _getFloorState(comment.id);
+    setState(() {
+      if (!state.expanded) {
+        state.expanded = true;
+        if (!state.initialized) {
+          _fetchFloorReplies(comment, reset: true);
+        }
+      } else {
+        state.expanded = false;
+      }
+    });
   }
 
-  /// 修复头像 URL：http → https
+  // ---- 工具方法 ----
+
+  String _formatLike(int value) {
+    if (value < 10000) return value.toString();
+    final fixed = (value / 10000).toStringAsFixed(value >= 100000 ? 0 : 1);
+    return '${fixed.replaceAll(RegExp(r'\.0$'), '')}w';
+  }
+
   String? _fixAvatarUrl(String? url) {
     if (url == null || url.isEmpty) return null;
     if (url.startsWith('http://')) {
@@ -418,4 +353,597 @@ class _CommentsViewState extends State<CommentsView> {
     if (diff.inDays < 7) return '${diff.inDays}天前';
     return '${date.month}月${date.day}日';
   }
+
+  @override
+  Widget build(BuildContext context) {
+    final Color primaryTextColor;
+    final Color secondaryTextColor;
+    final Color usernameColor;
+
+    if (widget.isAmStyle) {
+      primaryTextColor = Colors.white;
+      secondaryTextColor = const Color(0xB3FFFFFF);
+      usernameColor = const Color(0xB3FFFFFF);
+    } else {
+      final colorScheme = Theme.of(context).colorScheme;
+      primaryTextColor = colorScheme.onSurface;
+      secondaryTextColor = colorScheme.onSurfaceVariant;
+      usernameColor = colorScheme.primary;
+    }
+
+    if (_isLoading) {
+      return Center(
+        child: MD3ELoadingIndicator(color: primaryTextColor),
+      );
+    }
+
+    if (_error != null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(Icons.error_outline, size: 48, color: secondaryTextColor),
+              const SizedBox(height: 12),
+              Text(
+                '加载评论失败',
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      color: secondaryTextColor,
+                    ),
+              ),
+              const SizedBox(height: 16),
+              TextButton(
+                onPressed: _fetchComments,
+                style: TextButton.styleFrom(foregroundColor: primaryTextColor),
+                child: const Text('重试'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    if (_comments.isEmpty && _hotComments.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.comment_outlined, size: 48, color: secondaryTextColor),
+            const SizedBox(height: 12),
+            Text(
+              '暂无评论',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: secondaryTextColor,
+                  ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    // 构建显示列表：热门评论 + 全部评论
+    final displayItems = <_CommentDisplayItem>[];
+
+    if (_hotComments.isNotEmpty) {
+      displayItems.add(_CommentDisplayItem.header('热门评论'));
+      for (final c in _hotComments) {
+        displayItems.add(_CommentDisplayItem.comment(c));
+      }
+      if (_comments.isNotEmpty) {
+        displayItems.add(_CommentDisplayItem.header('最新评论'));
+      }
+    }
+    for (final c in _comments) {
+      displayItems.add(_CommentDisplayItem.comment(c));
+    }
+
+    return ShaderMask(
+      shaderCallback: (Rect bounds) {
+        const double fadeHeight = 24.0;
+        final double fadeRatio = (fadeHeight / bounds.height).clamp(0.0, 0.5);
+        return LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: const [
+            Colors.transparent,
+            Colors.black,
+            Colors.black,
+            Colors.transparent,
+          ],
+          stops: [0.0, fadeRatio, 1.0 - fadeRatio, 1.0],
+        ).createShader(bounds);
+      },
+      blendMode: BlendMode.dstIn,
+      child: ListView.builder(
+        controller: _scrollController,
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        itemCount: displayItems.length + (_hasMore ? 1 : 0),
+        itemBuilder: (context, index) {
+          if (index == displayItems.length) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: _isLoadingMore
+                    ? MD3ELoadingIndicator(
+                        size: 24, color: primaryTextColor)
+                    : TextButton(
+                        onPressed: _loadMore,
+                        style: TextButton.styleFrom(
+                          foregroundColor: primaryTextColor,
+                        ),
+                        child: const Text('加载更多'),
+                      ),
+              ),
+            );
+          }
+
+          final item = displayItems[index];
+          if (item.isHeader) {
+            return _buildSectionHeader(
+              item.headerTitle!,
+              primaryTextColor,
+            );
+          }
+          return _buildCommentItem(
+            item.comment!,
+            primaryTextColor,
+            secondaryTextColor,
+            usernameColor,
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildSectionHeader(String title, Color color) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 16, bottom: 8),
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.labelLarge?.copyWith(
+              color: color,
+              fontWeight: FontWeight.bold,
+            ),
+      ),
+    );
+  }
+
+  Widget _buildCommentItem(
+    KugouComment comment,
+    Color primaryTextColor,
+    Color secondaryTextColor,
+    Color usernameColor,
+  ) {
+    final floorState = _floorStates[comment.id];
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 12),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _buildAvatar(comment, usernameColor),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // 用户名 + 徽章 + 时间
+                Row(
+                  children: [
+                    Flexible(
+                      child: Text(
+                        comment.username,
+                        style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                              color: usernameColor,
+                              fontWeight: FontWeight.w500,
+                            ),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    if (comment.isStar) ...[
+                      const SizedBox(width: 6),
+                      _buildBadge('歌手', usernameColor),
+                    ],
+                    if (comment.isHot) ...[
+                      const SizedBox(width: 6),
+                      _buildBadge('热门', usernameColor),
+                    ],
+                    const SizedBox(width: 8),
+                    Text(
+                      _formatTime(comment.time),
+                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                            color: secondaryTextColor.withValues(alpha: 0.6),
+                          ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 4),
+                // 评论内容（长评论展开/收起，带动画）
+                AnimatedSize(
+                  duration: const Duration(milliseconds: 200),
+                  curve: Curves.easeInOut,
+                  alignment: Alignment.topLeft,
+                  child: _buildContent(
+                      comment, primaryTextColor, secondaryTextColor),
+                ),
+                // 点赞 + 回复
+                const SizedBox(height: 6),
+                Row(
+                  children: [
+                    if (comment.likes > 0) ...[
+                      Icon(
+                        Icons.thumb_up_outlined,
+                        size: 12,
+                        color: secondaryTextColor.withValues(alpha: 0.5),
+                      ),
+                      const SizedBox(width: 4),
+                      Text(
+                        _formatLike(comment.likes),
+                        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                              color: secondaryTextColor.withValues(alpha: 0.5),
+                            ),
+                      ),
+                    ],
+                    // 回复按钮
+                    if (comment.replyCount > 0) ...[
+                      const SizedBox(width: 16),
+                      GestureDetector(
+                        onTap: () => _toggleFloor(comment),
+                        child: Row(
+                          children: [
+                            AnimatedRotation(
+                              turns: floorState?.expanded == true ? 0.5 : 0,
+                              duration: const Duration(milliseconds: 200),
+                              child: Icon(
+                                Icons.expand_more,
+                                size: 14,
+                                color: usernameColor,
+                              ),
+                            ),
+                            const SizedBox(width: 4),
+                            Text(
+                              floorState?.expanded == true
+                                  ? '收起回复'
+                                  : '查看${comment.replyCount}条回复',
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .labelSmall
+                                  ?.copyWith(
+                                    color: usernameColor,
+                                  ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+                // 楼层评论（带展开动画）
+                AnimatedSize(
+                  duration: const Duration(milliseconds: 250),
+                  curve: Curves.easeInOut,
+                  alignment: Alignment.topLeft,
+                  child: floorState?.expanded == true
+                      ? _buildFloorReplies(
+                          comment,
+                          floorState!,
+                          primaryTextColor,
+                          secondaryTextColor,
+                          usernameColor,
+                        )
+                      : const SizedBox.shrink(),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildContent(
+    KugouComment comment,
+    Color primaryTextColor,
+    Color secondaryTextColor,
+  ) {
+    final content = comment.content;
+    if (!_needsTruncate(content) || _expandedContents.contains(comment.id)) {
+      return RichText(
+        text: TextSpan(
+          children: [
+            TextSpan(
+              text: content,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: primaryTextColor,
+                    height: 1.4,
+                  ),
+            ),
+            if (_needsTruncate(content) &&
+                _expandedContents.contains(comment.id))
+              WidgetSpan(
+                child: GestureDetector(
+                  onTap: () => _toggleContent(comment.id),
+                  child: Text(
+                    ' 收起',
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                          color: secondaryTextColor,
+                        ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      );
+    }
+
+    return RichText(
+      text: TextSpan(
+        children: [
+          TextSpan(
+            text: '${content.substring(0, 120)}...',
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: primaryTextColor,
+                  height: 1.4,
+                ),
+          ),
+          WidgetSpan(
+            child: GestureDetector(
+              onTap: () => _toggleContent(comment.id),
+              child: Text(
+                '展开',
+                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                      color: secondaryTextColor,
+                    ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBadge(String text, Color color) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: color.withValues(alpha: 0.2)),
+      ),
+      child: Text(
+        text,
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: color,
+              fontSize: 10,
+              fontWeight: FontWeight.bold,
+            ),
+      ),
+    );
+  }
+
+  Widget _buildFloorReplies(
+    KugouComment comment,
+    _FloorState state,
+    Color primaryTextColor,
+    Color secondaryTextColor,
+    Color usernameColor,
+  ) {
+    return Container(
+      margin: const EdgeInsets.only(top: 10),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: secondaryTextColor.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 回复列表
+          for (final reply in state.replies)
+            _buildFloorReplyItem(
+              reply,
+              primaryTextColor,
+              secondaryTextColor,
+              usernameColor,
+            ),
+          // 加载中
+          if (state.loading)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              child: Center(
+                child: MD3ELoadingIndicator(size: 16, color: usernameColor),
+              ),
+            ),
+          // 空状态
+          if (!state.loading &&
+              state.initialized &&
+              state.replies.isEmpty)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              child: Center(
+                child: Text(
+                  state.message.isNotEmpty ? state.message : '暂无回复',
+                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                        color: secondaryTextColor,
+                      ),
+                ),
+              ),
+            ),
+          // 加载更多
+          if (state.hasMore &&
+              !state.loading &&
+              state.replies.isNotEmpty)
+            Center(
+              child: GestureDetector(
+                onTap: () => _fetchFloorReplies(comment),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 6),
+                  child: Text(
+                    state.message.contains('失败')
+                        ? '加载失败，点击重试'
+                        : '加载更多回复',
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                          color: usernameColor,
+                        ),
+                  ),
+                ),
+              ),
+            ),
+          // 全部加载完
+          if (!state.hasMore &&
+              !state.loading &&
+              state.replies.isNotEmpty)
+            Center(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                child: Text(
+                  '已加载全部回复',
+                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                        color: secondaryTextColor.withValues(alpha: 0.5),
+                        fontSize: 10,
+                      ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFloorReplyItem(
+    KugouComment reply,
+    Color primaryTextColor,
+    Color secondaryTextColor,
+    Color usernameColor,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _buildSmallAvatar(reply, usernameColor),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Flexible(
+                      child: Text(
+                        reply.username,
+                        style:
+                            Theme.of(context).textTheme.labelSmall?.copyWith(
+                                  color: usernameColor,
+                                  fontWeight: FontWeight.w500,
+                                ),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    const SizedBox(width: 6),
+                    Text(
+                      _formatTime(reply.time),
+                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                            color: secondaryTextColor.withValues(alpha: 0.5),
+                            fontSize: 10,
+                          ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  reply.content,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: primaryTextColor,
+                        height: 1.3,
+                      ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAvatar(KugouComment comment, Color usernameColor) {
+    final avatarUrl = _fixAvatarUrl(comment.avatar);
+    if (avatarUrl != null && avatarUrl.isNotEmpty) {
+      return CircleAvatar(
+        radius: 18,
+        backgroundColor: usernameColor.withValues(alpha: 0.15),
+        child: ClipOval(
+          child: CachedNetworkImage(
+            imageUrl: avatarUrl,
+            width: 36,
+            height: 36,
+            fit: BoxFit.cover,
+            placeholder: (_, _) => _buildTextAvatar(comment, usernameColor),
+            errorWidget: (_, _, _) => _buildTextAvatar(comment, usernameColor),
+          ),
+        ),
+      );
+    }
+    return _buildTextAvatar(comment, usernameColor);
+  }
+
+  Widget _buildSmallAvatar(KugouComment comment, Color usernameColor) {
+    final avatarUrl = _fixAvatarUrl(comment.avatar);
+    if (avatarUrl != null && avatarUrl.isNotEmpty) {
+      return CircleAvatar(
+        radius: 12,
+        backgroundColor: usernameColor.withValues(alpha: 0.15),
+        child: ClipOval(
+          child: CachedNetworkImage(
+            imageUrl: avatarUrl,
+            width: 24,
+            height: 24,
+            fit: BoxFit.cover,
+            placeholder: (_, _) => _buildSmallTextAvatar(comment, usernameColor),
+            errorWidget: (_, _, _) =>
+                _buildSmallTextAvatar(comment, usernameColor),
+          ),
+        ),
+      );
+    }
+    return _buildSmallTextAvatar(comment, usernameColor);
+  }
+
+  Widget _buildTextAvatar(KugouComment comment, Color usernameColor) {
+    return CircleAvatar(
+      radius: 18,
+      backgroundColor: usernameColor.withValues(alpha: 0.15),
+      child: Text(
+        comment.username.isNotEmpty ? comment.username[0] : '?',
+        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              color: usernameColor,
+            ),
+      ),
+    );
+  }
+
+  Widget _buildSmallTextAvatar(KugouComment comment, Color usernameColor) {
+    return CircleAvatar(
+      radius: 12,
+      backgroundColor: usernameColor.withValues(alpha: 0.15),
+      child: Text(
+        comment.username.isNotEmpty ? comment.username[0] : '?',
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: usernameColor,
+              fontSize: 11,
+            ),
+      ),
+    );
+  }
+}
+
+/// 显示列表项（header 或 comment）
+class _CommentDisplayItem {
+  final String? headerTitle;
+  final KugouComment? comment;
+
+  bool get isHeader => headerTitle != null;
+
+  _CommentDisplayItem.header(this.headerTitle) : comment = null;
+  _CommentDisplayItem.comment(this.comment) : headerTitle = null;
 }

--- a/lib/modules/playlist/playlist_page.dart
+++ b/lib/modules/playlist/playlist_page.dart
@@ -1003,9 +1003,9 @@ class _PlaylistPageState extends State<PlaylistPage> {
         // 避免断网重进歌单时被空响应覆盖掉本地缓存的歌曲
         if (all.isNotEmpty || _songs.isEmpty) {
           _songs = all.where((song) {
-            final validTitle = song.title.isNotEmpty && song.title != '-';
-            final validDuration = song.duration.inMilliseconds > 0;
-            return validTitle && validDuration;
+            // 只过滤标题为空的歌曲；保留时长未知（duration=0）的歌曲，
+            // 部分无版权/信息不全的歌曲（如 "白菊 -shiragiku-"）可能缺少时长字段。
+            return song.title.isNotEmpty && song.title != '-';
           }).toList();
         }
         _invalidateDisplaySongs();

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -1809,42 +1809,7 @@ class PlayerProvider extends ChangeNotifier with WidgetsBindingObserver {
           TextButton(
             onPressed: () {
               Navigator.pop(dialogCtx);
-              showModalBottomSheet(
-                context: ctx,
-                isScrollControlled: true,
-                useSafeArea: true,
-                shape: const RoundedRectangleBorder(
-                  borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
-                ),
-                builder: (sheetCtx) => SizedBox(
-                  height: MediaQuery.of(sheetCtx).size.height * 0.75,
-                  child: Column(
-                    children: [
-                      Container(
-                        width: 32,
-                        height: 4,
-                        margin: const EdgeInsets.only(top: 12, bottom: 12),
-                        decoration: BoxDecoration(
-                          color: Theme.of(sheetCtx).colorScheme.outline,
-                          borderRadius: BorderRadius.circular(2),
-                        ),
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.only(bottom: 8),
-                        child: Text('评论',
-                          style: Theme.of(sheetCtx).textTheme.titleMedium),
-                      ),
-                      Expanded(
-                        child: CommentsView(
-                          songHash: song.id,
-                          albumAudioId: song.albumAudioId,
-                          artworkUri: song.artworkUri,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              );
+              showSongCommentsSheet(ctx, song);
             },
             child: const Text('看评论'),
           ),

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:just_audio/just_audio.dart' as just_audio;
 import 'package:provider/provider.dart';
@@ -14,6 +15,8 @@ import '../core/services/media_notification_service.dart';
 import '../core/services/wakelock_service.dart';
 import '../core/services/media_store_service.dart';
 import '../data/models/song.dart';
+import '../modules/player/comments_view.dart';
+import '../modules/player/mv_player_page.dart';
 import '../core/utils/audio_scanner.dart';
 import '../data/repositories/history_repository.dart';
 import '../data/repositories/player_state_repository.dart';
@@ -667,7 +670,13 @@ class PlayerProvider extends ChangeNotifier with WidgetsBindingObserver {
         } else {
           _isResolvingUrl = false;
           _resolveError = '无法获取播放链接';
+          final failedSong = _currentSong!;
           notifyListeners();
+          // 先弹窗提示，随即切到下一首（不阻塞）
+          _showUnplayableSongDialog(failedSong);
+          if (_playlist.length > 1) {
+            await next(autoPlay: true);
+          }
         }
       } catch (e) {
         _isResolvingUrl = false;
@@ -782,7 +791,13 @@ class PlayerProvider extends ChangeNotifier with WidgetsBindingObserver {
         } else {
           _isResolvingUrl = false;
           _resolveError = '无法获取播放链接';
+          final failedSong = _currentSong!;
           notifyListeners();
+          // 先弹窗提示，随即切到下一首（不阻塞）
+          _showUnplayableSongDialog(failedSong);
+          if (_playlist.length > 1) {
+            await next(autoPlay: true);
+          }
         }
       }
     } catch (e) {
@@ -1238,22 +1253,41 @@ class PlayerProvider extends ChangeNotifier with WidgetsBindingObserver {
       return;
     }
 
-    final nextIndex = (_currentIndex + 1) % _playlist.length;
-    _currentIndex = nextIndex;
-    _currentSong = _playlist[nextIndex];
-    _resolveError = null;
-    _position = Duration.zero; // 切歌时重置位置，避免恢复时跳到上一首的进度
-    _recordHistory(_currentSong!);
-    _updateNotification();
-    _saveState();
+    final startIndex = _currentIndex;
+    // 自动跳过无法获取播放链接的歌曲，直到找到可播放的或全部试过
+    for (int i = 0; i < _playlist.length; i++) {
+      final nextIndex = (_currentIndex + 1) % _playlist.length;
+      // 绕回起点：所有歌曲都试过了
+      if (nextIndex == startIndex) break;
 
-    final ok = await _resolveAndPlayCurrentSong(play: autoPlay);
-    if (!ok) {
+      _currentIndex = nextIndex;
+      _currentSong = _playlist[nextIndex];
+      _resolveError = null;
+      _position = Duration.zero; // 切歌时重置位置，避免恢复时跳到上一首的进度
+      _recordHistory(_currentSong!);
+      _updateNotification();
+      _saveState();
+
+      final ok = await _resolveAndPlayCurrentSong(play: autoPlay);
+      if (ok) {
+        // 切歌后刷新通知栏：_resolveAndPlayCurrentSong 可能更新了 _cachedArtworkPath，
+        // 投屏场景下 play=false 不会触发 playingStream 回调刷新通知，
+        // 需要在此显式刷新，避免 MediaSession 封面停留在上一首。
+        _updateNotification();
+        notifyListeners();
+        return;
+      }
+      // 无法获取链接，继续尝试下一首
       _resolveError = '无法获取播放链接';
+
+      // 非列表循环模式下，到末尾就停止尝试
+      if (_currentIndex >= _playlist.length - 1 &&
+          _loopMode != AppLoopMode.all) {
+        break;
+      }
     }
-    // 切歌后刷新通知栏：_resolveAndPlayCurrentSong 可能更新了 _cachedArtworkPath，
-    // 投屏场景下 play=false 不会触发 playingStream 回调刷新通知，
-    // 需要在此显式刷新，避免 MediaSession 封面停留在上一首。
+
+    // 所有歌曲都试过仍失败
     _updateNotification();
     notifyListeners();
   }
@@ -1312,7 +1346,14 @@ class PlayerProvider extends ChangeNotifier with WidgetsBindingObserver {
     _saveState();
     notifyListeners();
 
-    await _resolveAndPlayCurrentSong();
+    final ok = await _resolveAndPlayCurrentSong();
+    if (!ok && _playlist.length > 1) {
+      // 手动选歌无法播放时，先弹窗提示，随即切到下一首（不阻塞）
+      _resolveError = '无法获取播放链接';
+      final failedSong = _currentSong!;
+      _showUnplayableSongDialog(failedSong);
+      await next(autoPlay: true);
+    }
   }
 
   Future<void> clearPlaylist() async {
@@ -1739,6 +1780,77 @@ class PlayerProvider extends ChangeNotifier with WidgetsBindingObserver {
     }
     _lastNotificationUpdate = now;
     _updateNotification();
+  }
+
+  /// 手动选歌无法播放时，弹出提示对话框（提供查看 MV 和评论的入口）。
+  /// 通过 [appNavigatorKey] 获取全局 context，不依赖具体 widget 重建。
+  void _showUnplayableSongDialog(Song song) {
+    final ctx = appNavigatorKey.currentContext;
+    if (ctx == null) return;
+    showDialog(
+      context: ctx,
+      builder: (dialogCtx) => AlertDialog(
+        title: const Text('歌曲无法播放'),
+        content: Text('「${song.displayName}」暂时无法播放，将切换到下一首'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogCtx),
+            child: const Text('关闭'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.pop(dialogCtx);
+              Navigator.push(ctx,
+                MaterialPageRoute(builder: (_) => MvPlayerPage(song: song)),
+              );
+            },
+            child: const Text('去看MV'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.pop(dialogCtx);
+              showModalBottomSheet(
+                context: ctx,
+                isScrollControlled: true,
+                useSafeArea: true,
+                shape: const RoundedRectangleBorder(
+                  borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+                ),
+                builder: (sheetCtx) => SizedBox(
+                  height: MediaQuery.of(sheetCtx).size.height * 0.75,
+                  child: Column(
+                    children: [
+                      Container(
+                        width: 32,
+                        height: 4,
+                        margin: const EdgeInsets.only(top: 12, bottom: 12),
+                        decoration: BoxDecoration(
+                          color: Theme.of(sheetCtx).colorScheme.outline,
+                          borderRadius: BorderRadius.circular(2),
+                        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 8),
+                        child: Text('评论',
+                          style: Theme.of(sheetCtx).textTheme.titleMedium),
+                      ),
+                      Expanded(
+                        child: CommentsView(
+                          songHash: song.id,
+                          albumAudioId: song.albumAudioId,
+                          artworkUri: song.artworkUri,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            },
+            child: const Text('看评论'),
+          ),
+        ],
+      ),
+    );
   }
 
   void _updateNotification() {

--- a/lib/services/kugou_api/kugou_api_client.dart
+++ b/lib/services/kugou_api/kugou_api_client.dart
@@ -1384,13 +1384,36 @@ class KugouApiClient {
     }
   }
 
-  Future<KugouCommentList?> getFloorComments(
-    String commentId, {
+  /// 获取楼层评论（楼中楼回复）
+  ///
+  /// [specialId] 歌曲对应的 special_id（从评论数据中获取）
+  /// [tid] 评论 ID
+  /// [mixSongId] 歌曲 ID
+  /// [code] 评论 code（部分接口返回）
+  Future<KugouCommentList?> getFloorComments({
+    required String specialId,
+    required String tid,
+    String? mixSongId,
+    String? code,
     int page = 1,
+    int pagesize = 30,
   }) async {
+    if (specialId.isEmpty || tid.isEmpty) return null;
+    final params = <String, dynamic>{
+      'special_id': specialId,
+      'tid': tid,
+      'page': page,
+      'pagesize': pagesize,
+    };
+    if (mixSongId != null && mixSongId.isNotEmpty) {
+      params['mixsongid'] = mixSongId;
+    }
+    if (code != null && code.isNotEmpty) {
+      params['code'] = code;
+    }
     final json = await _get(
       KugouEndpoints.commentFloor,
-      queryParameters: {'commentid': commentId, 'page': page},
+      queryParameters: params,
     );
     if (json == null) return null;
     try {

--- a/lib/services/kugou_api/kugou_api_client.dart
+++ b/lib/services/kugou_api/kugou_api_client.dart
@@ -649,6 +649,7 @@ class KugouApiClient {
     String? albumId,
     String? albumAudioId,
     bool downgrade = true,
+    String? ppageId,
   }) async {
     final params = <String, dynamic>{
       'hash': hash.toLowerCase(),
@@ -656,13 +657,12 @@ class KugouApiClient {
     };
     if (albumId != null) params['album_id'] = albumId;
     if (albumAudioId != null) params['album_audio_id'] = albumAudioId;
+    if (ppageId != null) params['ppage_id'] = ppageId;
 
     // VIP 用户优先用 /song/url/new（→ /v6/priv_url），它会读取
     // Authorization 头里的 vip_token，能拿到完整音质。
-    // 注意：如果 _getSongUrlNew 因为 priv_status=0 / fail_process 等
-    // 原因返回 null，说明酷狗没认 VIP。这种情况继续走 /song/url
-    // 也只会拿到 30s 试听片段，必须直接返回 null，让上层提示
-    // 用户 VIP 不生效或登录失效。
+    // 如果 _getSongUrlNew 因 priv_status=0 / fail_process 等返回 null，
+    // 继续走 /song/url 兜底，让 ppage_id（收藏页）有机会解锁已收藏的无版权歌曲。
     if (hasVipToken) {
       final vipUrl = await _getSongUrlNew(
         hash,
@@ -671,7 +671,7 @@ class KugouApiClient {
         albumAudioId: albumAudioId,
       );
       if (vipUrl != null) return vipUrl;
-      return null;
+      // 不再直接 return null，继续走 /song/url 兜底
     }
 
     var json = await _get(KugouEndpoints.songUrl, queryParameters: params);
@@ -875,7 +875,25 @@ class KugouApiClient {
       } catch (_) {}
     }
 
-    // 所有音质都失败，最后尝试带降级的 standard 请求
+    // 已收藏无版权歌曲兜底：用 ppage_id=356753938（收藏页）尝试获取完整播放链接。
+    // 酷狗约定：歌曲被收藏后，即便无版权也可通过该 page_id 解锁播放。
+    // 必须放在 free_part 试听兜底之前，否则试听 URL 会抢先返回 30s 片段。
+    // 参考 EchoMusic 的 resolver.ts 中 getSongUrl(track.hash, '', 356753938) 实现。
+    try {
+      final result = await getSongUrl(
+        hash,
+        quality: KugouQuality.standard,
+        albumId: albumId,
+        albumAudioId: albumAudioId,
+        downgrade: false,
+        ppageId: '356753938',
+      );
+      if (result != null && result.url.isNotEmpty) {
+        return result;
+      }
+    } catch (_) {}
+
+    // 最后尝试带降级的 standard 请求
     // （会走 free_part=1 的 30s 试听兜底）
     try {
       return await getSongUrl(

--- a/lib/services/kugou_api/kugou_models.dart
+++ b/lib/services/kugou_api/kugou_models.dart
@@ -543,20 +543,31 @@ class KugouSongDetail {
   Song toSong() {
     // 清理 title：API 的 filename/songname 常返回 "歌手 - 歌曲名" 格式，
     // 去掉前缀，只保留纯歌曲名（subtitle 已单独显示歌手和专辑）。
-    // 用正则兼容 "歌手A/歌手B - 歌曲名"、"歌手A、歌手B - 歌曲名" 等多种分隔符。
+    // 只用 " - "（空格-破折号-空格）作为分隔符，避免误剥含有连字符的歌名
+    // （如 "白菊 -shiragiku-"）。与 EchoMusic processSongTitle 实现一致。
     var cleanTitle = songName;
-    final separatorPattern = RegExp(r'^.+\s*[-–—]\s*');
-    final match = separatorPattern.firstMatch(cleanTitle);
-    if (match != null) {
-      final afterSep = cleanTitle.substring(match.end);
-      if (afterSep.trim().isNotEmpty) {
-        cleanTitle = afterSep;
+    // 歌手名兜底：当 API 未返回歌手字段时，从 "歌手 - 歌曲名" 格式的
+    // 文件名中提取歌手。与 EchoMusic song.ts 实现一致。
+    var resolvedArtist = artistName;
+    if ((resolvedArtist == null || resolvedArtist.isEmpty) &&
+        songName.contains(' - ')) {
+      resolvedArtist = songName.split(' - ')[0];
+    }
+    if (cleanTitle.contains(' - ')) {
+      final parts = cleanTitle.split(' - ');
+      if (parts.length > 1) {
+        final rest = parts.sublist(1).join(' - ');
+        if (rest.trim().isNotEmpty) {
+          cleanTitle = rest;
+        }
       }
     }
     return Song(
       id: hash,
       title: cleanTitle,
-      artist: artistName ?? '',
+      artist: (resolvedArtist != null && resolvedArtist.isNotEmpty)
+          ? resolvedArtist
+          : '未知歌手',
       album: albumName ?? '',
       duration: Duration(seconds: duration),
       isOnline: true,

--- a/lib/services/kugou_api/kugou_models.dart
+++ b/lib/services/kugou_api/kugou_models.dart
@@ -750,17 +750,51 @@ class KugouPlaylist {
 
 class KugouCommentList {
   final List<KugouComment> comments;
+  final List<KugouComment> hotComments;
   final int total;
 
-  const KugouCommentList({this.comments = const [], this.total = 0});
+  const KugouCommentList({
+    this.comments = const [],
+    this.hotComments = const [],
+    this.total = 0,
+  });
 
   factory KugouCommentList.fromJson(Map<String, dynamic> json) {
     final data = json['data'] as Map<String, dynamic>? ?? json;
     final list = data['list'] ?? data['comments'] ?? [];
+
+    // 热门评论：weight_list / hot_list
+    final hotCandidate = data['weight_list'] ?? data['hot_list'];
+    final hotList = (hotCandidate is Map && hotCandidate['list'] is List)
+        ? hotCandidate['list'] as List<dynamic>
+        : (hotCandidate is List ? hotCandidate : <dynamic>[]);
+    // 歌手评论：star_cmts / star_comment
+    final starCandidate = data['star_cmts'] ?? data['star_comment'];
+    final starList = (starCandidate is Map && starCandidate['list'] is List)
+        ? starCandidate['list'] as List<dynamic>
+        : (starCandidate is List ? starCandidate : <dynamic>[]);
+
+    // 合并：歌手评论 + 热门评论（去重，避免 star_cmts 同时出现在两个列表中）
+    final hot = <KugouComment>[];
+    final seenIds = <String>{};
+    for (final e in starList) {
+      if (e is Map<String, dynamic>) {
+        final c = KugouComment.fromJson(e, isStar: true);
+        if (seenIds.add(c.id)) hot.add(c);
+      }
+    }
+    for (final e in hotList) {
+      if (e is Map<String, dynamic>) {
+        final c = KugouComment.fromJson(e, isHot: true);
+        if (seenIds.add(c.id)) hot.add(c);
+      }
+    }
+
     return KugouCommentList(
       comments: (list as List<dynamic>)
           .map((e) => KugouComment.fromJson(e as Map<String, dynamic>))
           .toList(),
+      hotComments: hot,
       total: _parseInt(
         data['total'] ?? data['count'] ?? data['comment_count'] ?? 0,
       ),
@@ -775,6 +809,15 @@ class KugouComment {
   final String content;
   final int time;
   final int likes;
+  final int replyCount;
+  final bool isHot;
+  final bool isStar;
+
+  /// 楼层评论所需字段
+  final String? specialId;
+  final String? tid;
+  final String? code;
+  final String? mixSongId;
 
   const KugouComment({
     required this.id,
@@ -783,9 +826,17 @@ class KugouComment {
     required this.content,
     this.time = 0,
     this.likes = 0,
+    this.replyCount = 0,
+    this.isHot = false,
+    this.isStar = false,
+    this.specialId,
+    this.tid,
+    this.code,
+    this.mixSongId,
   });
 
-  factory KugouComment.fromJson(Map<String, dynamic> json) {
+  factory KugouComment.fromJson(Map<String, dynamic> json,
+      {bool isHot = false, bool isStar = false}) {
     // 修复头像 URL：http → https，避免 Android 明文 HTTP 请求被拒
     String? fixAvatar(String? url) {
       if (url == null || url.isEmpty) return null;
@@ -797,6 +848,16 @@ class KugouComment {
 
     // 支持嵌套的 user 对象（部分接口返回 { user: { avatar, name, ... } }）
     final user = json['user'] as Map<String, dynamic>?;
+    final likeRecord = json['like'] is Map<String, dynamic>
+        ? json['like'] as Map<String, dynamic>
+        : null;
+
+    // 热门/歌手标记：优先从 json 读取，否则使用参数传入的值
+    bool parseBool(dynamic v) {
+      if (v is bool) return v;
+      if (v is num) return v == 1;
+      return false;
+    }
 
     return KugouComment(
       id: _str(json['commentid'] ?? json['id'] ?? ''),
@@ -806,7 +867,7 @@ class KugouComment {
             json['nickname'] ??
             user?['name'] ??
             user?['nickname'] ??
-            '',
+            '匿名用户',
       ),
       avatar: fixAvatar(
         _strNull(
@@ -819,8 +880,31 @@ class KugouComment {
         ),
       ),
       content: _str(json['content'] ?? json['comment_text'] ?? ''),
-      time: _parseInt(json['createtime'] ?? json['time'] ?? 0),
-      likes: _parseInt(json['like_count'] ?? json['likes'] ?? 0),
+      time: _parseInt(json['createtime'] ?? json['addtime'] ?? json['time'] ?? 0),
+      likes: _parseInt(
+        likeRecord?['count'] ??
+            json['like_count'] ??
+            json['likes'] ??
+            json['like_num'] ??
+            json['reply_like_count'] ??
+            0,
+      ),
+      replyCount: _parseInt(
+        json['reply_num'] ?? json['reply_count'] ?? 0,
+      ),
+      isHot: parseBool(json['is_hot'] ?? json['isHot'] ?? isHot),
+      isStar: parseBool(json['is_star'] ?? json['isStar'] ?? isStar),
+      specialId: _strNull(
+        json['special_child_id'] ??
+            json['special_id'] ??
+            json['specialId'] ??
+            json['childrenid'],
+      ),
+      tid: _strNull(json['tid'] ?? json['id'] ?? json['comment_id']),
+      code: _strNull(json['code']),
+      mixSongId: _strNull(
+        json['mixsongid'] ?? json['audio_id'] ?? json['album_audio_id'],
+      ),
     );
   }
 }

--- a/lib/widgets/playlist_comments_view.dart
+++ b/lib/widgets/playlist_comments_view.dart
@@ -3,12 +3,32 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../providers/kugou_provider.dart';
+import '../services/kugou_api/kugou_api_client.dart';
 import '../services/kugou_api/kugou_models.dart';
 import 'md3e_loading_indicator.dart';
 
+/// 楼层评论状态
+class _FloorState {
+  bool expanded = false;
+  bool loading = false;
+  bool initialized = false;
+  List<KugouComment> replies = [];
+  int total = 0;
+  int page = 1;
+  bool hasMore = true;
+  String message = '';
+}
+
 /// 歌单/专辑评论列表视图。
 ///
-/// 在 PlaylistPage / AlbumDetailPage 中展示评论，支持加载更多。
+/// 在 PlaylistPage / AlbumDetailPage 中展示评论。
+///
+/// **功能**：
+/// - 热门评论/歌手评论置顶展示，带徽章标识
+/// - 楼层评论（楼中楼），点击"查看N条回复"展开
+/// - 长评论展开/收起（超过 120 字）
+/// - 点赞数格式化（10000+ → "1w"）
+/// - 滚动到底部自动加载下一页
 class PlaylistCommentsView extends StatefulWidget {
   final String specialId;
 
@@ -32,12 +52,19 @@ class PlaylistCommentsView extends StatefulWidget {
 
 class _PlaylistCommentsViewState extends State<PlaylistCommentsView> {
   List<KugouComment> _comments = [];
+  List<KugouComment> _hotComments = [];
   bool _isLoading = false;
   bool _isLoadingMore = false;
   String? _error;
   int _currentPage = 1;
   bool _hasMore = true;
   ScrollController? _internalScrollController;
+
+  /// 长评论展开状态
+  final Set<String> _expandedContents = {};
+
+  /// 楼层评论状态（按评论 ID 索引）
+  final Map<String, _FloorState> _floorStates = {};
 
   ScrollController get _scrollController =>
       widget.scrollController ?? _internalScrollController!;
@@ -68,6 +95,9 @@ class _PlaylistCommentsViewState extends State<PlaylistCommentsView> {
       _currentPage = 1;
       _hasMore = true;
       _comments.clear();
+      _hotComments.clear();
+      _expandedContents.clear();
+      _floorStates.clear();
       WidgetsBinding.instance.addPostFrameCallback((_) {
         _fetchComments();
       });
@@ -106,12 +136,14 @@ class _PlaylistCommentsViewState extends State<PlaylistCommentsView> {
     if (mounted) {
       setState(() {
         _isLoading = false;
-        if (result != null && result.comments.isNotEmpty) {
+        if (result != null) {
           _comments = result.comments;
+          _hotComments = result.hotComments;
           _currentPage = 1;
           _hasMore = result.comments.length >= 20;
         } else {
           _comments = [];
+          _hotComments = [];
           _hasMore = false;
         }
         _error = kugouProvider.error;
@@ -120,7 +152,7 @@ class _PlaylistCommentsViewState extends State<PlaylistCommentsView> {
   }
 
   Future<void> _loadMore() async {
-    if (_isLoadingMore || !_hasMore) return;
+    if (_isLoadingMore || !_hasMore || _isLoading) return;
 
     setState(() => _isLoadingMore = true);
 
@@ -152,11 +184,133 @@ class _PlaylistCommentsViewState extends State<PlaylistCommentsView> {
     }
   }
 
+  // ---- 长评论展开/收起 ----
+
+  bool _needsTruncate(String content) {
+    return content.length > 120;
+  }
+
+  void _toggleContent(String id) {
+    setState(() {
+      if (_expandedContents.contains(id)) {
+        _expandedContents.remove(id);
+      } else {
+        _expandedContents.add(id);
+      }
+    });
+  }
+
+  // ---- 楼层评论 ----
+
+  _FloorState _getFloorState(String commentId) {
+    return _floorStates.putIfAbsent(commentId, () => _FloorState());
+  }
+
+  Future<void> _fetchFloorReplies(KugouComment comment,
+      {bool reset = false}) async {
+    final state = _getFloorState(comment.id);
+    if (state.loading) return;
+    if (!state.hasMore && !reset) return;
+
+    if (reset) {
+      state.page = 1;
+      state.replies = [];
+      state.hasMore = true;
+      state.message = '';
+    }
+
+    setState(() => state.loading = true);
+
+    final specialId = comment.specialId ?? '';
+    final tid = comment.tid ?? comment.id;
+
+    if (specialId.isEmpty || tid.isEmpty) {
+      state.message = '楼层评论暂不可用';
+      state.hasMore = false;
+      if (mounted) setState(() => state.loading = false);
+      return;
+    }
+
+    try {
+      final api = KugouApiClient();
+      final result = await api.getFloorComments(
+        specialId: specialId,
+        tid: tid,
+        mixSongId: comment.mixSongId,
+        code: comment.code,
+        page: state.page,
+      );
+
+      if (result != null) {
+        final replies = result.comments;
+        state.replies = reset ? replies : [...state.replies, ...replies];
+        state.total = result.total;
+        state.hasMore = state.total > 0
+            ? state.replies.length < state.total
+            : replies.length >= 30;
+        if (state.hasMore) state.page++;
+        if (state.replies.isEmpty) {
+          state.message = '暂无回复';
+        }
+      } else {
+        state.message = '楼层评论暂不可用';
+        state.hasMore = false;
+      }
+    } catch (_) {
+      state.message = '加载失败，点击重试';
+    } finally {
+      state.initialized = true;
+      if (mounted) setState(() => state.loading = false);
+    }
+  }
+
+  void _toggleFloor(KugouComment comment) {
+    final state = _getFloorState(comment.id);
+    setState(() {
+      if (!state.expanded) {
+        state.expanded = true;
+        if (!state.initialized) {
+          _fetchFloorReplies(comment, reset: true);
+        }
+      } else {
+        state.expanded = false;
+      }
+    });
+  }
+
+  // ---- 工具方法 ----
+
+  String _formatLike(int value) {
+    if (value < 10000) return value.toString();
+    final fixed = (value / 10000).toStringAsFixed(value >= 100000 ? 0 : 1);
+    return '${fixed.replaceAll(RegExp(r'\.0$'), '')}w';
+  }
+
+  String? _fixAvatarUrl(String? url) {
+    if (url == null || url.isEmpty) return null;
+    if (url.startsWith('http://')) {
+      return url.replaceFirst('http://', 'https://');
+    }
+    return url;
+  }
+
+  String _formatTime(int timestamp) {
+    if (timestamp == 0) return '';
+    final now = DateTime.now();
+    final date = DateTime.fromMillisecondsSinceEpoch(timestamp * 1000);
+    final diff = now.difference(date);
+
+    if (diff.inMinutes < 60) return '${diff.inMinutes}分钟前';
+    if (diff.inHours < 24) return '${diff.inHours}小时前';
+    if (diff.inDays < 7) return '${diff.inDays}天前';
+    return '${date.month}月${date.day}日';
+  }
+
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
 
-    if (_isLoading && _comments.isEmpty) {
+    if (_isLoading && _comments.isEmpty && _hotComments.isEmpty) {
       return const Center(
         child: Padding(
           padding: EdgeInsets.all(32),
@@ -165,7 +319,7 @@ class _PlaylistCommentsViewState extends State<PlaylistCommentsView> {
       );
     }
 
-    if (_error != null && _comments.isEmpty) {
+    if (_error != null && _comments.isEmpty && _hotComments.isEmpty) {
       return Center(
         child: Padding(
           padding: const EdgeInsets.all(32),
@@ -195,7 +349,7 @@ class _PlaylistCommentsViewState extends State<PlaylistCommentsView> {
       );
     }
 
-    if (_comments.isEmpty) {
+    if (_comments.isEmpty && _hotComments.isEmpty) {
       return Center(
         child: Padding(
           padding: const EdgeInsets.all(32),
@@ -220,16 +374,28 @@ class _PlaylistCommentsViewState extends State<PlaylistCommentsView> {
       );
     }
 
-    return ListView.separated(
+    // 构建显示列表：热门评论 + 最新评论
+    final displayItems = <_CommentDisplayItem>[];
+
+    if (_hotComments.isNotEmpty) {
+      displayItems.add(_CommentDisplayItem.header('热门评论'));
+      for (final c in _hotComments) {
+        displayItems.add(_CommentDisplayItem.comment(c));
+      }
+      if (_comments.isNotEmpty) {
+        displayItems.add(_CommentDisplayItem.header('最新评论'));
+      }
+    }
+    for (final c in _comments) {
+      displayItems.add(_CommentDisplayItem.comment(c));
+    }
+
+    return ListView.builder(
       controller: _scrollController,
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      itemCount: _comments.length + (_hasMore ? 1 : 0),
-      separatorBuilder: (_, _) => Divider(
-        height: 1,
-        color: colorScheme.onSurfaceVariant.withValues(alpha: 0.1),
-      ),
+      itemCount: displayItems.length + (_hasMore ? 1 : 0),
       itemBuilder: (context, index) {
-        if (index == _comments.length) {
+        if (index == displayItems.length) {
           return Center(
             child: Padding(
               padding: const EdgeInsets.all(16),
@@ -242,12 +408,31 @@ class _PlaylistCommentsViewState extends State<PlaylistCommentsView> {
             ),
           );
         }
-        return _buildCommentItem(_comments[index], colorScheme);
+
+        final item = displayItems[index];
+        if (item.isHeader) {
+          return _buildSectionHeader(item.headerTitle!, colorScheme);
+        }
+        return _buildCommentItem(item.comment!, colorScheme);
       },
     );
   }
 
+  Widget _buildSectionHeader(String title, ColorScheme colorScheme) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 16, bottom: 8),
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.labelLarge?.copyWith(
+              color: colorScheme.onSurface,
+              fontWeight: FontWeight.bold,
+            ),
+      ),
+    );
+  }
+
   Widget _buildCommentItem(KugouComment comment, ColorScheme colorScheme) {
+    final floorState = _floorStates[comment.id];
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 12),
       child: Row(
@@ -259,54 +444,327 @@ class _PlaylistCommentsViewState extends State<PlaylistCommentsView> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
+                // 用户名 + 徽章 + 时间
                 Row(
                   children: [
                     Flexible(
                       child: Text(
                         comment.username,
                         style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                          color: colorScheme.primary,
-                          fontWeight: FontWeight.w500,
-                        ),
+                              color: colorScheme.primary,
+                              fontWeight: FontWeight.w500,
+                            ),
                         overflow: TextOverflow.ellipsis,
                       ),
                     ),
+                    if (comment.isStar) ...[
+                      const SizedBox(width: 6),
+                      _buildBadge('歌手', colorScheme),
+                    ],
+                    if (comment.isHot) ...[
+                      const SizedBox(width: 6),
+                      _buildBadge('热门', colorScheme),
+                    ],
                     const SizedBox(width: 8),
                     Text(
                       _formatTime(comment.time),
                       style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                        color: colorScheme.onSurfaceVariant.withValues(alpha: 0.6),
-                      ),
+                            color: colorScheme.onSurfaceVariant
+                                .withValues(alpha: 0.6),
+                          ),
                     ),
                   ],
                 ),
-                const SizedBox(height: 6),
-                Text(
-                  comment.content,
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    color: colorScheme.onSurface,
-                    height: 1.4,
-                  ),
+                const SizedBox(height: 4),
+                // 评论内容（长评论展开/收起，带动画）
+                AnimatedSize(
+                  duration: const Duration(milliseconds: 200),
+                  curve: Curves.easeInOut,
+                  alignment: Alignment.topLeft,
+                  child: _buildContent(comment, colorScheme),
                 ),
-                if (comment.likes > 0) ...[
-                  const SizedBox(height: 6),
-                  Row(
-                    children: [
+                // 点赞 + 回复
+                const SizedBox(height: 6),
+                Row(
+                  children: [
+                    if (comment.likes > 0) ...[
                       Icon(
                         Icons.thumb_up_outlined,
                         size: 12,
-                        color: colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
+                        color: colorScheme.onSurfaceVariant
+                            .withValues(alpha: 0.5),
                       ),
                       const SizedBox(width: 4),
                       Text(
-                        '${comment.likes}',
+                        _formatLike(comment.likes),
                         style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                          color: colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
+                              color: colorScheme.onSurfaceVariant
+                                  .withValues(alpha: 0.5),
+                            ),
+                      ),
+                    ],
+                    // 回复按钮
+                    if (comment.replyCount > 0) ...[
+                      const SizedBox(width: 16),
+                      GestureDetector(
+                        onTap: () => _toggleFloor(comment),
+                        child: Row(
+                          children: [
+                            AnimatedRotation(
+                              turns: floorState?.expanded == true ? 0.5 : 0,
+                              duration: const Duration(milliseconds: 200),
+                              child: Icon(
+                                Icons.expand_more,
+                                size: 14,
+                                color: colorScheme.primary,
+                              ),
+                            ),
+                            const SizedBox(width: 4),
+                            Text(
+                              floorState?.expanded == true
+                                  ? '收起回复'
+                                  : '查看${comment.replyCount}条回复',
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .labelSmall
+                                  ?.copyWith(
+                                    color: colorScheme.primary,
+                                  ),
+                            ),
+                          ],
                         ),
                       ),
                     ],
+                  ],
+                ),
+                // 楼层评论（带展开动画）
+                AnimatedSize(
+                  duration: const Duration(milliseconds: 250),
+                  curve: Curves.easeInOut,
+                  alignment: Alignment.topLeft,
+                  child: floorState?.expanded == true
+                      ? _buildFloorReplies(
+                          comment,
+                          floorState!,
+                          colorScheme,
+                        )
+                      : const SizedBox.shrink(),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildContent(KugouComment comment, ColorScheme colorScheme) {
+    final content = comment.content;
+    if (!_needsTruncate(content) || _expandedContents.contains(comment.id)) {
+      return RichText(
+        text: TextSpan(
+          children: [
+            TextSpan(
+              text: content,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: colorScheme.onSurface,
+                    height: 1.4,
                   ),
-                ],
+            ),
+            if (_needsTruncate(content) &&
+                _expandedContents.contains(comment.id))
+              WidgetSpan(
+                child: GestureDetector(
+                  onTap: () => _toggleContent(comment.id),
+                  child: Text(
+                    ' 收起',
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      );
+    }
+
+    return RichText(
+      text: TextSpan(
+        children: [
+          TextSpan(
+            text: '${content.substring(0, 120)}...',
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onSurface,
+                  height: 1.4,
+                ),
+          ),
+          WidgetSpan(
+            child: GestureDetector(
+              onTap: () => _toggleContent(comment.id),
+              child: Text(
+                '展开',
+                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBadge(String text, ColorScheme colorScheme) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+      decoration: BoxDecoration(
+        color: colorScheme.primary.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: colorScheme.primary.withValues(alpha: 0.2)),
+      ),
+      child: Text(
+        text,
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: colorScheme.primary,
+              fontSize: 10,
+              fontWeight: FontWeight.bold,
+            ),
+      ),
+    );
+  }
+
+  Widget _buildFloorReplies(
+    KugouComment comment,
+    _FloorState state,
+    ColorScheme colorScheme,
+  ) {
+    return Container(
+      margin: const EdgeInsets.only(top: 10),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: colorScheme.onSurfaceVariant.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 回复列表
+          for (final reply in state.replies)
+            _buildFloorReplyItem(reply, colorScheme),
+          // 加载中
+          if (state.loading)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              child: Center(
+                child: MD3ELoadingIndicator(
+                    size: 16, color: colorScheme.primary),
+              ),
+            ),
+          // 空状态
+          if (!state.loading &&
+              state.initialized &&
+              state.replies.isEmpty)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              child: Center(
+                child: Text(
+                  state.message.isNotEmpty ? state.message : '暂无回复',
+                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                ),
+              ),
+            ),
+          // 加载更多
+          if (state.hasMore &&
+              !state.loading &&
+              state.replies.isNotEmpty)
+            Center(
+              child: GestureDetector(
+                onTap: () => _fetchFloorReplies(comment),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 6),
+                  child: Text(
+                    state.message.contains('失败')
+                        ? '加载失败，点击重试'
+                        : '加载更多回复',
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                          color: colorScheme.primary,
+                        ),
+                  ),
+                ),
+              ),
+            ),
+          // 全部加载完
+          if (!state.hasMore &&
+              !state.loading &&
+              state.replies.isNotEmpty)
+            Center(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                child: Text(
+                  '已加载全部回复',
+                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                        color: colorScheme.onSurfaceVariant
+                            .withValues(alpha: 0.5),
+                        fontSize: 10,
+                      ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFloorReplyItem(
+    KugouComment reply,
+    ColorScheme colorScheme,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _buildSmallAvatar(reply, colorScheme),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Flexible(
+                      child: Text(
+                        reply.username,
+                        style:
+                            Theme.of(context).textTheme.labelSmall?.copyWith(
+                                  color: colorScheme.primary,
+                                  fontWeight: FontWeight.w500,
+                                ),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    const SizedBox(width: 6),
+                    Text(
+                      _formatTime(reply.time),
+                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                            color: colorScheme.onSurfaceVariant
+                                .withValues(alpha: 0.5),
+                            fontSize: 10,
+                          ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  reply.content,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: colorScheme.onSurface,
+                        height: 1.3,
+                      ),
+                ),
               ],
             ),
           ),
@@ -322,13 +780,13 @@ class _PlaylistCommentsViewState extends State<PlaylistCommentsView> {
 
     if (avatarUrl != null && avatarUrl.isNotEmpty) {
       return CircleAvatar(
-        radius: 16,
+        radius: 18,
         backgroundColor: colorScheme.primary.withValues(alpha: 0.15),
         child: ClipOval(
           child: CachedNetworkImage(
             imageUrl: avatarUrl,
-            width: 32,
-            height: 32,
+            width: 36,
+            height: 36,
             fit: BoxFit.cover,
             placeholder: (_, _) => _buildTextAvatar(comment, colorScheme),
             errorWidget: (_, _, _) => _buildTextAvatar(comment, colorScheme),
@@ -340,37 +798,64 @@ class _PlaylistCommentsViewState extends State<PlaylistCommentsView> {
     return _buildTextAvatar(comment, colorScheme);
   }
 
+  Widget _buildSmallAvatar(KugouComment comment, ColorScheme colorScheme) {
+    final avatarUrl = _fixAvatarUrl(comment.avatar);
+    if (avatarUrl != null && avatarUrl.isNotEmpty) {
+      return CircleAvatar(
+        radius: 12,
+        backgroundColor: colorScheme.primary.withValues(alpha: 0.15),
+        child: ClipOval(
+          child: CachedNetworkImage(
+            imageUrl: avatarUrl,
+            width: 24,
+            height: 24,
+            fit: BoxFit.cover,
+            placeholder: (_, _) =>
+                _buildSmallTextAvatar(comment, colorScheme),
+            errorWidget: (_, _, _) =>
+                _buildSmallTextAvatar(comment, colorScheme),
+          ),
+        ),
+      );
+    }
+    return _buildSmallTextAvatar(comment, colorScheme);
+  }
+
   Widget _buildTextAvatar(KugouComment comment, ColorScheme colorScheme) {
     return CircleAvatar(
-      radius: 16,
+      radius: 18,
       backgroundColor: colorScheme.primary.withValues(alpha: 0.15),
       child: Text(
         comment.username.isNotEmpty ? comment.username[0] : '?',
-        style: Theme.of(context).textTheme.labelMedium?.copyWith(
-          color: colorScheme.primary,
-        ),
+        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              color: colorScheme.primary,
+            ),
       ),
     );
   }
 
-  /// 修复头像 URL：http → https
-  String? _fixAvatarUrl(String? url) {
-    if (url == null || url.isEmpty) return null;
-    if (url.startsWith('http://')) {
-      return url.replaceFirst('http://', 'https://');
-    }
-    return url;
+  Widget _buildSmallTextAvatar(KugouComment comment, ColorScheme colorScheme) {
+    return CircleAvatar(
+      radius: 12,
+      backgroundColor: colorScheme.primary.withValues(alpha: 0.15),
+      child: Text(
+        comment.username.isNotEmpty ? comment.username[0] : '?',
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: colorScheme.primary,
+              fontSize: 11,
+            ),
+      ),
+    );
   }
+}
 
-  String _formatTime(int timestamp) {
-    if (timestamp == 0) return '';
-    final now = DateTime.now();
-    final date = DateTime.fromMillisecondsSinceEpoch(timestamp * 1000);
-    final diff = now.difference(date);
+/// 显示列表项（header 或 comment）
+class _CommentDisplayItem {
+  final String? headerTitle;
+  final KugouComment? comment;
 
-    if (diff.inMinutes < 60) return '${diff.inMinutes}分钟前';
-    if (diff.inHours < 24) return '${diff.inHours}小时前';
-    if (diff.inDays < 7) return '${diff.inDays}天前';
-    return '${date.month}月${date.day}日';
-  }
+  bool get isHeader => headerTitle != null;
+
+  _CommentDisplayItem.header(this.headerTitle) : comment = null;
+  _CommentDisplayItem.comment(this.comment) : headerTitle = null;
 }

--- a/lib/widgets/song_list_item.dart
+++ b/lib/widgets/song_list_item.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../data/models/song.dart';
+import '../modules/player/comments_view.dart';
 import '../modules/player/mv_player_page.dart';
 import '../providers/downloads_provider.dart';
 import '../providers/favorites_provider.dart';
@@ -84,6 +85,14 @@ class SongListItem extends StatelessWidget {
                     behavior: SnackBarBehavior.floating,
                   ),
                 );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.comment_outlined),
+              title: const Text('看评论'),
+              onTap: () {
+                Navigator.pop(ctx);
+                showSongCommentsSheet(context, song);
               },
             ),
           ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: audio_service
-      sha256: cb122c7c2639d2a992421ef96b67948ad88c5221da3365ccef1031393a76e044
+      sha256: "95f3267f3449eb5cf71c8fcf1d556f57af1e898e2dc5815fb168d1843653edb7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.18"
+    version: "0.18.19"
   audio_service_platform_interface:
     dependency: transitive
     description:
@@ -181,26 +181,26 @@ packages:
     dependency: "direct main"
     description:
       name: dio
-      sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c
+      sha256: "0df44ebba85e503958eb75d07eedd3c86275a58c1d3eda2f2ce8f0a2c3abbb3c"
       url: "https://pub.dev"
     source: hosted
-    version: "5.9.2"
+    version: "5.11.0"
   dio_cookie_manager:
     dependency: "direct main"
     description:
       name: dio_cookie_manager
-      sha256: "0db1a7b997a0455e488ac35744c68eed3f2a4280d3ab531835a65641b0a08744"
+      sha256: "4ed4669cacb11931517c1158876a2189f19386674b9dab498abcca063dbe4c61"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.0"
+    version: "3.5.0"
   dio_web_adapter:
     dependency: transitive
     description:
       name: dio_web_adapter
-      sha256: "2f9e64323a7c3c7ef69567d5c800424a11f8337b8b228bad02524c9fb3c1f340"
+      sha256: "0786d0b7295a373de356fc0af4f6f1d0ab2844ed31b19dfc5e7556b70e24212c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.2.1"
   dlna_dart:
     dependency: "direct main"
     description:
@@ -324,18 +324,26 @@ packages:
     dependency: transitive
     description:
       name: jni
-      sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
+      sha256: f038e58b4dc2c9037f50e233175086337e0b305e356d28211bf55f21c504cbd3
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.3"
   jni_flutter:
     dependency: transitive
     description:
       name: jni_flutter
-      sha256: "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6"
+      sha256: "7b717011ea40d04fd47c2731d3d1d36eb99eba3435c2753d62489e8c3c9991d5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
+  jni_util:
+    dependency: transitive
+    description:
+      name: jni_util
+      sha256: "1ba86da04a5f2bf18fde2edb235587e70c5b0fc5bd4ba955f46b00942c3fc35f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   js:
     dependency: transitive
     description:
@@ -460,10 +468,10 @@ packages:
     dependency: transitive
     description:
       name: objective_c
-      sha256: "6cb691c686fa2838c6deb34980d426145c2a5d537491cb83d463c33cdbc726ed"
+      sha256: b7fb95a6d9a4f009edd63dc5ac69f07420b23a16161c6dd8660290b59c602e8e
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.1"
+    version: "9.5.0"
   octo_image:
     dependency: transitive
     description:
@@ -476,10 +484,10 @@ packages:
     dependency: transitive
     description:
       name: package_config
-      sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
+      sha256: ffcf4cf3d6c0b74ac43708d9f56625506e8a68aa935abe9d267a7330f320eb5d
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "3.0.0"
   package_info_plus:
     dependency: "direct main"
     description:
@@ -516,10 +524,10 @@ packages:
     dependency: "direct main"
     description:
       name: path_provider
-      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      sha256: a7f4874f987173da295a61c181b8ee71dab59b332a486b391babf26a1b884825
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.5"
+    version: "2.1.6"
   path_provider_android:
     dependency: transitive
     description:
@@ -540,18 +548,18 @@ packages:
     dependency: transitive
     description:
       name: path_provider_linux
-      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      sha256: "58c2005f147315b11e9b4a7bc889cd5203e250cba8e3f012dae259b4972b5c16"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.2.2"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      sha256: "484838772624c3a4b94f1e44a3e19897fee738f2d5c4ce448443b0417f7c9dda"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   path_provider_windows:
     dependency: transitive
     description:
@@ -580,34 +588,34 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_apple
-      sha256: e20daf680eef1ca62ffe8c8c526b778cc386d50137c77ac71c8ec9c88c13fb9d
+      sha256: "11b7e94a9d2fbee23c27f0cae0105c6266c03fd83b9a2eda6cf09141fc82624b"
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.9"
+    version: "9.5.0"
   permission_handler_html:
     dependency: transitive
     description:
       name: permission_handler_html
-      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
+      sha256: "6ea98b3f17f60d3b527f2647ed2ab4dc0f6bfe25b22cb1c363f5d8f62252f6ac"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.3+5"
+    version: "0.1.4+1"
   permission_handler_platform_interface:
     dependency: transitive
     description:
       name: permission_handler_platform_interface
-      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
+      sha256: a5c8a97ecf5616112a5b16d4b8e9ec0e5ae90ef63ac69c0d7b8ae240be760b23
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.0"
+    version: "4.4.0"
   permission_handler_windows:
     dependency: transitive
     description:
       name: permission_handler_windows
-      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
+      sha256: caeae01858a0a7d2df67a445ac98e1ad95e55a0e77c73044f4e9b1c8c2289cbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   petitparser:
     dependency: transitive
     description:
@@ -772,10 +780,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "93ae5884a9df5d3bb696825bceb3a17590754548b5d740eba51500afc8d088f5"
+      sha256: "0634e64bd719f89c012f392938e173521f535d3ecaf66558fa94a056d22b5cc7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.26"
+    version: "2.4.27"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -873,10 +881,10 @@ packages:
     dependency: transitive
     description:
       name: synchronized
-      sha256: "93b153dcb6a26dcddee6ca087dd634b53e38c10b5aa163e8e49501a776456153"
+      sha256: "61894a1956de6b4fc1aefd0892e109514a1a706cbece3ac59decd90ff5a7a423"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.1"
+    version: "3.4.1+1"
   term_glyph:
     dependency: transitive
     description:
@@ -977,10 +985,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
+      sha256: "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.3"
+    version: "4.6.0"
   vector_math:
     dependency: transitive
     description:


### PR DESCRIPTION
参考 EchoMusic 实现，对齐酷狗 API 的收藏页兜底逻辑：

1. 已收藏无版权歌曲播放（kugou_api_client.dart）
   - getSongUrl 新增 ppageId 参数，VIP 用户失败后 fall through 到普通端点
   - getSongUrlWithFallback 新增 ppage_id=356753938 收藏页兜底
   - 解析链：音质降级 → 收藏页兜底 → free_part 试听

2. 无法播放歌曲自动跳过（player_provider.dart）
   - next() 改为循环尝试，跳过无法获取链接的歌曲
   - playPlaylist/playOnlinePlaylist/playSongAt 失败后自动切下一首
   - 手动选歌失败时弹出提示对话框（含去看MV/看评论入口）

3. 歌曲信息显示修复（kugou_models.dart, playlist_page.dart）
   - 歌名清洗改用 ' - ' 分割，避免误剥含连字符的歌名
   - 歌手名缺失时从文件名提取，无则显示"未知歌手"
   - 歌单过滤移除 duration>0 要求，信息不全的歌曲仍显示