### PR TITLE
fix(wake, lyricon): 修复线控唤醒播放与词幕自动连接/重试

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -55,8 +55,11 @@
                 <action android:name="android.media.browse.MediaBrowserService" />
             </intent-filter>
         </service>
+        <!-- 线控耳机媒体键接收器：进程被杀死时仍可被 MEDIA_BUTTON 广播拉起，
+             通过启动 AudioPlaybackService 完成「唤醒播放」。
+             有活跃 MediaSession 时按键由 AudioService 的 MediaSession 回调处理。 -->
         <receiver
-            android:name="com.ryanheise.audioservice.MediaButtonReceiver"
+            android:name=".MediaButtonReceiver"
             android:exported="true"
             android:enabled="true">
             <intent-filter>

--- a/android/app/src/main/kotlin/com/md3music/md3music/AudioPlaybackService.kt
+++ b/android/app/src/main/kotlin/com/md3music/md3music/AudioPlaybackService.kt
@@ -24,10 +24,16 @@ import android.os.PowerManager
 import android.support.v4.media.MediaMetadataCompat
 import android.support.v4.media.session.MediaSessionCompat
 import android.support.v4.media.session.PlaybackStateCompat
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.embedding.engine.FlutterEngineCache
+import io.flutter.embedding.engine.dart.DartExecutor
 import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugins.GeneratedPluginRegistrant
 import io.github.proify.lyricon.provider.ConnectionListener
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import io.github.proify.lyricon.provider.LyriconFactory
 import io.github.proify.lyricon.provider.LyriconProvider
 import io.github.proify.lyricon.lyric.model.LyricWord
@@ -61,10 +67,20 @@ class AudioPlaybackService : Service() {
         // 桌面小组件按钮动作（由 MusicWidgetProvider 转发）
         const val ACTION_WIDGET_PLAY_PAUSE = "com.md3music.md3music.ACTION_WIDGET_PLAY_PAUSE"
         const val ACTION_WIDGET_NEXT = "com.md3music.md3music.ACTION_WIDGET_NEXT"
+        // 线控耳机媒体键（由 MediaButtonReceiver 转发，唤醒播放）
+        const val ACTION_MEDIA_BUTTON = "com.md3music.md3music.ACTION_MEDIA_BUTTON"
+        const val EXTRA_MEDIA_COMMAND = "mediaCommand"
+
+        private const val TAG = "AudioPlaybackService"
 
         // 静态变量用于跨组件传递 FlutterEngine
         private var staticFlutterEngine: FlutterEngine? = null
         private var wakeLock: PowerManager.WakeLock? = null
+
+        /// 进程被杀后由本服务创建的后台 FlutterEngine 是否已就绪。
+        /// Dart 端 PlayerProvider 完成状态恢复后会通过 playerReady 通知置为 true。
+        @Volatile
+        var playerReadyReceived = false
 
         fun setFlutterEngine(engine: FlutterEngine) {
             staticFlutterEngine = engine
@@ -98,8 +114,76 @@ class AudioPlaybackService : Service() {
         private var lyriconProvider: LyriconProvider? = null
         private var lyriconChannel: MethodChannel? = null
 
+        // —— 词幕（Lyricon）连接重试控制 ——
+        // 启动/连接过程中可能因中心服务尚未就绪等原因失败，按预设次数重试；
+        // 全部失败后向 Dart 发 connect_failed 事件，由 UI 弹窗提示用户。
+        private const val LYRICON_MAX_RETRIES = 3
+        private const val LYRICON_RETRY_DELAY_MS = 2000L
+        private val lyriconRetryHandler = Handler(Looper.getMainLooper())
+        // 用户意图上是否启用词幕（非 SDK 的 ConnectionStatus），决定失败后是否重试
+        @Volatile
+        private var lyriconEnabled = false
+        // 已重试次数 / 是否已有一次重试排期（避免并发事件重复 register）
+        @Volatile
+        private var lyriconRetryCount = 0
+        @Volatile
+        private var lyriconRetryScheduled = false
+
         fun setLyriconChannel(channel: MethodChannel?) {
             lyriconChannel = channel
+        }
+
+        /** 同步记录用户意图的启用状态（setEnabled / 启动恢复时调用）。 */
+        fun setLyriconEnabledState(enabled: Boolean) {
+            lyriconEnabled = enabled
+            if (!enabled) {
+                // 用户主动禁用：取消排期中的重试并清零计数
+                lyriconRetryCount = 0
+                lyriconRetryScheduled = false
+                lyriconRetryHandler.removeCallbacksAndMessages(null)
+            }
+        }
+
+        /**
+         * 连接失败（timeout/disconnected）后的重试调度。
+         * 仅在用户仍启用词幕时有效；重试次数耗尽后向 Dart 发送 connect_failed。
+         * 每次重试间隔 [LYRICON_RETRY_DELAY_MS]，避免对中心服务发起风暴式重连。
+         */
+        private fun retryLyriconConnect(reason: String) {
+            if (!lyriconEnabled) return
+            if (lyriconRetryScheduled) return
+            val provider = getLyriconProvider() ?: return
+            if (lyriconRetryCount >= LYRICON_MAX_RETRIES) {
+                lyriconRetryCount = 0
+                lyriconRetryScheduled = false
+                android.util.Log.w("LyriconDebug",
+                    "lyricon connect failed after $LYRICON_MAX_RETRIES retries ($reason)")
+                invokeLyriconChannelOnMain("onConnectionStateChanged", "connect_failed")
+                return
+            }
+            lyriconRetryCount++
+            lyriconRetryScheduled = true
+            val attempt = lyriconRetryCount
+            android.util.Log.d("LyriconDebug",
+                "lyricon retry $attempt/$LYRICON_MAX_RETRIES (reason=$reason)")
+            lyriconRetryHandler.postDelayed({
+                lyriconRetryScheduled = false
+                if (!lyriconEnabled) return@postDelayed
+                val p = getLyriconProvider() ?: return@postDelayed
+                try {
+                    p.register()
+                } catch (_: Exception) {
+                    // register 抛异常也视为一次失败，继续下一轮重试
+                    retryLyriconConnect("register exception")
+                }
+            }, LYRICON_RETRY_DELAY_MS)
+        }
+
+        /** 连接成功（connected/reconnected）或重新启用时重置重试状态。 */
+        private fun resetLyriconRetryState() {
+            lyriconRetryCount = 0
+            lyriconRetryScheduled = false
+            lyriconRetryHandler.removeCallbacksAndMessages(null)
         }
 
         /** 在主线程安全调用 lyriconChannel.invokeMethod，避免 SDK 回调在后台线程触发崩溃 */
@@ -157,12 +241,140 @@ class AudioPlaybackService : Service() {
             )
             return song
         }
+
+        /**
+         * 注册 Lyricon Provider MethodChannel（Dart ↔ 原生双向）。
+         * 由 MainActivity（正常启动）与 setupHeadlessChannels（进程被杀唤醒）
+         * 共用，避免 headless 场景下 Dart 的 setSong/setEnabled 等调用因缺少
+         * 原生 handler 而静默失败，也保证原生 onConnectionStateChanged 事件
+         * 能送达 Dart（这是 Lyricon 自动恢复的前提）。
+         */
+        fun registerLyriconChannel(engine: FlutterEngine) {
+            val channel = MethodChannel(
+                engine.dartExecutor.binaryMessenger,
+                "com.md3music.md3music/lyricon"
+            )
+            setLyriconChannel(channel)
+            channel.setMethodCallHandler { call, result ->
+                val provider = getLyriconProvider()
+                when (call.method) {
+                    "setEnabled" -> {
+                        val enabled = call.argument<Boolean>("enabled") ?: false
+                        setLyriconEnabledState(enabled)
+                        try {
+                            if (enabled) {
+                                // 重新启用：清零重试计数，重新走连接流程
+                                resetLyriconRetryState()
+                                provider?.register()
+                            } else {
+                                provider?.unregister()
+                            }
+                            result.success(true)
+                        } catch (_: Exception) {
+                            result.success(false)
+                        }
+                    }
+                    "setSong" -> {
+                        val arg = call.argument<Map<String, Any?>>("song")
+                        if (arg == null) {
+                            try {
+                                // SDK 的 setSong 不接受 null，传一个空 Song 表示清空
+                                provider?.player?.setSong(Song())
+                                result.success(true)
+                            } catch (_: Exception) {
+                                result.success(false)
+                            }
+                        } else {
+                            try {
+                                val song = buildLyriconSong(arg)
+                                provider?.player?.setSong(song)
+                                result.success(true)
+                            } catch (e: Exception) {
+                                result.error("BUILD_SONG_FAILED", e.message, null)
+                            }
+                        }
+                    }
+                    "sendText" -> {
+                        val text = call.argument<String>("text")
+                        try {
+                            provider?.player?.sendText(text)
+                            result.success(true)
+                        } catch (_: Exception) {
+                            result.success(false)
+                        }
+                    }
+                    "setPosition" -> {
+                        val pos = call.argument<Number>("positionMs")?.toLong() ?: 0L
+                        try {
+                            provider?.player?.setPosition(pos)
+                            result.success(true)
+                        } catch (_: Exception) {
+                            result.success(false)
+                        }
+                    }
+                    "setPlaybackState" -> {
+                        val state = call.argument<Number>("state")?.toInt()
+                            ?: PlaybackStateCompat.STATE_NONE
+                        val pos = call.argument<Number>("position")?.toLong() ?: 0L
+                        // SDK 的 setPlaybackState 接受 Boolean，从 PlaybackStateCompat 状态码推导 isPlaying
+                        val isPlaying = state == PlaybackStateCompat.STATE_PLAYING
+                        try {
+                            // 位置通过 setPosition 同步（原本打包在 PlaybackStateCompat 中）
+                            provider?.player?.setPosition(pos)
+                            provider?.player?.setPlaybackState(isPlaying)
+                            result.success(true)
+                        } catch (_: Exception) {
+                            result.success(false)
+                        }
+                    }
+                    "seekTo" -> {
+                        val pos = call.argument<Number>("positionMs")?.toLong() ?: 0L
+                        try {
+                            provider?.player?.seekTo(pos)
+                            result.success(true)
+                        } catch (_: Exception) {
+                            result.success(false)
+                        }
+                    }
+                    "setDisplayTranslation" -> {
+                        val enabled = call.argument<Boolean>("enabled") ?: false
+                        try {
+                            provider?.player?.setDisplayTranslation(enabled)
+                            result.success(true)
+                        } catch (_: Exception) {
+                            result.success(false)
+                        }
+                    }
+                    "setDisplayRoma" -> {
+                        val enabled = call.argument<Boolean>("enabled") ?: false
+                        try {
+                            // SDK 0.1.70+ 已原生支持 setDisplayRoma，直接调用
+                            provider?.player?.setDisplayRoma(enabled)
+                            result.success(true)
+                        } catch (_: Exception) {
+                            // 兜底：反射调用兼容旧版 SDK
+                            try {
+                                val method = provider?.player?.javaClass
+                                    ?.getMethod("setDisplayRoma", Boolean::class.java)
+                                method?.invoke(provider?.player, enabled)
+                                result.success(true)
+                            } catch (_: Exception) {
+                                result.success(false)
+                            }
+                        }
+                    }
+                    else -> result.notImplemented()
+                }
+            }
+        }
     }
 
     private var mediaSession: MediaSessionCompat? = null
     private var notificationManager: NotificationManager? = null
     private var receiver: BroadcastReceiver? = null
     private var flutterEngine: FlutterEngine? = null
+    // Lyricon Provider 是否已 register（restoreLyriconStateIfNeeded 可能被调用多次，需幂等）
+    private var lyriconRegistered = false
 
     // 蓝牙歌词状态：原生端缓存原始元数据，根据开关和当前歌词计算最终显示值
     private var bluetoothLyricEnabled = false
@@ -176,6 +388,13 @@ class AudioPlaybackService : Service() {
     private var lastDesktopLyricEnabled = false
     private var lastIsFavorited = false
     private var lastDuration = 0L
+    // 是否已调用过 startForeground（启动前台服务后必须尽快调用，Android 12+ 超时崩溃）
+    private var foregroundStarted = false
+    // 媒体键命令合并：唤醒期间连续按键只保留最新命令、只启动一个派发会话，
+    // 避免双击（play→next）并发创建多个后台 FlutterEngine
+    private val mediaCommandLock = Any()
+    private var pendingMediaCommand: String? = null
+    private var mediaCommandInFlight = false
 
     override fun onBind(intent: Intent?): IBinder? = null
 
@@ -195,16 +414,22 @@ class AudioPlaybackService : Service() {
                     // SDK 的 ConnectionListener 是 interface，必须用 object 表达式实现
                     service.addConnectionListener(object : ConnectionListener {
                         override fun onConnected(provider: LyriconProvider) {
+                            resetLyriconRetryState()
                             invokeLyriconChannelOnMain("onConnectionStateChanged", "connected")
                         }
                         override fun onReconnected(provider: LyriconProvider) {
+                            resetLyriconRetryState()
                             invokeLyriconChannelOnMain("onConnectionStateChanged", "reconnected")
                         }
                         override fun onDisconnected(provider: LyriconProvider) {
+                            // 用户主动禁用（unregister）也会触发本回调，此时 lyriconEnabled 为 false，
+                            // retryLyriconConnect 内部会直接返回；仅对「仍启用但断联」的场景重试。
                             invokeLyriconChannelOnMain("onConnectionStateChanged", "disconnected")
+                            retryLyriconConnect("disconnected")
                         }
                         override fun onConnectTimeout(provider: LyriconProvider) {
                             invokeLyriconChannelOnMain("onConnectionStateChanged", "timeout")
+                            retryLyriconConnect("timeout")
                         }
                     })
                 } catch (_: Exception) {}
@@ -245,12 +470,19 @@ class AudioPlaybackService : Service() {
             val enabled = prefs.getBoolean("flutter.lyricon_enabled", false)
             val displayTranslation = prefs.getBoolean("flutter.lyricon_display_translation", true)
             val displayRoma = prefs.getBoolean("flutter.lyricon_display_roma", false)
+            // 记录用户意图：headless 唤醒 / 连接失败重试都依赖该标志判断是否继续重试
+            setLyriconEnabledState(enabled)
             android.util.Log.d("LyriconDebug",
                 "restoreLyriconStateIfNeeded: enabled=$enabled, displayTranslation=$displayTranslation, " +
                 "displayRoma=$displayRoma, channelSet=${lyriconChannel != null}")
             if (enabled) {
-                provider.register()
-                android.util.Log.d("LyriconDebug", "restoreLyriconStateIfNeeded: provider.register() done")
+                // 幂等：headless 唤醒时会再次调用本方法（首次在 onCreate，channel 尚为 null），
+                // 只在首次真正 register，避免对 SDK 重复注册。
+                if (!lyriconRegistered) {
+                    provider.register()
+                    lyriconRegistered = true
+                    android.util.Log.d("LyriconDebug", "restoreLyriconStateIfNeeded: provider.register() done")
+                }
                 // 通知 Dart 端：Provider 已自动恢复 enabled 状态
                 // 让 Dart 端同步 _state 并重推当前歌曲
                 invokeLyriconChannelOnMain("onConnectionStateChanged", "auto_restored")
@@ -278,6 +510,14 @@ class AudioPlaybackService : Service() {
             ACTION_PREV, ACTION_PLAY_PAUSE, ACTION_NEXT, ACTION_TOGGLE_DESKTOP_LYRIC, ACTION_TOGGLE_FAVORITE,
             ACTION_WIDGET_PLAY_PAUSE, ACTION_WIDGET_NEXT -> {
                 handleAction(intent.action!!)
+                return START_STICKY
+            }
+            ACTION_MEDIA_BUTTON -> {
+                // 线控耳机唤醒播放：先保证前台服务状态（startForegroundService 必须尽快
+                // 调用 startForeground，否则 Android 12+ 会抛 ForegroundServiceDidNotStartInTimeException）
+                ensureForeground()
+                val command = intent?.getStringExtra(EXTRA_MEDIA_COMMAND) ?: "play"
+                handleMediaButtonCommand(command)
                 return START_STICKY
             }
             ACTION_UPDATE_BT_LYRIC -> {
@@ -344,6 +584,256 @@ class AudioPlaybackService : Service() {
             putExtra("method", method)
         }
         sendBroadcast(intent)
+    }
+
+    /// 前台服务占位通知：唤醒场景下服务可能刚被 startForegroundService 拉起，
+    /// 需要尽快进入前台。真实内容随后由 Dart 端 updateNotification 覆盖。
+    private fun ensureForeground() {
+        if (foregroundStarted) return
+        foregroundStarted = true
+        try {
+            val builder = NotificationCompat.Builder(this, CHANNEL_ID)
+                .setSmallIcon(android.R.drawable.ic_media_play)
+                .setContentTitle("md3music")
+                .setContentText("准备播放")
+                .setOngoing(true)
+                .setOnlyAlertOnce(true)
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+            startForeground(NOTIFICATION_ID, builder.build())
+        } catch (_: Exception) {}
+    }
+
+    /// 线控耳机媒体键 → 派发命令到 Dart 端。
+    /// - 进程存活：复用现有 FlutterEngine（含 MainActivity 缓存的引擎）
+    /// - 进程被杀：创建后台 FlutterEngine 启动 App，恢复上次播放状态后执行命令
+    ///
+    /// 唤醒期间可能连续收到多个按键（双击=下一首），这里做命令合并：
+    /// 任意时刻只保留「最新」命令（pendingMediaCommand），且同一进程内只启动
+    /// 一个派发会话，避免并发创建多个后台 FlutterEngine。
+    private fun handleMediaButtonCommand(command: String) {
+        val method = when (command) {
+            "play" -> "play"
+            "pause", "stop" -> "pause"
+            "next" -> "next"
+            "previous" -> "previous"
+            else -> "play"
+        }
+        var launch = false
+        synchronized(mediaCommandLock) {
+            pendingMediaCommand = method
+            if (!mediaCommandInFlight) {
+                mediaCommandInFlight = true
+                launch = true
+            }
+        }
+        if (!launch) return
+        Thread {
+            try {
+                val engine = obtainFlutterEngine()
+                if (engine != null) {
+                    dispatchToDartWithRetry(engine)
+                } else {
+                    createHeadlessEngineAndDispatch()
+                }
+            } finally {
+                synchronized(mediaCommandLock) {
+                    mediaCommandInFlight = false
+                    pendingMediaCommand = null
+                }
+            }
+        }.start()
+    }
+
+    /// 取走当前待派发的媒体命令（取后清空，避免被后续处理重复消费）。
+    private fun takeMediaCommand(): String? = synchronized(mediaCommandLock) {
+        val m = pendingMediaCommand
+        pendingMediaCommand = null
+        m
+    }
+
+    /// 找到可用的 FlutterEngine：实例字段 → 静态引用 → FlutterEngineCache。
+    /// 已销毁的引擎（isExecutingDart() == false）会被跳过，避免对死引擎派发命令。
+    private fun obtainFlutterEngine(): FlutterEngine? {
+        val candidates = listOfNotNull(
+            flutterEngine,
+            staticFlutterEngine,
+            FlutterEngineCache.getInstance().get("md3music_engine"),
+        )
+        for (engine in candidates) {
+            if (engine.dartExecutor.isExecutingDart()) {
+                if (engine !== staticFlutterEngine) staticFlutterEngine = engine
+                if (engine !== flutterEngine) flutterEngine = engine
+                return engine
+            }
+        }
+        return null
+    }
+
+    /// 进程存活场景：Dart 端可能仍在初始化（PlayerProvider 恢复状态中）。
+    /// 仅当派发失败（channel 尚未注册）时重试；成功后即停止，避免对已开始播放的
+    /// 歌曲重复调用 resume 造成音量波动。每次重试都取「最新」命令，唤醒期间的
+    /// 双击（play→next）能正确合并为 next。
+    ///
+    /// 同步执行（调用方已在后台线程）：必须在本方法内消费 pendingMediaCommand，
+    /// 否则外层 finally 会提前清空命令导致派发丢失（headless 场景曾因此失效）。
+    private fun dispatchToDartWithRetry(engine: FlutterEngine) {
+        try {
+            for (i in 0 until 3) {
+                val method = takeMediaCommand() ?: return
+                if (dispatchOnce(engine, method)) return
+                Thread.sleep(500)
+            }
+        } catch (_: Exception) {}
+    }
+
+    /// 进程被杀场景：创建后台 FlutterEngine 运行完整 App（main() → runApp →
+    /// PlayerProvider 自动恢复上次播放状态），等待 Dart 端上报 playerReady 后
+    /// 派发命令完成「唤醒播放」。引擎放入 FlutterEngineCache，用户随后打开 App
+    /// 时由 MainActivity 复用（provideFlutterEngine），避免双引擎冲突。
+    ///
+    /// 线程注意：FlutterEngine 必须在主线程创建并执行入口（引擎的平台线程即创建
+    /// 线程，后台线程创建会导致后续 MainActivity 复用/UI 附着失败）。
+    /// 本方法在调用方（handleMediaButtonCommand 的后台线程）内同步执行到命令
+    /// 被消费为止：内层不再新起线程，避免外层 finally 提前清空
+    /// pendingMediaCommand 导致 play/next 命令派发丢失。
+    private fun createHeadlessEngineAndDispatch() {
+        playerReadyReceived = false
+        val engineLatch = CountDownLatch(1)
+        runOnMainThread {
+            try {
+                val engine = FlutterEngine(applicationContext)
+                // 手动创建的引擎不会自动注册插件（just_audio 等），必须显式注册
+                GeneratedPluginRegistrant.registerWith(engine)
+                FlutterEngineCache.getInstance().put("md3music_engine", engine)
+                staticFlutterEngine = engine
+                flutterEngine = engine
+                setupHeadlessChannels(engine)
+                engine.dartExecutor.executeDartEntrypoint(
+                    DartExecutor.DartEntrypoint.createDefault()
+                )
+            } catch (e: Exception) {
+                Log.w(TAG, "headless engine create failed: $e")
+            } finally {
+                engineLatch.countDown()
+            }
+        }
+        try {
+            engineLatch.await(5, TimeUnit.SECONDS)
+            val engine = flutterEngine ?: staticFlutterEngine
+            if (engine == null || !engine.dartExecutor.isExecutingDart()) return
+            // 等待 Dart 端 PlayerProvider 完成状态恢复（本地歌曲快，在线歌曲走 API 较慢）
+            for (i in 0 until 30) {
+                if (playerReadyReceived) break
+                Thread.sleep(1000)
+            }
+            // playerReady 意味着 Dart main() 已跑完 runApp，Lyricon 反向 handler
+            // 必然已注册，此时补发 auto_restored 事件才可靠（setupHeadlessChannels
+            // 里那次可能因 Dart 尚未注册 handler 而丢消息）。幂等：register 已由
+            // onCreate 完成，这里只负责把事件送达 Dart。
+            restoreLyriconStateIfNeeded()
+            val method = takeMediaCommand() ?: return
+            dispatchOnce(engine, method)
+        } catch (_: Exception) {}
+    }
+
+    /// 在主线程通过 MethodChannel 派发一次命令到 Dart 端。
+    /// 返回是否成功（Dart 端 handler 已注册且方法被处理）。
+    /// 注意：handler 注册 ≠ PlayerProvider 就绪，play 命令的就绪时序由
+    /// playerReady 信号保证（headless 场景）。
+    private fun dispatchOnce(engine: FlutterEngine, method: String): Boolean {
+        val latch = CountDownLatch(1)
+        val dispatched = arrayOf(false)
+        runOnMainThread {
+            try {
+                MethodChannel(
+                    engine.dartExecutor.binaryMessenger,
+                    "com.md3music.md3music/floating_lyric"
+                ).invokeMethod(method, null, object : MethodChannel.Result {
+                    override fun success(result: Any?) {
+                        dispatched[0] = true
+                        latch.countDown()
+                    }
+                    override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
+                        latch.countDown()
+                    }
+                    override fun notImplemented() {
+                        latch.countDown()
+                    }
+                })
+            } catch (_: Exception) {
+                latch.countDown()
+            }
+        }
+        try {
+            latch.await(2, TimeUnit.SECONDS)
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+        }
+        return dispatched[0]
+    }
+
+    private fun runOnMainThread(block: () -> Unit) {
+        val handler = Handler(Looper.getMainLooper())
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            block()
+        } else {
+            handler.post(block)
+        }
+    }
+
+    /// 为后台（headless）FlutterEngine 注册原生端 MethodChannel handler。
+    /// MainActivity 正常启动时会注册完整 handler（含桌面歌词等）；进程被杀后由
+    /// 本服务兜底注册，保证通知栏 / MediaSession 在唤醒场景下仍能正常更新。
+    private fun setupHeadlessChannels(engine: FlutterEngine) {
+        try {
+            MethodChannel(
+                engine.dartExecutor.binaryMessenger,
+                "com.md3music.md3music/floating_lyric"
+            ).setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "playerReady" -> {
+                        playerReadyReceived = true
+                        result.success(null)
+                    }
+                    "showNotification", "updateNotification" -> {
+                        showNotification(
+                            title = call.argument<String>("title") ?: "",
+                            artist = call.argument<String>("artist") ?: "",
+                            artUrl = call.argument<String>("artUrl"),
+                            fallbackFilePath = call.argument<String>("fallbackFilePath"),
+                            isPlaying = call.argument<Boolean>("isPlaying") ?: false,
+                            position = call.argument<Number>("position")?.toLong() ?: 0L,
+                            duration = call.argument<Number>("duration")?.toLong() ?: 0L,
+                            desktopLyricEnabled = call.argument<Boolean>("desktopLyricEnabled") ?: false,
+                            isFavorited = call.argument<Boolean>("isFavorited") ?: false,
+                        )
+                        result.success(true)
+                    }
+                    "hideNotification" -> {
+                        stopForeground(STOP_FOREGROUND_REMOVE)
+                        releaseWakeLock()
+                        stopSelf()
+                        result.success(true)
+                    }
+                    "updateBluetoothLyric" -> {
+                        currentBtLyricText = call.argument<String>("lyric") ?: ""
+                        refreshMetadata()
+                        result.success(true)
+                    }
+                    "setBluetoothLyricEnabled" -> {
+                        bluetoothLyricEnabled = call.argument<Boolean>("enabled") ?: false
+                        refreshMetadata()
+                        result.success(true)
+                    }
+                    else -> result.notImplemented()
+                }
+            }
+            // 进程被杀唤醒场景：Lyricon channel 原生 handler 只能在这里注册
+            // （无 MainActivity），注册后重新通知 Dart 端 Lyricon 已自动恢复，
+            // 否则词幕不会随播放自动连接（Dart 端 _state 一直停留在 disabled）。
+            registerLyriconChannel(engine)
+            restoreLyriconStateIfNeeded()
+        } catch (_: Exception) {}
     }
 
     fun setFlutterEngine(engine: FlutterEngine) {
@@ -546,6 +1036,8 @@ class AudioPlaybackService : Service() {
         lastDesktopLyricEnabled = desktopLyricEnabled
         lastIsFavorited = isFavorited
         lastDuration = duration
+        // 通知会在下方所有分支中调用 startForeground，标记已进入前台
+        foregroundStarted = true
         // 计算最终显示值：蓝牙歌词开启且有当前歌词时，title→歌词，artist→「作者 - 标题」
         val displayTitle: String
         val displayArtist: String
@@ -793,6 +1285,8 @@ class AudioPlaybackService : Service() {
             lyriconProvider?.destroy()
         } catch (_: Exception) {}
         lyriconProvider = null
+        // 取消排期中的词幕重连任务，防止服务销毁后回调仍触发
+        setLyriconEnabledState(false)
         releaseWakeLock()
         super.onDestroy()
     }

--- a/android/app/src/main/kotlin/com/md3music/md3music/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/md3music/md3music/MainActivity.kt
@@ -17,7 +17,6 @@ import io.flutter.plugin.common.MethodChannel
 import com.md3music.md3music.AudioPlaybackService
 import com.md3music.md3music.FloatingLyricService
 import com.md3music.md3music.usb.UsbAudioPlugin
-import io.github.proify.lyricon.lyric.model.Song
 import java.io.File
 
 class MainActivity : FlutterActivity() {
@@ -39,6 +38,12 @@ class MainActivity : FlutterActivity() {
         private var cachedChannel: MethodChannel? = null
         // KugouApiService 单例引用，便于 Activity onDestroy / onTrimMemory 时确定性关停
         @Volatile private var kugouApiService: KugouApiService? = null
+
+        // 记录自定义插件已注册到的引擎：provideFlutterEngine 复用后台（headless）
+        // 引擎时 configureFlutterEngine 会再次执行，若对同一引擎重复注册
+        // UsbAudioPlugin 会注册两个拔插广播接收器（无法 unregister），导致 USB
+        // 事件被处理两次；而新引擎（进程被杀后重建）仍需注册，故按引擎身份判断。
+        private var customPluginsEngine: FlutterEngine? = null
 
         fun setKugouApiService(service: KugouApiService?) {
             kugouApiService = service
@@ -62,6 +67,18 @@ class MainActivity : FlutterActivity() {
         }
     }
 
+    /// 复用后台（headless）FlutterEngine：线控耳机「唤醒播放」被拉起时，
+    /// AudioPlaybackService 已创建并运行完整 App（main() 已执行、PlayerProvider
+    /// 正在恢复播放状态）。此处返回缓存引擎，避免创建第二个 FlutterEngine 导致
+    /// 双 Dart 隔离区 / 双音频会话冲突。引擎不可用时走默认逻辑新建。
+    override fun provideFlutterEngine(context: android.content.Context): FlutterEngine? {
+        val cached = FlutterEngineCache.getInstance().get("md3music_engine")
+        if (cached != null && cached.dartExecutor.isExecutingDart()) {
+            return cached
+        }
+        return super.provideFlutterEngine(context)
+    }
+
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
 
@@ -73,14 +90,21 @@ class MainActivity : FlutterActivity() {
         // 将 FlutterEngine 传递给 AudioPlaybackService
         AudioPlaybackService.setFlutterEngine(flutterEngine)
 
-        // 注册 MetadataWriterPlugin：处理下载完成后嵌入元数据（标题/艺术家/专辑/封面/歌词）
-        MetadataWriterPlugin().register(flutterEngine)
+        // 自定义插件仅对同一引擎注册一次：引擎被复用（provideFlutterEngine 返回
+        // 缓存引擎）时 configureFlutterEngine 会再次执行，重复注册会注册两个
+        // USB 拔插广播接收器
+        if (customPluginsEngine !== flutterEngine) {
+            customPluginsEngine = flutterEngine
 
-        // 注册均衡器插件：Android 原生 Equalizer，绑定 just_audio 的 audio session ID
-        EqualizerPlugin().register(flutterEngine)
+            // 注册 MetadataWriterPlugin：处理下载完成后嵌入元数据（标题/艺术家/专辑/封面/歌词）
+            MetadataWriterPlugin().register(flutterEngine)
 
-        // 注册 USB 独占输出插件：MethodChannel + 动态拔插广播 + AudioSink 拦截桥接
-        UsbAudioPlugin(this).register(flutterEngine)
+            // 注册均衡器插件：Android 原生 Equalizer，绑定 just_audio 的 audio session ID
+            EqualizerPlugin().register(flutterEngine)
+
+            // 注册 USB 独占输出插件：MethodChannel + 动态拔插广播 + AudioSink 拦截桥接
+            UsbAudioPlugin(this).register(flutterEngine)
+        }
 
         // 初始化 Node.js 本地 API 服务器
         android.util.Log.d("MainActivity", "Initializing KugouApiService...")
@@ -245,114 +269,8 @@ class MainActivity : FlutterActivity() {
         }
 
         // 注册 Lyricon Provider MethodChannel，让 Dart 端能控制 Lyricon 播放器
-        val lyriconChannel = MethodChannel(
-            flutterEngine.dartExecutor.binaryMessenger,
-            "com.md3music.md3music/lyricon"
-        )
-        AudioPlaybackService.setLyriconChannel(lyriconChannel)
-        lyriconChannel.setMethodCallHandler { call, result ->
-            val provider = AudioPlaybackService.getLyriconProvider()
-            when (call.method) {
-                "setEnabled" -> {
-                    val enabled = call.argument<Boolean>("enabled") ?: false
-                    try {
-                        if (enabled) provider?.register() else provider?.unregister()
-                        result.success(true)
-                    } catch (_: Exception) {
-                        result.success(false)
-                    }
-                }
-                "setSong" -> {
-                    val arg = call.argument<Map<String, Any?>>("song")
-                    if (arg == null) {
-                        try {
-                            // SDK 的 setSong 不接受 null，传一个空 Song 表示清空
-                            provider?.player?.setSong(Song())
-                            result.success(true)
-                        } catch (_: Exception) {
-                            result.success(false)
-                        }
-                    } else {
-                        try {
-                            val song = AudioPlaybackService.buildLyriconSong(arg)
-                            provider?.player?.setSong(song)
-                            result.success(true)
-                        } catch (e: Exception) {
-                            result.error("BUILD_SONG_FAILED", e.message, null)
-                        }
-                    }
-                }
-                "sendText" -> {
-                    val text = call.argument<String>("text")
-                    try {
-                        provider?.player?.sendText(text)
-                        result.success(true)
-                    } catch (_: Exception) {
-                        result.success(false)
-                    }
-                }
-                "setPosition" -> {
-                    val pos = call.argument<Number>("positionMs")?.toLong() ?: 0L
-                    try {
-                        provider?.player?.setPosition(pos)
-                        result.success(true)
-                    } catch (_: Exception) {
-                        result.success(false)
-                    }
-                }
-                "setPlaybackState" -> {
-                    val state = call.argument<Number>("state")?.toInt()
-                        ?: PlaybackStateCompat.STATE_NONE
-                    val pos = call.argument<Number>("position")?.toLong() ?: 0L
-                    // SDK 的 setPlaybackState 接受 Boolean，从 PlaybackStateCompat 状态码推导 isPlaying
-                    val isPlaying = state == PlaybackStateCompat.STATE_PLAYING
-                    try {
-                        // 位置通过 setPosition 同步（原本打包在 PlaybackStateCompat 中）
-                        provider?.player?.setPosition(pos)
-                        provider?.player?.setPlaybackState(isPlaying)
-                        result.success(true)
-                    } catch (_: Exception) {
-                        result.success(false)
-                    }
-                }
-                "seekTo" -> {
-                    val pos = call.argument<Number>("positionMs")?.toLong() ?: 0L
-                    try {
-                        provider?.player?.seekTo(pos)
-                        result.success(true)
-                    } catch (_: Exception) {
-                        result.success(false)
-                    }
-                }
-                "setDisplayTranslation" -> {
-                    val enabled = call.argument<Boolean>("enabled") ?: false
-                    try {
-                        provider?.player?.setDisplayTranslation(enabled)
-                        result.success(true)
-                    } catch (_: Exception) {
-                        result.success(false)
-                    }
-                }
-                "setDisplayRoma" -> {
-                    val enabled = call.argument<Boolean>("enabled") ?: false
-                    try {
-                        // SDK 0.1.70+ 已原生支持 setDisplayRoma，直接调用
-                        provider?.player?.setDisplayRoma(enabled)
-                        result.success(true)
-                    } catch (_: Exception) {
-                        // 兜底：反射调用兼容旧版 SDK
-                        try {
-                            val method = provider?.player?.javaClass?.getMethod("setDisplayRoma", Boolean::class.java)
-                            method?.invoke(provider?.player, enabled)
-                            result.success(true)
-                        } catch (_: Exception) {
-                            result.success(false)
-                        }
-                    }
-                }
-                else -> result.notImplemented()
-            }
-        }
+        // （逻辑与 AudioPlaybackService.setupHeadlessChannels 共用，见该函数）
+        AudioPlaybackService.registerLyriconChannel(flutterEngine)
 
         // 注册文件夹选择器 MethodChannel
         val folderPickerChannel = MethodChannel(

--- a/android/app/src/main/kotlin/com/md3music/md3music/MediaButtonReceiver.kt
+++ b/android/app/src/main/kotlin/com/md3music/md3music/MediaButtonReceiver.kt
@@ -1,0 +1,98 @@
+package com.md3music.md3music
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.view.KeyEvent
+
+/**
+ * 线控耳机媒体键接收器（「唤醒播放」核心入口）。
+ *
+ * 当系统内没有活跃的 MediaSession 时（例如 App 进程被杀、从未开始播放），
+ * 线控耳机的媒体键会以 `android.intent.action.MEDIA_BUTTON` 广播形式下发，
+ * 且该广播可以拉起已被杀死的 App 进程。本接收器负责把按键映射为播放命令，
+ * 并启动 [AudioPlaybackService] 完成「唤醒播放」。
+ *
+ * 有活跃 MediaSession 时（正常播放中 / 后台暂停），媒体键由
+ * [AudioPlaybackService] 持有的 MediaSession 回调处理，不会走到这里。
+ *
+ * 按键映射（有线耳机常规逻辑）：
+ * - 单击 KEYCODE_HEADSETHOOK / KEYCODE_MEDIA_PLAY_PAUSE → 播放（唤醒）
+ * - 快速双击 → 下一首（先播放当前歌曲，随后立即切下一首）
+ * - 快速三击 → 上一首
+ * - 独立的 MEDIA_PLAY / MEDIA_PAUSE / MEDIA_NEXT / MEDIA_PREVIOUS / MEDIA_STOP
+ *
+ * 说明：单击立即下发「播放」，确保按键动作发生在广播处理窗口内（Android 12+
+ * 允许收到媒体键广播的应用启动前台服务）；双击/三击在单击之后补发切歌命令，
+ * 此时服务已作为前台服务运行，不再受后台启动前台服务限制。
+ */
+class MediaButtonReceiver : BroadcastReceiver() {
+    companion object {
+        private const val TAG = "MediaButtonReceiver"
+        private const val MULTI_CLICK_TIMEOUT = 350L
+        private val mainHandler = Handler(Looper.getMainLooper())
+        private var clickCount = 0
+        private var pendingAction: Runnable? = null
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != Intent.ACTION_MEDIA_BUTTON) return
+        val event = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableExtra(Intent.EXTRA_KEY_EVENT, KeyEvent::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            intent.getParcelableExtra<KeyEvent>(Intent.EXTRA_KEY_EVENT)
+        } ?: return
+        // 只处理按下事件，避免 ACTION_UP 重复触发
+        if (event.action != KeyEvent.ACTION_DOWN) return
+
+        when (event.keyCode) {
+            KeyEvent.KEYCODE_HEADSETHOOK,
+            KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE -> handleMultiClickPlay(context.applicationContext)
+            KeyEvent.KEYCODE_MEDIA_PLAY -> dispatch(context.applicationContext, "play")
+            KeyEvent.KEYCODE_MEDIA_PAUSE -> dispatch(context.applicationContext, "pause")
+            KeyEvent.KEYCODE_MEDIA_NEXT -> dispatch(context.applicationContext, "next")
+            KeyEvent.KEYCODE_MEDIA_PREVIOUS -> dispatch(context.applicationContext, "previous")
+            KeyEvent.KEYCODE_MEDIA_STOP -> dispatch(context.applicationContext, "pause")
+        }
+    }
+
+    /// 单击播放 / 双击下一首 / 三击上一首。
+    /// 第一击立即下发「播放」，避免错过广播处理窗口；后续按点击次数补发切歌命令。
+    private fun handleMultiClickPlay(context: Context) {
+        clickCount++
+        pendingAction?.let { mainHandler.removeCallbacks(it) }
+        if (clickCount == 1) {
+            dispatch(context, "play")
+        }
+        pendingAction = Runnable {
+            val count = clickCount
+            clickCount = 0
+            when (count) {
+                2 -> dispatch(context, "next")
+                3 -> dispatch(context, "previous")
+            }
+        }
+        mainHandler.postDelayed(pendingAction!!, MULTI_CLICK_TIMEOUT)
+    }
+
+    private fun dispatch(context: Context, command: String) {
+        val intent = Intent(context, AudioPlaybackService::class.java).apply {
+            action = AudioPlaybackService.ACTION_MEDIA_BUTTON
+            putExtra(AudioPlaybackService.EXTRA_MEDIA_COMMAND, command)
+        }
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                context.startService(intent)
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "dispatch failed: $command", e)
+        }
+    }
+}

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 import 'package:quick_actions/quick_actions.dart';
 
 import 'core/layout/responsive_layout.dart';
+import 'core/services/lyricon_provider_service.dart';
 import 'core/theme/app_theme.dart';
 import 'core/theme/motion_constants.dart';
 import 'data/models/playlist.dart';
@@ -377,6 +378,9 @@ class _MainLayoutState extends State<_MainLayout> with WidgetsBindingObserver {
   /// 上一次同步的沉浸状态，避免重复调用 SystemChrome（幂等去重）。
   bool _immersiveSynced = false;
 
+  /// 词幕连接失败弹窗展示中标记，防止连发 connect_failed 时重复弹窗。
+  bool _lyriconFailDialogShown = false;
+
   /// 根据 tab id 构建对应页面 Widget。
   Widget _buildPageForTab(String tabId) {
     switch (tabId) {
@@ -622,10 +626,20 @@ class _MainLayoutState extends State<_MainLayout> with WidgetsBindingObserver {
     shortcutTabRequest.addListener(_handleShortcutTabRequest);
     // 监听封面流沉浸请求（长按切换 / 返回键恢复），变更时重算沉浸状态
     kCoverFlowImmersive.addListener(_onCoverFlowImmersiveChanged);
+    // 监听词幕连接失败（原生侧多次重试后 connect_failed）→ 弹窗提示
+    LyriconProviderService.instance.addListener(_onLyriconStateChanged);
+    // 冷启动前若已连接失败（如后台唤醒时），进入主页后立即补弹一次
+    if (LyriconProviderService.instance.connectFailed) {
+      _lyriconFailDialogShown = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _showLyriconConnectFailedDialog();
+      });
+    }
   }
 
   @override
   void dispose() {
+    LyriconProviderService.instance.removeListener(_onLyriconStateChanged);
     kCoverFlowImmersive.removeListener(_onCoverFlowImmersiveChanged);
     shortcutTabRequest.removeListener(_handleShortcutTabRequest);
     WidgetsBinding.instance.removeObserver(this);
@@ -664,6 +678,53 @@ class _MainLayoutState extends State<_MainLayout> with WidgetsBindingObserver {
       // ignore: discarded_futures
       KugouApiServer.stop();
     }
+  }
+
+  /// 词幕连接失败（原生侧重试耗尽 → connect_failed）回调：弹窗提示用户。
+  /// 只在失败标记置位时触发一次，弹窗期间忽略重复事件。
+  void _onLyriconStateChanged() {
+    if (!LyriconProviderService.instance.connectFailed) return;
+    if (_lyriconFailDialogShown) return;
+    _lyriconFailDialogShown = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _showLyriconConnectFailedDialog();
+    });
+  }
+
+  /// 词幕连接失败提示弹窗（用根 Navigator 的 context，任何页面都能弹出）。
+  Future<void> _showLyriconConnectFailedDialog() async {
+    final ctx = appNavigatorKey.currentContext;
+    if (ctx == null) {
+      _lyriconFailDialogShown = false;
+      return;
+    }
+    await showDialog<void>(
+      context: ctx,
+      barrierDismissible: false,
+      builder: (dialogCtx) => AlertDialog(
+        title: const Text('词幕连接失败'),
+        content: const Text('多次尝试连接词幕服务失败，请确认已开启词幕（Lyricon），检查设备上的词幕服务是否正常运行后重试。'),
+        actions: [
+          TextButton(
+            onPressed: () {
+              LyriconProviderService.instance.connectFailed = false;
+              Navigator.of(dialogCtx).pop();
+            },
+            child: const Text('知道了'),
+          ),
+          FilledButton(
+            onPressed: () {
+              Navigator.of(dialogCtx).pop();
+              // 重新启用触发原生侧重新注册，重试逻辑在原生端（AudioPlaybackService）
+              // ignore: discarded_futures
+              LyriconProviderService.instance.setEnabled(true);
+            },
+            child: const Text('重试'),
+          ),
+        ],
+      ),
+    );
+    _lyriconFailDialogShown = false;
   }
 
   void _showLoginRequiredDialog() {

--- a/lib/core/services/lyricon_provider_service.dart
+++ b/lib/core/services/lyricon_provider_service.dart
@@ -43,6 +43,10 @@ class LyriconProviderService {
 
   bool get enabled => _state != LyriconConnectionState.disabled;
 
+  /// 原生端多次重连仍失败（connect_failed）后置 true，UI 监听后弹窗提示用户。
+  /// 用户重新启用 / 连接成功后清空。
+  bool connectFailed = false;
+
   // 通知外部状态变化（让 UI 可以监听刷新连接状态指示）
   final List<VoidCallback> _listeners = [];
   void addListener(VoidCallback cb) => _listeners.add(cb);
@@ -68,6 +72,7 @@ class LyriconProviderService {
     switch (state) {
       case 'connected':
       case 'reconnected':
+        connectFailed = false;
         _state = LyriconConnectionState.connected;
         break;
       case 'auto_restored':
@@ -75,7 +80,13 @@ class LyriconProviderService {
         // 这里直接进 connecting：Provider 已 register，但 Lyricon 中心服务
         // 尚未回调 onConnected，等异步连接成功后再切到 connected。
         // 同时让 PlayerProvider 监听到此状态变化后重推当前歌曲。
+        connectFailed = false;
         _state = LyriconConnectionState.connecting;
+        break;
+      case 'connect_failed':
+        // Kotlin 端多次重连仍失败后回调：通知 UI 弹窗提示用户检查词幕服务。
+        _state = LyriconConnectionState.timeout;
+        connectFailed = true;
         break;
       case 'disconnected':
         _state = LyriconConnectionState.disconnected;
@@ -99,6 +110,8 @@ class LyriconProviderService {
     } else {
       _state = LyriconConnectionState.disabled;
     }
+    // 用户手动操作：清空失败标记，允许后续再次弹窗
+    connectFailed = false;
     _notify();
     try {
       await _channel.invokeMethod('setEnabled', {'enabled': enabled});

--- a/lib/core/services/media_notification_service.dart
+++ b/lib/core/services/media_notification_service.dart
@@ -9,6 +9,9 @@ class MediaNotificationService {
   static void Function()? onNext;
   static void Function()? onTogglePlayPause;
   static void Function(int)? onSeekTo;
+  // 线控耳机媒体键映射的独立播放 / 暂停命令（原生端唤醒播放下发）
+  static void Function()? onPlay;
+  static void Function()? onPause;
   // 来自通知栏桌面歌词按钮
   static void Function()? onToggleDesktopLyric;
   static void Function()? onToggleFavorite;
@@ -28,6 +31,12 @@ class MediaNotificationService {
           break;
         case 'togglePlayPause':
           onTogglePlayPause?.call();
+          break;
+        case 'play':
+          onPlay?.call();
+          break;
+        case 'pause':
+          onPause?.call();
           break;
         case 'seekTo':
           final pos = call.arguments as int?;
@@ -81,6 +90,15 @@ class MediaNotificationService {
   static Future<void> hideNotification() async {
     try {
       await _channel.invokeMethod('hideNotification');
+    } catch (_) {}
+  }
+
+  /// 通知原生端：播放状态已恢复完成，可安全派发线控耳机命令（唤醒播放）。
+  /// 原生端 AudioPlaybackService 进程被杀后创建后台 FlutterEngine 并等待该信号
+  /// 后才派发 play/next 等命令，确保 PlayerProvider 已完成状态恢复。
+  static Future<void> notifyPlayerReady() async {
+    try {
+      await _channel.invokeMethod('playerReady');
     } catch (_) {}
   }
 

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -179,6 +179,10 @@ class PlayerProvider extends ChangeNotifier with WidgetsBindingObserver {
     _initAudioService();
     // 监听自身变化检测切歌 → 推送 Lyricon（仅 enabled 时实际推送）
     addListener(_handleLyriconSongChange);
+    // 监听 Lyricon 连接状态：headless 唤醒等场景下 auto_restored/connected
+    // 事件到达时可能晚于状态恢复的 notifyListeners，这里补推当前歌曲，
+    // 否则词幕不会自动连接显示（PlayerProvider 自己监听自己无法感知 Lyricon 启用）。
+    LyriconProviderService.instance.addListener(_handleLyriconEnabledChanged);
   }
 
   Future<void> _initAudioService() async {
@@ -193,6 +197,8 @@ class PlayerProvider extends ChangeNotifier with WidgetsBindingObserver {
           resume();
         }
       };
+      MediaNotificationService.onPlay = () => resume();
+      MediaNotificationService.onPause = () => pause();
       MediaNotificationService.onSeekTo = (pos) {
         seek(Duration(milliseconds: pos));
       };
@@ -205,6 +211,12 @@ class PlayerProvider extends ChangeNotifier with WidgetsBindingObserver {
       // 恢复上次播放状态
       await _restoreState();
     } catch (e) {}
+    // 无论初始化是否成功都通知原生端：状态恢复流程已结束。
+    // 进程被杀场景下 AudioPlaybackService 等待该信号后才派发线控耳机命令
+    //（唤醒播放），避免对尚未就绪的播放器派发命令导致空操作。
+    try {
+      await MediaNotificationService.notifyPlayerReady();
+    } catch (_) {}
   }
 
   Future<void> _loadDefaultQuality() async {
@@ -1956,6 +1968,24 @@ class PlayerProvider extends ChangeNotifier with WidgetsBindingObserver {
     _pushLyriconSongChange(song);
   }
 
+  // 记录上次的 enabled 状态，只在 disabled→enabled 边界触发重推，
+  // 避免断开/超时等保持 enabled 的事件反复触发歌词重推
+  bool _lyriconWasEnabled = false;
+
+  /// Lyricon 状态变化时（enabled 从 false→true，如 auto_restored / connected），
+  /// 重置 _lastLyriconSong 强制重推当前歌曲。enabled=false 时无需处理，
+  /// 等下次 enabled 时再推（_handleLyriconSongChange 会自然恢复）。
+  void _handleLyriconEnabledChanged() {
+    final enabled = LyriconProviderService.instance.enabled;
+    if (enabled && !_lyriconWasEnabled) {
+      _lyriconWasEnabled = true;
+      _lastLyriconSong = null;
+      _handleLyriconSongChange();
+    } else if (!enabled) {
+      _lyriconWasEnabled = false;
+    }
+  }
+
   /// 拉取歌词 → 解析 → 推送 Lyricon onSongChanged。
   ///
   /// 参考 [DesktopLyricService._onTick] / [_fetchLyricFor] 的模式：
@@ -2043,6 +2073,7 @@ class PlayerProvider extends ChangeNotifier with WidgetsBindingObserver {
     _saveDebounce?.cancel();
     WidgetsBinding.instance.removeObserver(this);
     removeListener(_handleLyriconSongChange);
+    LyriconProviderService.instance.removeListener(_handleLyriconEnabledChanged);
     _positionSubscription?.cancel();
     _durationSubscription?.cancel();
     _playingSubscription?.cancel();


### PR DESCRIPTION
- 唤醒播放：createHeadlessEngineAndDispatch 改为同步消费媒体命令， 避免外层 finally 提前清空 pendingMediaCommand，修复需二次按键才能播放
- 词幕自动连接：Lyricon MethodChannel 注册逻辑抽为共用函数， headless 唤醒场景也在 Service 内注册，恢复完成后补发 auto_restored 事件，词幕随播放自动连接
- 词幕重试：连接失败/断联时自动重试 3 次（每次间隔 2s）， 仍失败则通知 Dart 弹窗提示用户检查词幕服务